### PR TITLE
Step template for adding back connection host names to Windows registry

### DIFF
--- a/step-templates/windows-add-back-connection-host-name.json
+++ b/step-templates/windows-add-back-connection-host-name.json
@@ -1,0 +1,27 @@
+{
+  "Id": "ActionTemplates-163",
+  "Name": "Windows - Add Back Connection Host Name",
+  "Description": "Disables loopback checking for a given host header name, allowing an IIS site running with integrated authentication to be accessed from the same machine, e.g. an MVC application referencing a WebAPI application. See below for more information:\n\n<https://support.microsoft.com/en-us/kb/896861>",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$hostName = $OctopusParameters['HostName']\r\n\r\n$key = 'HKLM:\\System\\CurrentControlSet\\Control\\Lsa\\MSV1_0\\'\r\n\r\n$hostNames = get-itemproperty $key -Name BackConnectionHostNames -ErrorAction SilentlyContinue\r\n\r\nIf ($hostNames -eq $null) { new-itemproperty $key -Name BackConnectionHostNames -Value $hostName -PropertyType MultiString }\r\n\r\nElseIf ($hostNames.BackConnectionHostNames -notcontains  $hostName) { set-itemproperty $key -Name BackConnectionHostNames -Value ($hostNames.BackConnectionHostNames + $hostName) }\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "HostName",
+      "Label": "Host header name",
+      "HelpText": "The host header of the target application referenced by the client application. For example, an MVC website which requires access to a WebAPI application on the same machine would add a back connection host name for the API's host header, e.g.:\n\napi.mycompany.com",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    }
+  ],
+  "LastModifiedOn": "2015-06-30T11:17:55.053+00:00",
+  "LastModifiedBy": "robbell",
+  "$Meta": {
+    "ExportedAt": "2015-06-30T11:18:08.029Z",
+    "OctopusVersion": "2.6.0.778",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Step template for adding back connection host names to Windows registry. Disables loopback checking for a given host header name, allowing an IIS site running with integrated authentication to be accessed from the same machine. Common for web to API connections. See <https://support.microsoft.com/en-us/kb/896861> for more information.