### PR TITLE
Create sql-execute-sql-agent-job.json

### DIFF
--- a/step-templates/sql-execute-sql-agent-job.json
+++ b/step-templates/sql-execute-sql-agent-job.json
@@ -1,0 +1,47 @@
+{
+  "Id": "ActionTemplates-97",
+  "Name": "SQL - Execute SQL Agent Job",
+  "Description": "Execute a SQL Agent Job and wait for results.",
+  "ActionType": "Octopus.Script",
+  "Version": 12,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$connection = New-Object System.Data.SqlClient.SqlConnection\r\n$connection.ConnectionString = $OctopusParameters['ConnectionString']\r\nRegister-ObjectEvent -inputobject $connection -eventname InfoMessage -action {\r\n    write-host $event.SourceEventArgs\r\n} | Out-Null\r\n\r\nfunction Run-SqlAgentJob($jobname,$timeout) {\r\n\t$sqlstring = @\"\r\n\t\tSET NOCOUNT ON\r\n\r\n\t\t--Declaration\r\n\t\tDECLARE @jobtorun VARCHAR(MAX) = '<JobName>'\r\n\t\tDECLARE @jobid\tVARCHAR(50) = ''\r\n\t\tDECLARE @previousid INT\r\n        DECLARE @previous_status INT \r\n\t\tdeclare @newid\tINT\r\n\t\tDECLARE @runstatus\tINT\r\n\r\n\t\tCREATE TABLE #results\r\n\t\t(\r\n\t\t\tinstance_id INT,\r\n\t\t\tjob_id\tvarchar(255),\r\n\t\t\tjob_name VARCHAR(255),\r\n\t\t\tstep_id\tINT,\r\n\t\t\tstep_name VARCHAR(255),\r\n\t\t\tsql_message_id INT,\r\n\t\t\tsql_severity INT,\r\n\t\t\tmessage VARCHAR(MAX),\r\n\t\t\trun_status INT,\r\n\t\t\trun_date INT,\r\n\t\t\trun_time INT,\r\n\t\t\trun_duration INT,\r\n\t\t\toperator_emailed VARCHAR(255),\r\n\t\t\toperator_netsent VARCHAR(255),\r\n\t\t\toperator_paged VARCHAR(255),\r\n\t\t\tretries_attempted INT,\r\n\t\t\tserver sysname\r\n\t\t)\r\n\r\n\t\t--Get Job ID\r\n\t\tSELECT @jobid = job_id FROM dbo.sysjobs where name = @jobtorun\r\n\t\tIF @jobid = ''\r\n        BEGIN \r\n        \tRAISERROR ('Job Name Not Found.', -- Message text.\r\n        \t\t\t\t16, -- Severity.\r\n        \t\t\t\t1 -- State.\r\n        \t\t\t\t);\r\n        \tRETURN\r\n        END\r\n\r\n\t\t--Store previous job history\r\n\t\tINSERT INTO #results\r\n\t\tEXEC sp_help_jobhistory @job_id = @jobid, @mode = 'full', @step_id = 1\r\n        SELECT @previousid = t.instance_id, @previous_status = t.run_status FROM (SELECT TOP 1 instance_id, run_status FROM #results ORDER BY instance_id DESC) t\r\n        PRINT 'Previous job ID: ' + CAST(@previousid AS VARCHAR(5)) + '\t\tRun Status:' + CAST(@previous_status AS VARCHAR(5))\r\n\t\tSET @newid = @previousid\r\n\r\n\t\t--Start SQL Agent Job\r\n\t\tEXEC msdb.dbo.sp_start_job @jobtorun\r\n\r\n\t\t--Loop for x seconds or until jobhistory has been updated with a new record\r\n\t\tDECLARE @loopct\tINT = 1\r\n\t\tWHILE (@newid = @previousid) and (@loopct < <Timeout>)\r\n\t\tBEGIN\r\n\t\t\tTRUNCATE TABLE #results\r\n\t\t\tINSERT INTO #results\r\n\t\t\t\tEXEC sp_help_jobhistory @job_id = @jobid, @mode = 'full', @step_id = 1\r\n\r\n\t\t\tSELECT @newid = instance_id, @runstatus = run_status FROM #results WHERE instance_id = (SELECT MAX(instance_id) FROM #results)\r\n\r\n\t\t\tPRINT 'Poll ' + CAST(@loopct AS VARCHAR(5)) + '\t\tTime: ' + CONVERT(VARCHAR(8), GETDATE(), 108) \r\n\r\n\t\t\tSET @loopct += 1\r\n\t\t\tWAITFOR DELAY '00:00:05'\r\n\t\tEND\r\n\r\n\t\tIF @newid = @previousid\r\n\t\t\tRAISERROR ('Job did not complete in time.', -- Message text.\r\n\t\t\t\t\t   16, -- Severity.\r\n\t\t\t\t\t   1 -- State.\r\n\t\t\t\t\t   );\r\n\t\tIF @runstatus <> 1\r\n\t\t\tRAISERROR ('Job did not complete successfully.', -- Message text.\r\n\t\t\t\t\t   16, -- Severity.\r\n\t\t\t\t\t   1 -- State.\r\n\t\t\t\t\t   );\r\n\r\n\t\tPRINT ''\r\n\t\tPRINT 'Time: ' + CONVERT(VARCHAR(8), GETDATE(), 108) + '\tNew Job ID:' + CAST(@newid AS VARCHAR(5)) + '\t\tRun Status:' + CAST(@runstatus AS VARCHAR(5))\r\n\r\n\t\t--Cleanup\r\n\t\tDROP TABLE #results\r\n\"@\r\n\r\n    $jobname = $jobname -replace \"'\", \"''\"\r\n\t$sqlstring = $sqlstring -replace \"<JobName>\", $jobname\r\n\t$sqlstring = $sqlstring -replace \"<Timeout>\", $timeout\r\n\t\r\n\t#Debug Code\r\n\t#Write-Host $sqlstring\r\n\t\r\n\t$command = $connection.CreateCommand()\r\n\t$command.CommandText = $sqlstring\r\n\t$command.CommandTimeout = 0\r\n\t$command.ExecuteNonQuery() | Out-Null\r\n}\r\n\r\nWrite-Host \"Connecting\"\r\ntry {\r\n    $connection.Open()\r\n\r\n    Write-Host \"Running SQL Agent Job\"\r\n    Run-SqlAgentJob -jobname $OctopusParameters['JobName'] -timeout $OctopusParameters['Timeout']\r\n}\r\nfinally {\r\n    Write-Host \"Closing connection\"\r\n    $connection.Dispose()\r\n}\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "ConnectionString",
+      "Label": "Connection String",
+      "HelpText": "Connection string for the SQL connection. Example:\n\nServer=.\\SQLExpress;Database=OctoFX;Integrated Security=True;\nBind to a variable to provide different values for different environments.",
+      "DefaultValue": "Server=;Database=msdb;Integrated Security=True;",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "JobName",
+      "Label": "Job Name",
+      "HelpText": "SQL Agent job to run. Can be bound to a variable split. \nText output by the PRINT statement in SQL will be logged to the deployment log.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "Timeout",
+      "Label": "Timeout Value",
+      "HelpText": "The maximum length of time in 5 second intervals to wait for job completion. \nThe default value is 600 seconds (120 intervals x 5s = 600s)",
+      "DefaultValue": "120",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-04-06T20:01:31.948+00:00",
+  "LastModifiedBy": "chrisgelhaus",
+  "$Meta": {
+    "ExportedAt": "2015-04-06T20:01:54.552Z",
+    "OctopusVersion": "2.6.4.951",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Adds support for executing SQL Agent jobs. It waits for job completion and reports back the status. A maximum time to wait can be configured as well.