### PR TITLE
fixed restart-service so works with powershell 2.0

### DIFF
--- a/step-templates/windows-service-restart.json
+++ b/step-templates/windows-service-restart.json
@@ -5,7 +5,7 @@
   "ActionType": "Octopus.Script",
   "Version": 2,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$serviceName = $OctopusParameters['ServiceName']\r\rWrite-Output \"Restarting $serviceName, stopping...\"\r\r$serviceInstance = Get-Service $serviceName\r\rrestart-service $serviceName -Force\r\r$serviceInstance.WaitForStatus('Running','00:01:00')\r\rWrite-Output \"Service $serviceName started.\"\r"
+    "Octopus.Action.Script.ScriptBody": "$serviceName = $OctopusParameters['ServiceName']\r\rWrite-Output \"Restarting $serviceName, stopping...\"\r\r$serviceInstance = Get-Service $serviceName\r\rrestart-service -Input-Object $serviceName -Force\r\r$serviceInstance.WaitForStatus('Running','00:01:00')\r\rWrite-Output \"Service $serviceName started.\"\r"
   },
   "SensitiveProperties": {},
   "Parameters": [


### PR DESCRIPTION
I had a problem when on of my tentacles was installed on a machine running powershell 2.0. After adding `-InputObject` to the powershell script, it worked. It also worked with tentacles that were running ps 4