### PR TITLE
adding execute aws powershell template step

### DIFF
--- a/step-templates/aws-execute-powershell.json
+++ b/step-templates/aws-execute-powershell.json
@@ -3,9 +3,9 @@
   "Name": "Execute AWS Powershell Script",
   "Description": "This combines two previous library templates of [checking for Chocolatey being installed](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-ensure-installed), and [installing something via Chocolatey](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-install-package), in this case awstools.powershell, and then adds on a third piece of running a custom Powershell script using AWS Powershell tools",
   "ActionType": "Octopus.Script",
-  "Version": 5,
+  "Version": 6,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\cinst.exe\"\n\nif (-not $chocInstalled) {\n  Write-Output \"Chocolatey not found, installing...\"\n\n  $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n  Invoke-Expression $installPs1\n\n  Write-Output \"Chocolatey installation complete.\"\n} else {\n  Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\\cinst.exe\";\n\n$ChocolateyPackageId = 'awstools.powershell'\n\nif (-not $ChocolateyPackageId) {\n  throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not (Test-Path $chocolateyBin)) {\n  throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n  Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n  & $chocolateyBin $ChocolateyPackageId\n} else {\n  Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n  & $chocolateyBin $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n\nImport-Module \"C:\\Program Files (x86)\\AWS Tools\\PowerShell\\AWSPowerShell\\AWSPowerShell.psd1\"\n\nSet-AWSCredentials -AccessKey $AccessKey -SecretKey $SecretKey -StoreAs AWSKeyProfile\n\nInitialize-AWSDefaults -ProfileName AWSKeyProfile -Region $Region\n\n\nInvoke-Expression $AWSScript"
+    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocolateyExe = \"$chocolateyBin\\cinst.exe\"\n$chocInstalled = Test-Path $chocolateyExe\n\nif (-not $chocInstalled) {\n  Write-Output \"Chocolatey not found, installing...\"\n\n  $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n  Invoke-Expression $installPs1\n\n  Write-Output \"Chocolatey installation complete.\"\n} else {\n  Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n\n$ChocolateyPackageId = 'awstools.powershell'\n\nif (-not $ChocolateyPackageId) {\n  throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n  Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n  & $chocolateyExe $ChocolateyPackageId\n} else {\n  Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n  & $chocolateyExe $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n\nImport-Module \"C:\\Program Files (x86)\\AWS Tools\\PowerShell\\AWSPowerShell\\AWSPowerShell.psd1\"\n\nSet-AWSCredentials -AccessKey $AccessKey -SecretKey $SecretKey -StoreAs AWSKeyProfile\n\nInitialize-AWSDefaults -ProfileName AWSKeyProfile -Region $Region\n\n\nInvoke-Expression $AWSScript"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -46,10 +46,10 @@
       }
     }
   ],
-  "LastModifiedOn": "2015-04-01T20:55:15.735+00:00",
+  "LastModifiedOn": "2015-05-01T18:13:05.077+00:00",
   "LastModifiedBy": "hulahomer",
   "$Meta": {
-    "ExportedAt": "2015-04-01T20:55:17.196Z",
+    "ExportedAt": "2015-05-01T18:13:07.633Z",
     "OctopusVersion": "2.5.8.447",
     "Type": "ActionTemplate"
   }

--- a/step-templates/execute-aws-powershell.json
+++ b/step-templates/execute-aws-powershell.json
@@ -1,0 +1,56 @@
+{
+  "Id": "ActionTemplates-4",
+  "Name": "Execute AWS Powershell Script",
+  "Description": "This combines two previous library templates of [checking for Chocolatey being installed](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-ensure-installed), and [installing something via Chocolatey](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-install-package), in this case awstools.powershell, and then adds on a third piece of running a custom Powershell script using AWS Powershell tools",
+  "ActionType": "Octopus.Script",
+  "Version": 5,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\cinst.exe\"\n\nif (-not $chocInstalled) {\n  Write-Output \"Chocolatey not found, installing...\"\n\n  $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n  Invoke-Expression $installPs1\n\n  Write-Output \"Chocolatey installation complete.\"\n} else {\n  Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\\cinst.exe\";\n\n$ChocolateyPackageId = 'awstools.powershell'\n\nif (-not $ChocolateyPackageId) {\n  throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not (Test-Path $chocolateyBin)) {\n  throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n  Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n  & $chocolateyBin $ChocolateyPackageId\n} else {\n  Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n  & $chocolateyBin $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n\nImport-Module \"C:\\Program Files (x86)\\AWS Tools\\PowerShell\\AWSPowerShell\\AWSPowerShell.psd1\"\n\nSet-AWSCredentials -AccessKey $AccessKey -SecretKey $SecretKey -StoreAs AWSKeyProfile\n\nInitialize-AWSDefaults -ProfileName AWSKeyProfile -Region $Region\n\n\nInvoke-Expression $AWSScript"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "SecretKey",
+      "Label": "SecretKey",
+      "HelpText": "Enter your AWS Secret Key here. This will be used to authenticate the session with AWS",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AccessKey",
+      "Label": "AccessKey",
+      "HelpText": "Enter your AWS Access Key here. This will be used to authenticate the session with AWS",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "Region",
+      "Label": "Region",
+      "HelpText": "Enter the region for where you will be executing your powershell scripts against. If you are unsure of the region you are in, check the list found [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html)",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AWSScript",
+      "Label": "AWSScript",
+      "HelpText": "This is the Powershell Script that contains commands using the AWSPowershell module that you want to execute",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-04-01T20:55:15.735+00:00",
+  "LastModifiedBy": "hulahomer",
+  "$Meta": {
+    "ExportedAt": "2015-04-01T20:55:17.196Z",
+    "OctopusVersion": "2.5.8.447",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
This pull request contains a new template for executing commands against AWS via the AWSPowershell module. I was previously accomplishing this same work by creating three different steps in a deployment, which seemed like a bit much, so I decided to simplify it down to just one step that it really needed to be.

The template was created by combining the work of [this template](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-ensure-installed) that checked for Chocolatey being installed and [this template](http://library.octopusdeploy.com/#!/step-template/actiontemplate-chocolatey-install-package) that installed a package via Chocolatey to install the AWS Powershell tools, and then added on my own piece of having it import the AWSPowershell module and then executing a Powershell script that the user specifies.

When adding this step the user simply has to fill in their AWS Secret Key, Access Key, Region, and then also the script they would like to run.

Here is a screenshot showing what it looks like, where I currently use it to find an instance by name and then stop it at the end of my deployments:
![step](https://cloud.githubusercontent.com/assets/1013553/6952745/1671ca00-d88a-11e4-91b4-3329bf29872b.png)



