### PR TITLE
two more steps to deal with Octopus removing all IIS bindings when co…

### DIFF
--- a/step-templates/iis-bindings-backup.json
+++ b/step-templates/iis-bindings-backup.json
@@ -1,0 +1,29 @@
+{
+  "Id": "ActionTemplates-34",
+  "Name": "IIS Bindings - Backup",
+  "Description": "Backs up IIS bindings for a given site so they can be restored in later steps. This is very useful if we we have any existing bindings on IIS server since Octopus wipes all existing bindings when create new ones.",
+  "ActionType": "Octopus.Script",
+  "Version": 9,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction Get-File-Name() {\r\n   if($OctopusParameters -eq $null) {\r\n        return \"site_backup.xml\"   \r\n   } else {\r\n        return $OctopusParameters[\"Octopus.Release.Number\"] + \"_\" + $OctopusParameters[\"Octopus.Environment.Name\"] + \".xml\"\r\n   }\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName\r\n    ) \r\n\r\n    Write-Host \"Save $webSiteName bindings to bindings variable\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n\r\n         $currentBindings = Get-WebBinding -Name $webSiteName\r\n         $bindingsBackupFile = Get-File-Name\r\n         $currentBindings | Export-CliXML $bindingsBackupFile\r\n\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem saving bindings\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required)\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "webSiteName",
+      "Label": "Web Site Name",
+      "HelpText": "Name of the web site for which we should backup bindings",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-09-01T16:37:27.638+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-09-01T16:52:34.425Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/iis-bindings-restore.json
+++ b/step-templates/iis-bindings-restore.json
@@ -1,0 +1,29 @@
+{
+  "Id": "ActionTemplates-35",
+  "Name": "IIS Bindings - Restore",
+  "Description": "This step will restore IIS bindings from backup taken in IIS Bindings - Backup step. Only bindings which doesn't exist will be restored.",
+  "ActionType": "Octopus.Script",
+  "Version": 4,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction Get-File-Name() {\r\n   if($OctopusParameters -eq $null) {\r\n        return \"site_backup.xml\"   \r\n   } else {\r\n        return $OctopusParameters[\"Octopus.Release.Number\"] + \"_\" + $OctopusParameters[\"Octopus.Environment.Name\"] + \".xml\"\r\n   }\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName\r\n    ) \r\n\r\n    Write-Host \"Restore $webSiteName bindings from bindings variable\"\r\n\r\n    try {\r\n        Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n        Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n        $bindingsBackupFile = Get-File-Name\r\n        $currentBindings = Import-CliXML $bindingsBackupFile \r\n\r\n        if($currentBindings -eq $null) {\r\n            Write-Host \"There is no saved bindings, you have to run IIS save bindings before\"\r\n        } else {\r\n            foreach($binding in $currentBindings) {\r\n                $bindingArray = $binding.bindingInformation.Split(\":\")\r\n                $existing = Get-WebBinding -Name $webSiteName -Protocol $binding.protocol -IPAddress $bindingArray[0] -Port $bindingArray[1] -HostHeader $bindingArray[2]\r\n\r\n                if($existing -eq $null) {\r\n                    Write-Host \"Adding binding\" $binding.protocol $binding.bindingInformation                    \r\n                    New-WebBinding -Name $webSiteName -Protocol $binding.protocol -IPAddress $bindingArray[0] -Port $bindingArray[1] -HostHeader $bindingArray[2]\r\n                }\r\n            }\r\n        }\r\n\r\n        Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem restoring bindings\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required)\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "webSiteName",
+      "Label": "Web Site Name",
+      "HelpText": "Name of the web site for which bindings will be restored from backup taken in previous IIS Bindings - Backup task. Only bindings which doesn't already exist will be restored.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-09-01T16:51:46.600+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-09-01T16:53:28.028Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
When we use Octopus to configure web site on IIS server, it removes all existing IIS bindings for the site it configures, and add all bindings which are configured in Octopus. This is an issue if we already have IIS bindings configure and we only want Octopus to add new ones but not remove all existing bindings. To deal with that I have created one step which saves all bindings for provided site name to xml file. This should be executed before the step which configure web site. Next you add restore step after web site configuration step. This step will restore IIS bindings if they doesn't already exist.