### PR TITLE
Added environment name to message sendt to slack.

### DIFF
--- a/step-templates/slack-notify-deployment.json
+++ b/step-templates/slack-notify-deployment.json
@@ -3,9 +3,9 @@
   "Name": "Slack - Notify Deployment",
   "Description": "Notifies Slack of a deployment succeeding or failing. To add the failure notification, you need to add a step that runs on failure and set DeploySuccessful to false.",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "function Slack-Rich-Notification ($notification)\r\n{\r\n    $payload = @{\r\n        channel = $OctopusParameters['Channel']\r\n        username = $OctopusParameters['Username'];\r\n        icon_url = $OctopusParameters['IconUrl'];\r\n        attachments = @(\r\n            @{\r\n            fallback = $notification[\"fallback\"];\r\n            color = $notification[\"color\"];\r\n            fields = @(\r\n                @{\r\n                title = $notification[\"title\"];\r\n                value = $notification[\"value\"];\r\n                });\r\n            };\r\n        );\r\n    }\r\n\r\n    Invoke-Restmethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['HookUrl']\r\n}\r\n\r\nif ($OctopusParameters['DeploySuccessful'] -eq \"true\"){\r\n    Slack-Rich-Notification @{\r\n        title = \"Success\";\r\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName\";\r\n        fallback = \"Deployed $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName successfully\";\r\n        color = \"good\";\r\n    };\r\n} else {\r\n    Slack-Rich-Notification @{\r\n        title = \"Failed\";\r\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName\";\r\n        fallback = \"Failed to deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName\";\r\n        color = \"danger\";\r\n    };\r\n}"
+    "Octopus.Action.Script.ScriptBody": "function Slack-Rich-Notification ($notification)\r\n{\r\n    $payload = @{\r\n        channel = $OctopusParameters['Channel']\r\n        username = $OctopusParameters['Username'];\r\n        icon_url = $OctopusParameters['IconUrl'];\r\n        attachments = @(\r\n            @{\r\n            fallback = $notification[\"fallback\"];\r\n            color = $notification[\"color\"];\r\n            fields = @(\r\n                @{\r\n                title = $notification[\"title\"];\r\n                value = $notification[\"value\"];\r\n                });\r\n            };\r\n        );\r\n    }\r\n\r\n    Invoke-Restmethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['HookUrl']\r\n}\r\n\r\nif ($OctopusParameters['DeploySuccessful'] -eq \"true\"){\r\n    Slack-Rich-Notification @{\r\n        title = \"Success\";\r\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName on $env:computername\";\r\n        fallback = \"Deployed $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName successfully on $env:computername\";\r\n        color = \"good\";\r\n    };\r\n} else {\r\n    Slack-Rich-Notification @{\r\n        title = \"Failed\";\r\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName on $env:computername\";\r\n        fallback = \"Failed to deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName on $env:computername\";\r\n        color = \"danger\";\r\n    };\r\n}"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -13,38 +13,43 @@
       "Name": "HookUrl",
       "Label": "Webhook URL",
       "HelpText": "The Webhook URL provided by Slack, including token.",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "Channel",
       "Label": "Channel",
       "HelpText": "Which Slack channel to post notifications to.",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "IconUrl",
       "Label": "Icon URL",
       "HelpText": "The icon to use for this user in Slack",
-      "DefaultValue": "http://octopusdeploy.com/content/resources/favicon.png"
+      "DefaultValue": "http://octopusdeploy.com/content/resources/favicon.png",
+      "DisplaySettings": {}
     },
     {
       "Name": "Username",
       "Label": null,
       "HelpText": "The username shown in Slack against these notifications",
-      "DefaultValue": "OctopusDeploy"
+      "DefaultValue": "OctopusDeploy",
+      "DisplaySettings": {}
     },
     {
       "Name": "DeploySuccessful",
       "Label": "Deploy Successful",
       "HelpText": "This flag controls whether to post a success or failure message.",
-      "DefaultValue": "true"
+      "DefaultValue": "true",
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2014-05-15T15:11:56.955+00:00",
-  "LastModifiedBy": "exo",
+  "LastModifiedOn": "2014-11-05T15:29:55.990+00:00",
+  "LastModifiedBy": "admin",
   "$Meta": {
-    "ExportedAt": "2014-06-19T13:27:37.299Z",
-    "OctopusVersion": "2.4.7.85",
+    "ExportedAt": "2014-11-21T12:16:29.115Z",
+    "OctopusVersion": "2.5.12.666",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
I've added the Environment name in the message sent to slack to identify what machine that the step was called from.
In a clustered environment you typically deploy to more than one machine, and need to know to what machine that OD has deployed.

Example of messages sent:

OctopusDeploy [12:47 PM] 
Success
----------------
Deploy feeds release 1.0.200 to Dev on WEBDEV


OctopusDeploy [12:48 PM]
Success
----------------
Deploy feeds release 1.0.200 to Stage on WEB01PST


OctopusDeploy [12:48 PM]
Success
----------------
Deploy feeds release 1.0.200 to Stage on WEB02PST


OctopusDeploy [12:50 PM]
Success
----------------
Deploy feeds release 1.0.200 to Stage on WEB01PST


OctopusDeploy [12:50 PM]
Success
----------------
Deploy feeds release 1.0.200 to Stage on WEB02PST