### PR TITLE
added link support for search

### DIFF
--- a/app/areas/listing/listing.js
+++ b/app/areas/listing/listing.js
@@ -1,7 +1,7 @@
 var module = angular.module('octopus-library');
 
 module.config(function($routeProvider){
-  $routeProvider.when('/listing', {
+  $routeProvider.when('/listing/:searchTerm?', {
     templateUrl: 'areas/listing/listing_index.tpl.html',
     controller: 'ListingIndexController'
   });

--- a/app/areas/listing/listing_index.js
+++ b/app/areas/listing/listing_index.js
@@ -1,6 +1,7 @@
 var module = angular.module('octopus-library');
 
-module.controller('ListingIndexController', function($scope, library, searchCriteria){
+module.controller('ListingIndexController', function($scope, $routeParams, library, searchCriteria){
+  var searchTerm = $routeParams.searchTerm;
   $scope.list = library.list();
-  $scope.searchCriteria = searchCriteria.create($scope.list.length);
+  $scope.searchCriteria = searchCriteria.create($scope.list.length, searchTerm);
 });

--- a/app/areas/listing/search_criteria.js
+++ b/app/areas/listing/search_criteria.js
@@ -2,9 +2,9 @@ var module = angular.module('octopus-library');
 
 module.factory('searchCriteria', function() {
   return {
-    create: function(max) {
+    create: function(max, text) {
       var result = {
-        text: '',
+        text: (text === null || text === undefined) ? '' : text,
         maxResults: max
       };
 


### PR DESCRIPTION
With these changes, you can now get a link for a search. For example, if you hit *localhost:4000/#!/listing/redgate*, it will search for **redgate** on the page landing:

![image](https://cloud.githubusercontent.com/assets/328122/6649562/7905f826-c9e4-11e4-9e32-85a40de216b7.png)

Note:

  - I wasn't able to find a way to reflect the search input value changes to URL. Would be nice to add that as well.
  - If this makes it in, we will use a link to direct users to our step templates. So, it's important not to break this `/#!/listing/:searchTerm?` route pattern if possible :smile: 