### PR TITLE
Added template to enable or disable data centres in an F5 GTM

### DIFF
--- a/step-templates/f5-gtm-enable-or-disable.json
+++ b/step-templates/f5-gtm-enable-or-disable.json
@@ -1,0 +1,84 @@
+{
+  "Id": "ActionTemplates-33",
+  "Name": "Enable or Disable F5 GTM",
+  "Description": "Enables or disables pools in the F5 GTM\n",
+  "ActionType": "Octopus.Script",
+  "Version": 12,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "Add-PSSnapIn iControlSnapIn. F5 iControlSnapIn can be downloaded from here https://devcentral.f5.com/articles/icontrol-cmdlets \r\n\r\nInitialize-F5.iControl -HostName $OctopusParameters['HostName'] -Username $OctopusParameters['Username'] -Password $OctopusParameters['Password']\r\n\r\n$Pool = $OctopusParameters['PoolName'];\r\n\r\n$PoolA = (, $Pool);\r\n$MemberEnabledState = New-Object -TypeName iControl.GlobalLBPoolMemberMemberEnabledState;\r\n$MemberEnabledState.member = New-Object iControl.CommonIPPortDefinition;\r\n$MemberEnabledState.member.address = $OctopusParameters['MemberIP'];\r\n$MemberEnabledState.member.port = $OctopusParameters['MemberPort'];\r\n$MemberEnabledState.state = $OctopusParameters['EnableOrDisable'];\r\n[iControl.GlobalLBPoolMemberMemberEnabledState[]]$MemberEnabledStateA = [iControl.GlobalLBPoolMemberMemberEnabledState[]](, $MemberEnabledState);\r\n[iControl.GlobalLBPoolMemberMemberEnabledState[][]]$MemberEnabledStateAofA = [iControl.GlobalLBPoolMemberMemberEnabledState[][]](, $MemberEnabledStateA);\r\n\r\n(Get-F5.iControl).GlobalLBPoolMember.set_enabled_state($PoolA, $MemberEnabledStateAofA);"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "EnableOrDisable",
+      "Label": "GTM status",
+      "HelpText": null,
+      "DefaultValue": "STATE_ENABLED",
+      "DisplaySettings": {
+        "Octopus.SelectOptions": "STATE_ENABLED|Enable\nSTATE_DISABLED|Disable"
+F5        "Octopus.ControlType": "Select",
+      }
+    },
+    {
+      "Name": "PoolName",
+      "Label": "GTM Pool name",
+      "HelpText": null,
+      "DefaultValue": "pl_DummyDeployWeb",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "MemberIP",
+      "Label": "GTM member IP",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "MemberPort",
+      "Label": "GTM member port",
+      "HelpText": null,
+      "DefaultValue": "80",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "HostName",
+      "Label": "GTM host name",
+      "HelpText": null,
+      "DefaultValue": "192.168.45.204",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "Username",
+      "Label": "GTM username",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "Password",
+      "Label": "GTM password",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    }
+  ],
+  "LastModifiedOn": "2014-07-24T10:41:45.863+00:00",
+  "LastModifiedBy": "lee.englestone@gmail.com",
+  "$Meta": {
+    "ExportedAt": "2014-07-29T14:51:04.864Z",
+    "OctopusVersion": "2.5.4.280",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
We host our websites on multiple machines across 2 data centres managed by an F5 GTM / LTM. When deploying websites we disable a data centre at the GTM (Global Traffic Manager) level, deploy code to those machines, re-enable that data centre, then do the same to a remaining data centre.

The submitted script makes it simple to enable or disable a data centre as part of the deployment process.
The script requires that a plugin tool (provided by F5) be installed. More information is available here https://devcentral.f5.com/articles/icontrol-cmdlets

We are currently using this Octopus step in production and it works fine.

Note : After a firmware update, we will be moving over to using F5's REST API to tell the GTM to enable / disable data centres (removing the reliance on this additional install), once we have moved to this i'll either update this script or write a new one.
