### PR TITLE
Wait / Sleep step

### DIFF
--- a/step-templates/wait.json
+++ b/step-templates/wait.json
@@ -1,0 +1,29 @@
+{
+  "Id": "ActionTemplates-66",
+  "Name": "Wait",
+  "Description": "Pauses the process for a set duration",
+  "ActionType": "Octopus.Script",
+  "Version": 0,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "Start-Sleep $Seconds"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "Seconds",
+      "Label": "Seconds",
+      "HelpText": "Number of seconds to wait",
+      "DefaultValue": "120",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2014-08-15T06:44:24.762+00:00",
+  "LastModifiedBy": "lee.englestone@gmail.com",
+  "$Meta": {
+    "ExportedAt": "2014-08-15T08:06:12.316Z",
+    "OctopusVersion": "2.5.4.280",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
A general wait/sleep step. We use it to wait for traffic to drop off after taking a server out of the pool before deploying code to it and bringing it back in.
