### PR TITLE
Doesn't seem to work with "Octopus.Step.Package.NuGetPackageVersion" parameter

### DIFF
--- a/step-templates/iis-website-add-release-number-to-response-header.json
+++ b/step-templates/iis-website-add-release-number-to-response-header.json
@@ -1,11 +1,11 @@
 {
-  "Id": "ActionTemplates-97",
+  "Id": "ActionTemplates-3",
   "Name": "IIS Website - Add Release Number to Response Header",
-  "Description": "Adds the Octopus Release number to the response header. When you browser to your site you can look at the response header to verify the build number that is loading",
+  "Description": "Adds the Octopus Deploy Release number to the IIS response header. When you browse your site you can look at the response header to verify the build number that is running.",
   "ActionType": "Octopus.Script",
-  "Version": 7,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "write-host \"#Adding release number to response header\"\n\n[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.Web.Administration\") | Out-Null\n$iis = new-object Microsoft.Web.Administration.ServerManager\n$config = $iis.GetWebConfiguration($OctopusParameters['webSiteName'])\n$httpProtocolSection = $config.GetSection(\"system.webServer/httpProtocol\")\n$customHeadersCollection = $httpProtocolSection.GetCollection(\"customHeaders\")\n\n$update = $false\n\nforeach($path in $customHeadersCollection.GetCollection()) { \n    if ($path.GetAttributeValue(\"name\") -eq $OctopusParameters['FieldName']) {\n        write-host \"Release number is already in the response header, skipping\"\n        $update = $false\n        break\n    } else {\n        $update = $true\n    }\n}\n\nif ($update)\n{\n    write-host \"Adding release number\"\n    $addElement = $customHeadersCollection.CreateElement(\"add\")\n    $addElement[\"name\"] = $OctopusParameters['FieldName']\n    $addElement[\"value\"] = $OctopusParameters[\"Octopus.Step.Package.NuGetPackageVersion\"]\n    $customHeadersCollection.Add($addElement)\n    $iis.CommitChanges() | Write-Host\n}"
+    "Octopus.Action.Script.ScriptBody": "Write-Host \"#Adding release number to response header\"\n\n[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.Web.Administration\") | Out-Null\n$iis = new-object Microsoft.Web.Administration.ServerManager\n$config = $iis.GetWebConfiguration($OctopusParameters['webSiteName'])\n$httpProtocolSection = $config.GetSection(\"system.webServer/httpProtocol\")\n$customHeadersCollection = $httpProtocolSection.GetCollection(\"customHeaders\")\n\n$update = $false\n\nforeach($path in $customHeadersCollection.GetCollection()) { \n    if ($path.GetAttributeValue(\"name\") -eq $OctopusParameters['FieldName']) {\n        write-host \"Release number is already in the response header, skipping\"\n        $update = $false\n        break\n    } else {\n        $update = $true\n    }\n}\n\nif ($update)\n{\n    Write-Host \"Adding release number\"\n    $addElement = $customHeadersCollection.CreateElement(\"add\")\n    $addElement[\"name\"] = $OctopusParameters['FieldName']\n    $addElement[\"value\"] = $OctopusParameters[\"Octopus.Release.Number\"]\n    $customHeadersCollection.Add($addElement)\n    $iis.CommitChanges() | Write-Host\n}"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -13,20 +13,22 @@
       "Name": "FieldName",
       "Label": "Field name",
       "HelpText": "The name of the the Field name you want the release to show as.",
-      "DefaultValue": "rel"
+      "DefaultValue": "Release",
+      "DisplaySettings": {}
     },
     {
       "Name": "WebsiteName",
       "Label": "Website name",
       "HelpText": "The name of the site in IIS",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2014-07-31T20:47:43.457+00:00",
-  "LastModifiedBy": "emailbob",
+  "LastModifiedOn": "2015-08-28T11:39:07.139+00:00",
+  "LastModifiedBy": "gormac",
   "$Meta": {
-    "ExportedAt": "2014-07-31T20:51:22.736Z",
-    "OctopusVersion": "2.4.5.46",
+    "ExportedAt": "2015-08-28T12:37:06.927Z",
+    "OctopusVersion": "2.6.4.951",
     "Type": "ActionTemplate"
   }
 }

