### PR TITLE
Added simple invoke url step template which doesn't throw when url re…

### DIFF
--- a/step-templates/http-invoke-url.json
+++ b/step-templates/http-invoke-url.json
@@ -1,0 +1,29 @@
+{
+  "Id": "ActionTemplates-33",
+  "Name": "HTTP - Invoke URL",
+  "Description": "Invoke HTTP Get request using provided url. Doesn't throw exception when request fails.",
+  "ActionType": "Octopus.Script",
+  "Version": 2,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$url,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$url\r\n    ) \r\n\r\n    Write-Host \"Invoke Url: $url\"\r\n\r\n    try {\r\n    \r\n        Invoke-WebRequest -Uri $url -Method Get -UseBasicParsing\r\n\r\n    } catch {\r\n        Write-Host \"There was a problem invoking Url\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'url' -Required)"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "url",
+      "Label": "Url",
+      "HelpText": "Web request Url",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-08-31T12:06:43.681+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-08-31T12:25:19.923Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Added simple invoke url step template which doesn't throw when url request is not successful, we use it to invoke ui automation on another server after the build. The whole idea about it is to execute request which will not fail build process even if request fails for some reason. Just fire and forget.