### PR TITLE
2 Steps: Windows Service With Kill + Pin TeamCity Build

### DIFF
--- a/step-templates/TeamCity-Pin-Build.json
+++ b/step-templates/TeamCity-Pin-Build.json
@@ -1,0 +1,63 @@
+{
+  "Id": "ActionTemplates-194",
+  "Name": "Pin TeamCity Build Version",
+  "Description": "Try to pin the TeamCity build version. (Requires Octopus version to match TeamCity version)",
+  "ActionType": "Octopus.Script",
+  "Version": 0,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$buildNumber = $OctopusParameters['buildNumber']\r\n$buildTypeId = $OctopusParameters['buildTypeId']\r\n\r\n$tcUrl = $OctopusParameters['TeamCityUrl']\r\n$tcUser = $OctopusParameters['TeamCityUser']\r\n$tcPass = $OctopusParameters['TeamCityPassword']\r\n\r\n[string]$tcRestUrl = $tcUrl + '/httpAuth/app/rest/builds/buildType:{1},number:{0}/pin/'\r\n$url = $tcRestUrl -f $buildNumber,$buildTypeId\r\n\r\nWrite-Host \"****************************\"\r\nWrite-Host \"Pinning build in TeamCity at:\"$url \r\nWrite-Host \"****************************\"\r\n\r\n$req = [System.Net.WebRequest]::Create($url)\r\n$req.Credentials = new-object System.Net.NetworkCredential($tcUser, $tcPass)\r\n$req.Method =\"PUT\"\r\n$req.ContentLength = 0\r\n\r\n$resp = $req.GetResponse()\r\n$reader = new-object System.IO.StreamReader($resp.GetResponseStream())\r\n$reader.ReadToEnd() | Write-Host\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "buildNumber",
+      "Label": "Build Number",
+      "HelpText": null,
+      "DefaultValue": "#{Octopus.Release.Number}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "buildTypeId",
+      "Label": "Build Configuration ID",
+      "HelpText": "The build configuration id to look for the build to pin.\n\nGeneral Settings of the Build Configuration",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TeamCityUrl",
+      "Label": "Url of TeamCity Server",
+      "HelpText": "The url to the TeamCity server.",
+      "DefaultValue": "http://localhost:8082",
+      "DisplaySettings": {}
+    },
+    {
+      "Name": "TeamCityUser",
+      "Label": "TeamCity User",
+      "HelpText": "The TeamCity user used for pinning the build",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TeamCityPassword",
+      "Label": "TeamCity User Password",
+      "HelpText": "The password for the TeamCity user.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-02-11T08:20:03.577+00:00",
+  "LastModifiedBy": "jzi96",
+  "$Meta": {
+    "ExportedAt": "2015-02-11T08:20:13.192Z",
+    "OctopusVersion": "2.6.1.796",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/windows-service-stop-or-kill.json
+++ b/step-templates/windows-service-stop-or-kill.json
@@ -1,0 +1,29 @@
+{
+  "Id": "ActionTemplates-33",
+  "Name": "Stop Service With Kill",
+  "Description": "This steps stops the specified service and in case it does not respond or times out, the service will be killed.",
+  "ActionType": "Octopus.Script",
+  "Version": 6,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$svcName = $OctopusParameters['ServiceName']\n\nWrite-Host \"Checking for service \" + $svcName\n$svcpid = (get-wmiobject Win32_Service | where{$_.Name -eq $svcName}).ProcessId\nWrite-Host \"Found PID \" + $svcpid \n\nStop-Service $svcName\nStart-Sleep -seconds 10\n\n$service = Get-Service -name $svcName | Select -Property Status\nif($service.Status -ne \"Stopped\"){\tStart-Sleep -seconds 5 }\n\n#Check-Service process \nif($svcpid){\n    #still exists?\n    $p = get-process -id $svcpid\n    Write-Host \"Rechecking PID\"\n    if($p){\n        Write-Host \"Killing Service\"\n        Stop-Process $p.Id -force\n    }\n}\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "ServiceName",
+      "Label": "Service Name",
+      "HelpText": "Name of the service to stop",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2014-08-13T09:35:49.638+00:00",
+  "LastModifiedBy": "jzi96",
+  "$Meta": {
+    "ExportedAt": "2015-02-11T07:42:27.538Z",
+    "OctopusVersion": "2.6.1.796",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
This pull request includes 2 step template.
1. Windows Service with kill will try to stop a service, if this does not work, the service will be killed
2. Pin TeamCity Build will try to PIN the build in TeamCity, e. g. on GoLive day make sure TC will not remove packages.