### PR TITLE
Add Step Template to Backup a Folder

### DIFF
--- a/step-templates/file-system-backup-directory.json
+++ b/step-templates/file-system-backup-directory.json
@@ -1,0 +1,44 @@
+{
+  "Id": "ActionTemplates-33",
+  "Name": "File System - Backup Directory",
+  "Description": "Uses Robocopy to backup directories and files from a source to a destination.",
+  "ActionType": "Octopus.Script",
+  "Version": 3,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "function Get-Stamped-Destination($destination) {\r\n\t$stampedFolderName = get-date -format \"yyyy-MM-dd\"\r\n\t$count = 1\r\n\t$stampedDestination = Join-Path $destination $stampedFolderName\r\n\twhile(Test-Path $stampedDestination) {\r\n\t\t$count++\r\n\t\t$stamped = $stampedFolderName + \"(\" + $count + \")\"\r\n\t\t$stampedDestination = Join-Path $destination $stamped\r\n\t}\r\n\treturn $stampedDestination\r\n}\r\n\r\n$source = $OctopusParameters['Source']\r\n$destination = $OctopusParameters['Destination']\r\n$CreateStampedBackupFolder = $OctopusParameters['CreateStampedBackupFolder']\r\nif($CreateStampedBackupFolder -like \"TRUE\" ) {\r\n\t$destination = get-stamped-destination $destination\r\n}\r\n\r\n$options = $OctopusParameters['Options'] -split \"\\s+\"\r\nrobocopy $source $destination $options\r\n\r\nif($LastExitCode -gt 8) {\r\n    exit 1\r\n}\r\nelse {\r\n    exit 0\r\n}\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "Source",
+      "Label": "Source",
+      "HelpText": "The source directory where files and folders will be copied from",
+      "DefaultValue": null
+    },
+    {
+      "Name": "Destination",
+      "Label": "Destination Folder",
+      "HelpText": "The Destination where the files will be copied to.",
+      "DefaultValue": null
+    },
+    {
+      "Name": "Options",
+      "Label": "Robo Copy Options",
+      "HelpText": "Robo Copy accepts a few command line options (e.g. /S /E /Z). List of these can be [found here](http://ss64.com/nt/robocopy.html)",
+      "DefaultValue": "/E /V"
+    },
+    {
+      "Name": "CreateStampedBackupFolder",
+      "Label": "Create Stamped Backup Folder",
+      "HelpText": "If set to TRUE then it will create a dated backup folder under the destination folder (e.g. c:\\backup\\2014-05-11)",
+      "DefaultValue": "TRUE"
+    }
+  ],
+  "LastModifiedOn": "2014-05-22T02:58:03.139+00:00",
+  "LastModifiedBy": "bholdt",
+  "$Meta": {
+    "ExportedAt": "2014-05-22T02:58:41.985Z",
+    "OctopusVersion": "2.4.5.46",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Uses Robocopy to backup directories and files from a source to a destination.

Exit Code: used convention of RoboCopy that anything above exit code 8 is an error and should fail the step.
