### PR TITLE
Added Clean-Files PowerShell Step Template

### DIFF
--- a/step-templates/file-system-clean-directory.json
+++ b/step-templates/file-system-clean-directory.json
@@ -10,6 +10,12 @@
   "SensitiveProperties": {},
   "Parameters": [
     {
+      "Name": "PathsToClean",
+      "Label": "Paths to clean",
+      "HelpText": "A semicolon-separated list of paths to clean.\n\nUsually you would set this to `Octopus.Action[StepName].Output.Package.InstallationDirectoryPath`.",
+      "DefaultValue": null
+    },
+    {
       "Name": "CleanInclude",
       "Label": "Files to remove",
       "HelpText": "A semicolon-separated list of path expressions that match files to be removed.\n\nExamples:  \n\n    - *.jpg\n    - web.*.config\n    - **\\*.dll\n    - \\Logs\\**\\*.txt\n    - web.*.config;*.txt\n\n`\\**\\` denotes a recursive search",
@@ -20,19 +26,13 @@
       "Label": "Files to ignore",
       "HelpText": "A semicolon-separated list of path expressions that will be not be removed.\n\nExamples:  \n\n    - web.log4net.config\n    - img\\needed.jpg\n    - **\\*.dll\n    - web.config;Release Notes.txt\n\n`\\**\\` denotes a recursive search",
       "DefaultValue": null
-    },
-    {
-      "Name": "PathsToClean",
-      "Label": "Paths to clean",
-      "HelpText": "A semicolon-separated list of paths to clean.\n\nUsually you would set this to `Octopus.Action[StepName].Output.Package.InstallationDirectoryPath`.",
-      "DefaultValue": null
     }
   ],
   "LastModifiedOn": "2014-05-29T02:07:57.181+00:00",
   "LastModifiedBy": "Lavinski",
   "$Meta": {
     "ExportedAt": "2014-05-29T02:08:33.665Z",
-    "OctopusVersion": "1.0.0.0",
+    "OctopusVersion": "2.4.0.0",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
This template lets people delete files from a directory after a deployment. This is useful to remove unused files such as `web.*.config` files after a NuGet package is deployed.

For reference this template is also aimed to solving this issue OctopusDeploy/Issues#834 
