### PR TITLE
Now $ replacement syntax works

### DIFF
--- a/step-templates/file-system-regular-expression-find-and-replace.json
+++ b/step-templates/file-system-regular-expression-find-and-replace.json
@@ -1,11 +1,12 @@
 {
-  "Id": "ActionTemplates-66",
-  "Name": "File System - Regular Expression Find and Replace",
-  "Description": "Find and replace text matching a regular expression in one or more files.",
+  "Id": "ActionTemplates-20",
+  "Name": "File System - Regular Expression Find and Replace (Updated)",
+  "Description": "Find and replace text matching a regular expression in one or more files. Now with working $ replacement.",
   "ActionType": "Octopus.Script",
   "Version": 6,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "function Execute-RegexFindReplace($target, $find, $replace, $options) {\n    Write-Output \"Searching $target...\"\n    $orig = [System.IO.File]::ReadAllText($target)\n    \n    $regex = new-object System.Text.RegularExpressions.Regex($find, $options)\n    \n    $occurrences = $regex.Matches($orig).Count\n    if ($occurrences -gt 0) {\n        Write-Output \"Found $occurrences occurrence(s), replacing...\"\n        \n        $escReplaced = $replace.Replace(\"$\", \"$$\")\n        $replaced = $regex.Replace($orig, $escReplaced)\n        [System.IO.File]::WriteAllText($target, $replaced)\n    }\n}\n\nif ([string]::IsNullOrEmpty($RFRFindRegex)) {\n    throw \"A non-empty 'Pattern' is required\"\n}\n\n$options = [System.Text.RegularExpressions.RegexOptions]::None\n$RFROptions.Split(' ') | foreach {\n    $opt = $_.Trim()\n    $flag = [System.Enum]::Parse([System.Text.RegularExpressions.RegexOptions], $opt)\n    $options = $options -bor $flag\n}\n\nWrite-Output \"Replacing occurrences of '$RFRFindRegex' with '$RFRSubstitution' applying options $RFROptions\"\n\n$RFRCandidatePathGlobs.Split(\";\") | foreach {\n    $glob = $_.Trim()\n    Write-Output \"Searching for files that match $glob...\"\n\n    $matches = $null\n    $splits = $glob.Split(@('/**/'), [System.StringSplitOptions]::RemoveEmptyEntries)\n\n    if ($splits.Length -eq 1) {\n        $splits = $glob.Split(@('\\**\\'), [System.StringSplitOptions]::RemoveEmptyEntries)\n    }\n    \n    if ($splits.Length -eq 1) {\n        $matches = ls $glob\n    } else {\n        if ($splits.Length -eq 2) {\n            pushd $splits[0]\n            $matches = ls $splits[1] -Recurse\n            popd\n        } else {\n            $splits\n            throw \"The segment '**' can only appear once, as a directory name, in the glob expression\"\n\n        }\n    }\n\n    $matches | foreach {\n        \n        $target = $_.FullName\n\n        Execute-RegexFindReplace -target $target -find $RFRFindRegex -replace $RFRSubstitution -options $options\n    }\n}\n\n\nWrite-Output \"Done.\""
+    "Octopus.Action.Script.ScriptBody": "function Execute-RegexFindReplace($target, $find, $replace, $options) {\n    Write-Output \"Searching $target...\"\n    $orig = [System.IO.File]::ReadAllText($target)\n    \n    $regex = new-object System.Text.RegularExpressions.Regex($find, $options)\n    \n    $occurrences = $regex.Matches($orig).Count\n    if ($occurrences -gt 0) {\n        Write-Output \"Found $occurrences occurrence(s), replacing...\"\n        \n        $replaced = $regex.Replace($orig, $replace)\n        [System.IO.File]::WriteAllText($target, $replaced)\n    }\n}\n\nif ([string]::IsNullOrEmpty($RFRFindRegex)) {\n    throw \"A non-empty 'Pattern' is required\"\n}\n\n$options = [System.Text.RegularExpressions.RegexOptions]::None\n$RFROptions.Split(' ') | foreach {\n    $opt = $_.Trim()\n    $flag = [System.Enum]::Parse([System.Text.RegularExpressions.RegexOptions], $opt)\n    $options = $options -bor $flag\n}\n\nWrite-Output \"Replacing occurrences of '$RFRFindRegex' with '$RFRSubstitution' applying options $RFROptions\"\n\n$RFRCandidatePathGlobs.Split(\";\") | foreach {\n    $glob = $_.Trim()\n    Write-Output \"Searching for files that match $glob...\"\n\n    $matches = $null\n    $splits = $glob.Split(@('/**/'), [System.StringSplitOptions]::RemoveEmptyEntries)\n\n    if ($splits.Length -eq 1) {\n        $splits = $glob.Split(@('\\**\\'), [System.StringSplitOptions]::RemoveEmptyEntries)\n    }\n    \n    if ($splits.Length -eq 1) {\n        $matches = ls $glob\n    } else {\n        if ($splits.Length -eq 2) {\n            pushd $splits[0]\n            $matches = ls $splits[1] -Recurse\n            popd\n        } else {\n            $splits\n            throw \"The segment '**' can only appear once, as a directory name, in the glob expression\"\n\n        }\n    }\n\n    $matches | foreach {\n        \n        $target = $_.FullName\n\n        Execute-RegexFindReplace -target $target -find $RFRFindRegex -replace $RFRSubstitution -options $options\n    }\n}\n\n\nWrite-Output \"Done.\"",
+    "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -13,32 +14,34 @@
       "Name": "RFRCandidatePathGlobs",
       "Label": "Files",
       "HelpText": "The files to search. Wildcards `*` and `**` are supported. Paths must be fully-qualified, e.g. `C:\\MyApp\\**\\*.xml`. Separate multiple paths with `;` semicolons.",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "RFRFindRegex",
       "Label": "Pattern",
       "HelpText": "The regular expression to find in the target files.",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "RFRSubstitution",
       "Label": "Substitution",
       "HelpText": "The text to insert in place of each occurrence of _Pattern_. Regular expression [substitutions](http://msdn.microsoft.com/en-us/library/ewy2t5e0.aspx) are supported, so any literal `$` in the substitution pattern must be escaped by doubling (`$$`).",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "RFROptions",
       "Label": "Options",
       "HelpText": "A space-separated list of options from the [RegexOptions](http://msdn.microsoft.com/en-us/library/system.text.regularexpressions.regexoptions.aspx) enumeration.",
-      "DefaultValue": "ExplicitCapture"
+      "DefaultValue": "ExplicitCapture",
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2014-05-14T05:36:33.818+00:00",
-  "LastModifiedBy": "nblumhardt",
   "$Meta": {
-    "ExportedAt": "2014-05-14T05:36:35.364Z",
-    "OctopusVersion": "2.4.4.0",
+    "ExportedAt": "2015-10-26T21:24:18.756Z",
+    "OctopusVersion": "3.0.10.2278",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Originally the script didn't handle any $ syntax - as if it was deleting
them even if multiples were used to quote.  This change re-enables the $
syntax for replacements allowing grouping to be used in the replacement
string.  And $$ quotes a single $ into the output too.