### PR TITLE
Add datadog events

### DIFF
--- a/step-templates/datadog-create-event.json
+++ b/step-templates/datadog-create-event.json
@@ -53,7 +53,7 @@
     }
   ],
   "LastModifiedOn": "2014-07-08T02:15:54.920+00:00",
-  "LastModifiedBy": "BMontague@cvent.net",
+  "LastModifiedBy": "bigbam505",
   "$Meta": {
     "ExportedAt": "2014-07-08T02:19:06.141Z",
     "OctopusVersion": "2.4.10.235",


### PR DESCRIPTION
This adds the ability to post an event to [Datadog](https://www.datadoghq.com/) in order to keep track when certain actions happen to better track down the cause.
