### PR TITLE
Added a step template for triggering Team City builds.

### DIFF
--- a/step-templates/teamcity-trigger-build.json
+++ b/step-templates/teamcity-trigger-build.json
@@ -1,0 +1,56 @@
+{
+  "Id": "ActionTemplates-65",
+  "Name": "Trigger TeamCity Build",
+  "Description": "Trigger a specific Team City build from an Octopus Deploy process.",
+  "ActionType": "Octopus.Script",
+  "Version": 0,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$buildConfId = $OctopusParameters['BuildConfigurationId']\r\n\r\n$teamCityUrl = $OctopusParameters['TeamCityUrl']\r\n$teamCityUsername = $OctopusParameters['TeamCityUsername']\r\n$teamCityPassword = $OctopusParameters['TeamCityPassword']\r\n\r\n$url = $teamCityUrl + '/httpAuth/app/rest/buildQueue'\r\n$contentTemplate = '<build><buildType id=\"{0}\"/></build>'\r\n$content = $contentTemplate -f $buildConfId\r\n$encodedContent = [System.Text.Encoding]::UTF8.GetBytes($content)\r\n\r\nWrite-Host \"================================================================================\"\r\nWrite-Host \"Triggering build with Id $buildConfId in TeamCity. Server:\" $teamCityUrl \r\nWrite-Host \"================================================================================\"\r\n\r\n$req = [System.Net.WebRequest]::Create($url)\r\n$req.Credentials = new-object System.Net.NetworkCredential($teamCityUsername, $teamCityPassword)\r\n$req.Method =\"POST\"\r\n$req.ContentType = \"application/xml\"\r\n\r\n$req.ContentLength = $encodedContent.length\r\n$requestStream = $req.GetRequestStream()\r\n$requestStream.Write($encodedContent, 0, $encodedContent.length)\r\n$requestStream.Close()\r\n\r\n$resp = $req.GetResponse()\r\n$reader = new-object System.IO.StreamReader($resp.GetResponseStream())\r\n$reader.ReadToEnd() | Write-Host\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "BuildConfigurationId",
+      "Label": null,
+      "HelpText": "The Id of the build configuration to trigger.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TeamCityUrl",
+      "Label": null,
+      "HelpText": "The URL of the Team City server.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TeamCityUsername",
+      "Label": null,
+      "HelpText": "The username to use for accessing TeamCity.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TeamCityPassword",
+      "Label": null,
+      "HelpText": "The password for the TeamCity user.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-03-16T10:45:58.588+00:00",
+  "LastModifiedBy": "bjorgvino",
+  "$Meta": {
+    "ExportedAt": "2015-03-16T10:47:31.328Z",
+    "OctopusVersion": "2.6.3.886",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
This pull request contains a step template for triggering Team City builds. This can be useful for example when you want to run API tests from Team City on services deployed with Octopus Deploy.