### PR TITLE
Change key storage flags to MachineKeySet,PersistKeySet

### DIFF
--- a/step-templates/ssl-certificate-install.json
+++ b/step-templates/ssl-certificate-install.json
@@ -5,7 +5,7 @@
   "ActionType": "Octopus.Script",
   "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$base64Certificate = $OctopusParameters['Base64Certificate']\n$password = $OctopusParameters['Password']\n$location = $OctopusParameters['StoreLocation']\n$name = $OctopusParameters['StoreName']\n\nWrite-Host \"Adding/updating certificate in store\"\n\n$certBytes = [System.Convert]::FromBase64String($base64Certificate)\n$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certBytes, $password, \"Exportable,PersistKeySet\")\n$store = New-Object System.Security.Cryptography.X509Certificates.X509Store($name, $location)\n$store.Open(\"ReadWrite\")\n$store.Add($cert)\n$store.Close()"
+    "Octopus.Action.Script.ScriptBody": "$base64Certificate = $OctopusParameters['Base64Certificate']\n$password = $OctopusParameters['Password']\n$location = $OctopusParameters['StoreLocation']\n$name = $OctopusParameters['StoreName']\n\nWrite-Host \"Adding/updating certificate in store\"\n\n$certBytes = [System.Convert]::FromBase64String($base64Certificate)\n$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($certBytes, $password, \"MachineKeySet,PersistKeySet\")\n$store = New-Object System.Security.Cryptography.X509Certificates.X509Store($name, $location)\n$store.Open(\"ReadWrite\")\n$store.Add($cert)\n$store.Close()"
   },
   "SensitiveProperties": {},
   "Parameters": [


### PR DESCRIPTION
I find the key set flags in this template to be a bit subpar. I had to add "MachineKeySet" to the flags in order to have the private key imported. Furthermore, I doubt that you would need to ever export the private key from one of the production machines, so I would vote for removing "Exportable". In sum, I would suggest the key storage flags to be "MachineKeySet,PersistKeySet" instead of "Exportable,PersistKeySet"