### PR TITLE
Create windows-scheduled-task-changepath.json

### DIFF
--- a/step-templates/windows-scheduled-task-changepath.json
+++ b/step-templates/windows-scheduled-task-changepath.json
@@ -1,0 +1,59 @@
+{
+  "Id": "ActionTemplates-131",
+  "Name": "Windows Scheduled Task - Change Path",
+  "Description": "Changes the execution path of a Windows Scheduled Task for both 2008 and 2012.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$taskName   = $OctopusParameters['TaskName']\r$taskFolder = $OctopusParameters['TaskFolder']\r$taskExe    = $OctopusParameters['TaskExe']\r$userName   = $OctopusParameters['TaskUserName']\r$password   = $OctopusParameters['TaskPassword']\r\r$taskPath = Join-Path $taskFolder $taskExe\rWrite-Output \"Changing execution path of $taskName to $taskPath\"\r\r#Check if 2008 Server\rif ((Get-WmiObject Win32_OperatingSystem).Name.Contains(\"2008\"))\r{\r    schtasks /Change /RU $userName /RP $password /TR $taskPath /TN $taskName\r}\relse\r{\r    Set-ScheduledTask -TaskName $taskName -TaskPath $taskPath -User $userName -Password $password;\r}"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "TaskName",
+      "Label": "Task Name",
+      "HelpText": "Name of the Windows Scheduled Task.",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    },
+    {
+      "Name": "TaskFolder",
+      "Label": "Task Folder",
+      "HelpText": "Folder path of the command to be executed by the Scheduled Task.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TaskUserName",
+      "Label": "User Name",
+      "HelpText": "User name the task will run under.",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    },
+    {
+      "Name": "TaskPassword",
+      "Label": "Password",
+      "HelpText": "Password for the user the task will run under.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Name": "TaskExe",
+      "Label": "Task Executable",
+      "HelpText": "Executable name of the task to be run from the Task Folder.",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    }
+  ],
+  "LastModifiedOn": "2014-12-10T17:59:38.186+00:00",
+  "LastModifiedBy": "aBezverkov",
+  "$Meta": {
+    "ExportedAt": "2014-12-10T18:00:42.218Z",
+    "OctopusVersion": "2.5.12.666",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
I noticed a UserVoice suggestion for this: 
https://octopusdeploy.uservoice.com/forums/170787-general/suggestions/6217623-feature-to-allow-for-configuration-of-task-schedul

And we had already created a step template for this based off of existing step templates.