### PR TITLE
Add ability to create a shortcut as a deploy step

### DIFF
--- a/step-templates/windows-create-shortcut.json
+++ b/step-templates/windows-create-shortcut.json
@@ -1,0 +1,38 @@
+{
+  "Id": "ActionTemplates-33",
+  "Name": "Windows - Create Shortcut",
+  "Description": null,
+  "ActionType": "Octopus.Script",
+  "Version": 5,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "Write-Output \"Shortcut: $($OctopusParameters['shortcutPath'])\\$($OctopusParameters['shortcutName'])\"\nWrite-Output \"Target: $($OctopusParameters['targetFilePath'])\"\n\nif(!(Test-Path $shortcutPath)){\n    New-Item -ItemType Directory -Path $shortcutPath\n}\n\n$WshShell = New-Object -comObject WScript.Shell\n$Shortcut = $WshShell.CreateShortcut(\"$($OctopusParameters['shortcutPath'])\\$($OctopusParameters['shortcutName']).lnk\")\n$Shortcut.TargetPath = $OctopusParameters['targetFilePath']\n$Shortcut.Save()"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "targetFilePath",
+      "Label": "Target file the shortcut will reference",
+      "HelpText": "This should be set to the file that the shortcut will link to.",
+      "DefaultValue": null
+    },
+    {
+      "Name": "shortcutPath",
+      "Label": "The path the shortcut will be put in",
+      "HelpText": "This should include a path that the shortcut should live in.  If the path does not exist, it will be created.",
+      "DefaultValue": null
+    },
+    {
+      "Name": "shortcutName",
+      "Label": "The name of the shortcut",
+      "HelpText": "This should be the name of the shortcut.",
+      "DefaultValue": null
+    }
+  ],
+  "LastModifiedOn": "2014-06-05T19:06:30.919+00:00",
+  "LastModifiedBy": "BMontague@cvent.net",
+  "$Meta": {
+    "ExportedAt": "2014-06-05T19:06:31.690Z",
+    "OctopusVersion": "2.4.7.85",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Allows creating a shortcut as an Octopus deploy step.

The main purpose is if you had a program or asset of some kind that needed to be run on a server and you wanted to let OD manage the versioning, but have a user easily run or find the item from a set location, then they could just create a shortcut.
