### PR TITLE
Update property step templates for AppPool, WebSite, App

### DIFF
--- a/step-templates/iis-app-update-property.json
+++ b/step-templates/iis-app-update-property.json
@@ -1,0 +1,56 @@
+ {
+  "Id": "ActionTemplates-38",
+  "Name": "IIS App - Update Property",
+  "Description": "Updates property for specified application",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [string]$applicationName,\r\n    [string]$propertyName,\r\n    [object]$propertyValue,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName,\r\n        [string]$applicationName,\r\n        [string]$propertyName,\r\n        [object]$propertyValue\r\n    ) \r\n\r\n    Write-Host \"Setting $webSiteName\\$applicationName property $propertyName to $propertyValue\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName | Select-Object -ExpandProperty \"Value\"\r\n         $oldValueString = \"\"\r\n\r\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\r\n         {\r\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\");\r\n         }\r\n         else \r\n         {\r\n             $oldValueString = $oldValue\r\n         }\r\n\r\n         Write-Host \"Old value $oldValueString\"\r\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName -Value $propertyValue\r\n         Write-Host \"New value $propertyValue\"\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem setting property\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required) (Get-Param 'applicationName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "webSiteName",
+      "Label": "Web site name",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "applicationName",
+      "Label": "Aplication name",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyName",
+      "Label": "Name of the property to set",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyValue",
+      "Label": "Value of the property to set",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-10-23T00:59:31.908+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-10-23T02:13:55.226Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/iis-apppool-update-property.json
+++ b/step-templates/iis-apppool-update-property.json
@@ -1,0 +1,47 @@
+{
+  "Id": "ActionTemplates-36",
+  "Name": "IIS AppPool - Update Property",
+  "Description": "Updates property for specified AppPool, useful for example to change startMode to AlwaysRunning.",
+  "ActionType": "Octopus.Script",
+  "Version": 4,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$appPoolName,\r\n    [string]$propertyName,\r\n    [object]$propertyValue,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$appPoolName,\r\n        [string]$propertyName,\r\n        [object]$propertyValue\r\n    ) \r\n\r\n    Write-Host \"Setting $appPoolName property $propertyName to $propertyValue\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n         $oldValue = Get-ItemProperty \"IIS:\\AppPools\\$appPoolName\" -Name $propertyName \r\n         $oldValueString = \"\"\r\n\r\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\r\n         {\r\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\");\r\n         }\r\n         else \r\n         {\r\n             $oldValueString = $oldValue\r\n         }\r\n\r\n         Write-Host \"Old value $oldValueString\"\r\n         Set-ItemProperty \"IIS:\\AppPools\\$appPoolName\" -Name $propertyName -Value $propertyValue\r\n         Write-Host \"New value $propertyValue\"\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem setting property\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'appPoolName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "appPoolName",
+      "Label": "Application pool name",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyName",
+      "Label": "Name of the property to set",
+      "HelpText": "",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyValue",
+      "Label": "Value of the property to set",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-10-23T00:59:58.662+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-10-23T02:15:10.732Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/iis-autostartprovider-add.json
+++ b/step-templates/iis-autostartprovider-add.json
@@ -1,0 +1,38 @@
+{
+  "Id": "ActionTemplates-39",
+  "Name": "IIS AutoStartProvider - Add",
+  "Description": "Add autostartprovider entry so type can be used to warm up applicaiton. Final changes in applicationHost.config look like that:\n\n<serviceAutoStartProviders>\n    <add name=\"ApplicationPreload\" type=\"WebApplication1.ApplicationPreload, WebApplication1\" />\n</serviceAutoStartProviders>\n\nwhere name and type are taken from parameters.",
+  "ActionType": "Octopus.Script",
+  "Version": 0,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n        [string]$serviceName,\r\n        [string]$serviceType,\r\n        [switch]$whatIf\r\n     ) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n        if ($OctopusParameters -ne $null) {\r\n            $result = $OctopusParameters[$Name]\r\n        }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n            if ($variable -ne $null) {\r\n                $result = $variable.Value\r\n            }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n            [string]$serviceName,\r\n            [string]$serviceType\r\n         ) \r\n\r\n        Write-Host \"Setting $serviceName, $serviceType service autostart provider\"\r\n\r\n        try {\r\n            Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n            Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n\r\n            $oldValue = Get-WebConfiguration -filter /system.applicationHost/serviceAutoStartProviders/add | \r\n                        Where-Object { $_.Name -eq $serviceName }\r\n\r\n            if ($oldValue -eq $null) {\r\n                Write-Host \"Adding new service type provider $serviceName, $serviceType\"\r\n                Add-WebConfiguration -filter /system.applicationHost/serviceAutoStartProviders -Value @{name=$serviceName; type=$serviceType}\r\n            } \r\n            elseif ($oldValue.Type -eq $serviceType) { \r\n                Write-Host \"Service provider with the same name and type exists\"\r\n            } else {\r\n                $oldValueType = $oldValue.Type\r\n                Write-Host \"Replacing service type from $oldValueType to $serviceType\"\r\n                Set-WebConfiguration -filter \"/system.applicationHost/serviceAutoStartProviders/add[@name='$serviceName']\" -Value @{\"type\" = \"$serviceType\"}\r\n            }\r\n\r\n            Write-Host \"Done\"\r\n        } catch {\r\n            Write-Host $_.Exception|format-list -force\r\n            Write-Host \"There was a problem setting property\"    \r\n        }\r\n} `\r\n(Get-Param 'serviceName' -Required) (Get-Param 'serviceType' -Required) \r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "serviceName",
+      "Label": "Name of autostart service",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "serviceType",
+      "Label": "Type which implements IProcessHostPreloadClient",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-10-23T01:06:20.789+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-10-23T02:23:21.661Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/iis-website-update-property.json
+++ b/step-templates/iis-website-update-property.json
@@ -1,0 +1,47 @@
+{
+  "Id": "ActionTemplates-37",
+  "Name": "IIS WebSite - Update Property",
+  "Description": "Updates property for specified WebSite",
+  "ActionType": "Octopus.Script",
+  "Version": 4,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [string]$propertyName,\r\n    [object]$propertyValue,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName,\r\n        [string]$propertyName,\r\n        [object]$propertyValue\r\n    ) \r\n\r\n    Write-Host \"Setting $webSiteName property $propertyName to $propertyValue\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName | Select-Object -ExpandProperty \"Value\"\r\n         $oldValueString = \"\"\r\n\r\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\r\n         {\r\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\");\r\n         }\r\n         else \r\n         {\r\n             $oldValueString = $oldValue\r\n         }\r\n\r\n         Write-Host \"Old value $oldValueString\"\r\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName -Value $propertyValue\r\n         Write-Host \"New value $propertyValue\"\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem setting property\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\r\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "webSiteName",
+      "Label": "Web site name",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyName",
+      "Label": "Name of the property to set",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "propertyValue",
+      "Label": "Value of the property to set",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-10-23T01:00:50.788+00:00",
+  "LastModifiedBy": "jmalczak",
+  "$Meta": {
+    "ExportedAt": "2015-10-23T02:15:40.676Z",
+    "OctopusVersion": "2.6.5.1010",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Hi Guys

Those are step templates I used to configure my IIS website to hot start using autostartenabled, serviceautostartprovider and apppool start mode. This is example:

IIS AppPool - Update Property - Start Mode -AlwaysRunning
* propertyName: startMode, propertyValue: AlwaysRunning
IIS WebSite - Update Property - AutoStartEnabled - True
* propertyName: applicationDefaults.serviceAutoStartEnabled, propertyValue: True
IIS WebSite - Update Property - ServiceAutostartProvider
* propertyName: applicationDefaults.serviceAutoStartProvider, propertyValue: ProviderNae

But those templates can be used to set most of the properties of AppPool, WebSite, Application.