### PR TITLE
checking agaisnt null for description during search

### DIFF
--- a/app/areas/listing/search_criteria.js
+++ b/app/areas/listing/search_criteria.js
@@ -15,7 +15,7 @@ module.factory('searchCriteria', function() {
 
         var lc = result.text.toLowerCase();
         return item.Name.toLowerCase().indexOf(lc) !== -1 ||
-          item.Description.toLowerCase().indexOf(lc) !== -1;
+          ((item.Description !== null) && (item.Description.toLowerCase().indexOf(lc) !== -1));
       };
 
       return result;


### PR DESCRIPTION
I guess somebody sneaked in a step template without a description and broke the search :smile: This works around the problem and possibly fixes it (depends on whether a step template without a description is allowed).