### PR TITLE
Added a process to bind an SSL certificate with SNI enabled in IIS 8

### DIFF
--- a/step-templates/iis-bind-ssl-certificate-with-sni-enabled.json
+++ b/step-templates/iis-bind-ssl-certificate-with-sni-enabled.json
@@ -1,0 +1,38 @@
+{
+  "Id": "ActionTemplates-34",
+  "Name": "IIS - Bind SSL Certificate with SNI Enabled",
+  "Description": "Applies a https binding, with SNI enabled.",
+  "ActionType": "Octopus.Script",
+  "Version": 9,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$WebsiteName = $OctopusParameters['WebsiteName']\r\n$SSLBindingHost = $OctopusParameters['SSLBindingHost']\r\n$CertificateThumbPrint = $OctopusParameters['CertificateThumbPrint']\r\n\r\nnew-webbinding -Name $WebsiteName -Protocol \"https\" -Port 443 -HostHeader $SSLBindingHost -SslFlags 1\r\nnetsh http add sslcert hostnameport=$($SSLBindingHost):443 certhash=$CertificateThumbPrint appid='{58ee6009-4e61-400b-80cf-dedc242faf63}' certstorename=MY\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "WebsiteName",
+      "Label": "Website Name",
+      "HelpText": "Name of the web site in IIS",
+      "DefaultValue": null
+    },
+    {
+      "Name": "SSLBindingHost",
+      "Label": "SSL Binding Host",
+      "HelpText": "The host name to bind (www.pancreaticcancer.org.uk)",
+      "DefaultValue": null
+    },
+    {
+      "Name": "CertificateThumbPrint",
+      "Label": "Certificate Thumbprint",
+      "HelpText": "The SSL Thumbprint for the certificate.  Do not include spaces",
+      "DefaultValue": null
+    }
+  ],
+  "LastModifiedOn": "2014-10-23T14:40:32.456+00:00",
+  "LastModifiedBy": "Base33",
+  "$Meta": {
+    "ExportedAt": "2014-10-23T14:40:38.823Z",
+    "OctopusVersion": "2.4.5.46",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Allows the user to set an website name, SSL thumbprint, domain to bind to.  SNI will be enabled when this process is run.
