### PR TITLE
Step template to ensure Windows hosts file entry exists

### DIFF
--- a/step-templates/windows-ensure-hosts-file-entry-exists.json
+++ b/step-templates/windows-ensure-hosts-file-entry-exists.json
@@ -1,0 +1,34 @@
+{
+  "Id": "ActionTemplates-164",
+  "Name": "Windows - Ensure Hosts File Entry Exists",
+  "Description": "Ensures that the given IP/host name entry exists in the hosts file.",
+  "ActionType": "Octopus.Script",
+  "Version": 5,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$ip = $OctopusParameters['IP']\r\n$hostName = $OctopusParameters['HostName']\r\n\r\n$hostsPath = \"$env:windir\\System32\\drivers\\etc\\hosts\"\r\n\r\n$hosts = Get-Content $hostsPath\r\n\r\n$match = $hosts -match (\"^\\s*$ip\\s+$hostName\" -replace '\\.', '\\.')\r\n\r\nIf ($match) { Exit }\r\n\r\n$hostsEntry = \"$ip`t$hostName\"\r\n\r\nIf ([IO.File]::ReadAllText($hostsPath) -notmatch \"\\r\\n\\z\") { $hostsEntry = [environment]::newline + $hostsEntry }\r\n\r\nAdd-Content $hostsPath $hostsEntry\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "IP",
+      "Label": "IP Address",
+      "HelpText": "The IP address which the host name should resolve to, e.g. 127.0.0.1",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    },
+    {
+      "Name": "HostName",
+      "Label": "Host Name",
+      "HelpText": "The host name which should resolve to the given IP, e.g. www.mydomain.com",
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    }
+  ],
+  "LastModifiedOn": "2015-07-15T14:32:07.787+00:00",
+  "LastModifiedBy": "robbell",
+  "$Meta": {
+    "ExportedAt": "2015-07-15T15:02:15.749Z",
+    "OctopusVersion": "2.6.0.778",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Step template to ensure that the given IP/host name entry exists in the Windows hosts file. Step is idempotent and can be run several times without adding duplicate entries.