--- a/step-templates/iis-website-add-release-number-to-response-header.json
+++ b/step-templates/iis-website-add-release-number-to-response-header.json
@@ -3,31 +3,35 @@
   "Name": "IIS Website - Add Release Number to Response Header",
   "Description": "Adds the Octopus Deploy Release number to the IIS response header. When you browse your site you can look at the response header to verify the build number that is running.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 9,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "Write-Host \"#Adding release number to response header\"\n\n[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.Web.Administration\") | Out-Null\n$iis = new-object Microsoft.Web.Administration.ServerManager\n$config = $iis.GetWebConfiguration($OctopusParameters['webSiteName'])\n$httpProtocolSection = $config.GetSection(\"system.webServer/httpProtocol\")\n$customHeadersCollection = $httpProtocolSection.GetCollection(\"customHeaders\")\n\n$update = $false\n\nforeach($path in $customHeadersCollection.GetCollection()) { \n    if ($path.GetAttributeValue(\"name\") -eq $OctopusParameters['FieldName']) {\n        write-host \"Release number is already in the response header, skipping\"\n        $update = $false\n        break\n    } else {\n        $update = $true\n    }\n}\n\nif ($update)\n{\n    Write-Host \"Adding release number\"\n    $addElement = $customHeadersCollection.CreateElement(\"add\")\n    $addElement[\"name\"] = $OctopusParameters['FieldName']\n    $addElement[\"value\"] = $OctopusParameters[\"Octopus.Release.Number\"]\n    $customHeadersCollection.Add($addElement)\n    $iis.CommitChanges() | Write-Host\n}"
+    "Octopus.Action.Script.ScriptBody": "Write-Host \"Adding release number to response header\"\n\n[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.Web.Administration\") | Out-Null\n$iis = new-object Microsoft.Web.Administration.ServerManager\n$config = $iis.GetWebConfiguration($OctopusParameters['WebsiteName'])\n$httpProtocolSection = $config.GetSection(\"system.webServer/httpProtocol\")\n$customHeadersCollection = $httpProtocolSection.GetCollection(\"customHeaders\")\n\n$update = $true\n\nforeach($path in $customHeadersCollection.GetCollection()) { \n    if ($path.GetAttributeValue(\"name\") -eq $OctopusParameters['FieldName']) {\n        write-host \"Release number is already in the response header, skipping\"\n        $update = $false\n        break\n    }\n}\n\nif ($update)\n{\n    $fieldName = $OctopusParameters['FieldName']\n    $releaseNumber = $OctopusParameters['Octopus.Release.Number']\n    \n    Write-Host \"Adding release number $releaseNumber to custom header $fieldName\"\n    \n    $addElement = $customHeadersCollection.CreateElement(\"add\")\n    $addElement[\"name\"] = $fieldName\n    $addElement[\"value\"] = $releaseNumber\n    $customHeadersCollection.Add($addElement)\n    \n    $iis.CommitChanges() | Write-Host\n}"
   },
   "SensitiveProperties": {},
   "Parameters": [
     {
       "Name": "FieldName",
       "Label": "Field name",
-      "HelpText": "The name of the the Field name you want the release to show as.",
+      "HelpText": "The name of the custom header field with the release information.",
       "DefaultValue": "Release",
-      "DisplaySettings": {}
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
     {
       "Name": "WebsiteName",
       "Label": "Website name",
-      "HelpText": "The name of the site in IIS",
+      "HelpText": "The name of the website in IIS.",
       "DefaultValue": null,
-      "DisplaySettings": {}
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
-  "LastModifiedOn": "2015-08-28T11:39:07.139+00:00",
+  "LastModifiedOn": "2015-08-31T12:05:18.511+00:00",
   "LastModifiedBy": "gormac",
   "$Meta": {
-    "ExportedAt": "2015-08-28T12:37:06.927Z",
+    "ExportedAt": "2015-08-31T12:05:21.070Z",
     "OctopusVersion": "2.6.4.951",
     "Type": "ActionTemplate"
   }


### PR DESCRIPTION
Using Octopus parameter "Octopus.Step.Package.NuGetPackageVersion" resulted in an empty release number, because the parameter should be used as "Octopus.Step[step_name_here].Package.NuGetPackageVersion".

Replaced Octopus parameter "Octopus.Step.Package.NuGetPackageVersion" with "Octopus.Release.Number" to solve this.