### PR TITLE
Updating for latest chocolatey. 

### DIFF
--- a/step-templates/chocolatey-ensure-installed.json
+++ b/step-templates/chocolatey-ensure-installed.json
@@ -1,19 +1,19 @@
 {
-  "Id": "ActionTemplates-1",
+  "Id": "ActionTemplates-68",
   "Name": "Chocolatey - Ensure Installed",
   "Description": "Ensures that the Chocolatey package manager is installed on the system. The installer is downloaded from https://chocolatey.org if required.",
   "ActionType": "Octopus.Script",
-  "Version": 6,
+  "Version": 1,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = \"$env:SystemDrive\\chocolatey\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\cinst.bat\"\n\nif (-not $chocInstalled) {\n    Write-Output \"Chocolatey not found, installing...\"\n    \n    $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n    Invoke-Expression $installPs1\n\n    & cmd.exe /C \"SET PATH=%PATH%;$chocolateyBin\"\n    \n    Write-Output \"Chocolatey installation complete.\"\n} else {\n    Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n"
+    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = \"$env:ChocolateyInstall\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\cinst.exe\"\n\nif (-not $chocInstalled) {\n    Write-Output \"Chocolatey not found, installing...\"\n    \n    $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n    Invoke-Expression $installPs1\n    \n    Write-Output \"Chocolatey installation complete.\"\n} else {\n    Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n"
   },
   "SensitiveProperties": {},
   "Parameters": [],
-  "LastModifiedOn": "2014-05-06T02:18:49.103+00:00",
-  "LastModifiedBy": "nblumhardt",
+  "LastModifiedOn": "2014-07-07T22:49:38.708+00:00",
+  "LastModifiedBy": "joewaid",
   "$Meta": {
-    "ExportedAt": "2014-05-06T02:18:51.022Z",
-    "OctopusVersion": "2.4.3.0",
+    "ExportedAt": "2014-07-07T22:53:16.554Z",
+    "OctopusVersion": "2.4.7.85",
     "Type": "ActionTemplate"
   }
 }

--- a/step-templates/chocolatey-install-package.json
+++ b/step-templates/chocolatey-install-package.json
@@ -1,11 +1,11 @@
 {
-  "Id": "ActionTemplates-2",
+  "Id": "ActionTemplates-67",
   "Name": "Chocolatey - Install Package",
   "Description": "Installs a package using the Chocolatey package manager.",
   "ActionType": "Octopus.Script",
-  "Version": 0,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$chocolateyBin = \"$env:SystemPath\\chocolatey\\bin\\cinst.bat\"\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not (Test-Path $chocolateyBin)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $chocolateyBin $ChocolateyPackageId\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $chocolateyBin $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n"
+    "Octopus.Action.Script.ScriptBody": "$chocolateyBin = \"$env:ChocolateyInstall\\bin\\cinst.exe\"\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not (Test-Path $chocolateyBin)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $chocolateyBin $ChocolateyPackageId\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $chocolateyBin $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -22,11 +22,11 @@
       "DefaultValue": null
     }
   ],
-  "LastModifiedOn": "2014-05-06T03:31:34.870+00:00",
-  "LastModifiedBy": "nblumhardt",
+  "LastModifiedOn": "2014-07-07T22:28:35.531+00:00",
+  "LastModifiedBy": "joewaid",
   "$Meta": {
-    "ExportedAt": "2014-05-06T03:31:36.464Z",
-    "OctopusVersion": "2.4.3.0",
+    "ExportedAt": "2014-07-07T22:54:22.078Z",
+    "OctopusVersion": "2.4.7.85",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
The latest version of chocolatey(0.9.8.25) has made some changes, they've removed the bat files and replaced them with exes. There is also an environment variable which identifies the installation directory.

I've updated the step templates for chocolatey to work with the latest version.

Updated for the latest chocolatey:
-cinst.exe
-ChocolateyInstall environment variable
