### PR TITLE
Create RavenDB - Smuggler - Move Data Between Databases

### DIFF
--- a/step-templates/Azure - Upload Files to Azure
+++ b/step-templates/Azure - Upload Files to Azure
@@ -1,0 +1,75 @@
+#--------------------------------------------------------------------
+# Azure subscription-specific variables.
+#Gets Azure Account Name
+$storageAccountName = $OctopusParameters["storageAccountName"]
+
+#Gets Azure Account Key
+$storageAccountKey = $OctopusParameters["storageAccountKey"]
+
+#Gets Azure Container Name
+$containerName = $OctupusParameters["containerName"]
+
+#--------------------------------------------------------------------
+#Information of the folder being uploaded
+#Gets the location of the folder that is being uploaded
+$fileLocation = $OctopusParamters["fileLocation"]
+
+#Get the name of the parent folder being uploaded
+$localFolder = $OctopusParameters["localFolder"]
+
+#--------------------------------------------------------------------
+#Recursive optional
+$recursive = $OctopusParameters["recursive"]
+
+#Sets the Permissions to public if the selection is true
+if ([boolean]::Parse($recursive)) 
+{
+    
+	$recurse = "-Recurse"
+
+}
+
+#--------------------------------------------------------------------
+#Checking to see if Azure is installed on the computer
+$name = 'Azure'
+
+Write-Output "Checking if Azure Powershell is installed"
+
+if(Get-Module -ListAvailable | Where-Object {$_.name -eq $name})
+{
+	(Get-Module -ListAvailable | Where-Object{ $_.Name -eq $name}) |
+	Select Version, Name, Author, PowerShellVersion | Format-List;
+	Write-Output "Azure Powershell is installed"
+}
+else
+{
+	#Provides the link to install Azure Powershell, if it is not installed
+	Write-Warning "Please install Azure Powershell. To install Azure Powershell go to http://bit.ly/AzurePowershellDownload"
+	Exit 1
+}
+
+
+
+#--------------------------------------------------------------------
+
+#Initialises the Azure Credentials based on the Storage Account Name and the Storage Account Key, 
+#so that we can invoke the APIs further down. 
+$storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
+
+#--------------------------------------------------------------------
+
+$files = Get-ChildItem $localFolder
+#Gets each file in the data subfolder and uploads them
+foreach($file in $files)
+{
+  #Gets the location of the file 
+  $fileName = "$currentLocation\$file"
+  #Gets the blob name that the file will be uploaded to
+  $blobName = "$localFolder/$file"
+  #Gives the user an update on the progress
+  Write-Output "copying $fileName to $blobName"
+  #Sets the location and uploads the file
+  Set-AzureStorageBlobContent -File $filename -Container $containerName -Blob $blobName -Context $storageContext -Force $recurse
+} 
+
+Write-Output "All files in $localFolder uploaded to $containerName!"

--- a/step-templates/RavenDB - Smuggler - Move Data Between Databases
+++ b/step-templates/RavenDB - Smuggler - Move Data Between Databases
@@ -1,0 +1,140 @@
+@@ -0,0 +1,138 @@
+{
+  "Id": "ActionTemplates-60",
+  "Name": "RavenDB - Smuggler - Move Data Between Databases",
+  "Description": "To move data directly between two instances (or different databases in the same instance) using the between option introduced in Smuggler version 3.",
+  "ActionType": "Octopus.Script",
+  "Version": 5,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "# Variables\r\n\r\n#Location of the Raven Smuggler exe\r\n$ravenSmugglerPath = $OctopusParameters[\"ravenDBSmugglerPath\"]\r\n\r\n#--------------------------------------------------------------------\r\n# Source Database Variables\r\n\r\n#URL of RavenDB that is being backed up \r\n$sourceDatabaseURL = $OctopusParameters[\"sourceDBUrl\"]\r\n\r\n#name of the RavenDB that is being backed up\r\n$sourceDatabaseName = $OctopusParameters[\"sourceDBName\"]\r\n\r\n#API Key fo...(line truncated)...
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "ravenDBSmugglerPath",
+      "Label": "Raven Smuggler Path",
+      "HelpText": "Full path to the Smuggler EXE.\n \nFor example **C:\\RavenDB\\Smuggler\\Raven.Smuggler.exe**",
+      "DefaultValue": "C:\\RavenDB\\Smuggler\\Raven.Smuggler.exe",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "sourceDBUrl",
+      "Label": "Source Database URL",
+      "HelpText": "The URL of the Raven database, where the **Source Database** is located. \n\nFor example **http://localhost:8080/**",
+      "DefaultValue": "http://localhost:8080/",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "sourceDBName",
+      "Label": "Name of the Source Database",
+      "HelpText": "Name of the **Source Database** in Raven.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "sourceDBApiKey",
+      "Label": "API Key for the Source Database",
+      "HelpText": "API Key needed to access the **Source Database**. \n\nIf key is not provided, anonymous authentication will be used.\n\nFor more information: http://ravendb.net/docs/article-page/3.0/csharp/studio/accessing-studio",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "destinationDBUrl",
+      "Label": "Destination Database URL",
+      "HelpText": "The URL of the Raven database, where the **Destination Database** is located. \n\nFor example **http://localhost:8080/**",
+      "DefaultValue": "http://localhost:8080/",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "destinationDBName",
+      "Label": "Name of the Destination Database",
+      "HelpText": "Name of the **Destination Database** in Raven.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "destinationDBApiKey",
+      "Label": "API Key for the Destination Database",
+      "HelpText": "API Key needed to access the **Destination Database**. \n\nIf key is not provided, anonymous authentication will be used.\n\nFor more information: http://ravendb.net/docs/article-page/3.0/csharp/studio/accessing-studio",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "OperateDocuments",
+      "Label": "Operate on Documents",
+      "HelpText": "With Raven backup, you can choose which types are operated during the backup.\n\nUnselect this option to exclude **Documents** from the copying process.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "OperateAttachments",
+      "Label": "Operate on Attachments",
+      "HelpText": "With Raven backup, you can choose which types are operated during the backup.\n\nUnselect this option to exclude **Attachments** from the copying process.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "OperateIndexes",
+      "Label": "Operate on Indexes",
+      "HelpText": "With Raven backup, you can choose which types are operated during the backup.\n\nUnselect this option to exclude **Indexes** from the copying process.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "OperateTransformers",
+      "Label": "Operate on Transformers",
+      "HelpText": "With Raven backup, you can choose which types are operated during the backup.\n\nUnselect this option to exclude **Transformers** from the copying process.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "backUpTimeout",
+      "Label": "Timeout",
+      "HelpText": "The timeout (in milliseconds) to use for requests.",
+      "DefaultValue": "300000",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "WaitIndexing",
+      "Label": "Wait for Indexing",
+      "HelpText": "Wait until all indexing activity has been completed (Import Only).",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    }
+  ],
+  "LastModifiedOn": "2015-11-02T22:39:11.556Z",
+  "LastModifiedBy": "timhunt303",
+  "$Meta": {
+    "ExportedAt": "2015-11-02T23:10:31.140Z",
+    "OctopusVersion": "3.1.3",
+    "Type": "ActionTemplate"
+  }
+}
+\ No newline at end of file

--- a/step-templates/RavenDB - Smuggler - Moving Data between File Systems
+++ b/step-templates/RavenDB - Smuggler - Moving Data between File Systems
@@ -1,0 +1,166 @@
+
+# Variables
+
+#Location of the Raven Smuggler exe
+$ravenSmugglerPath = $OctopusParameters["ravenSmugglerPath"]
+
+
+#--------------------------------------------------------------------
+# Source File System Variables
+
+#URL of RavenFS that is being backed up 
+$sourceFileSystemURL = $OctopusParameters["sourceFileSystemURL"]
+
+#name of the RavenFS that is being backed up
+$sourceFileSystemName = $OctopusParameters["sourceFileSystemName"]
+
+#API Key for the Source File System
+$sourceFileSystemApiKey = $OctopusParameters["sourceFileSystemApiKey"]
+
+
+
+
+#--------------------------------------------------------------------
+#Destination File System Variables
+
+#URL of destination RavenFS 
+$destinationFileSystemURL = $OctopusParameters["destinationFileSystemURL"]
+
+#Name of the destination RavenFS
+$destinationFileSystemName = $OctopusParameters["destinationFileSystemName"]
+
+#API Key for the Destination File System
+$destinationFileSystemAPIKey = $OctopusParameters["destinationFileSystemAPIKey"]
+
+
+#--------------------------------------------------------------------
+# Other Variables retrieved from Octopus
+
+#Get timeout variable
+$timeout = $OctopusParameters["timeout"]
+
+
+
+#--------------------------------------------------------------------
+
+#checks to see if the entered file system exists, return a Boolean value depending on the outcome
+function doesRavenFSExist([string] $FSChecking, [string]$URL)
+{
+    #retrieves the list of File Systems at the specified URL
+    $fs_list = Invoke-RestMethod -Uri "$URL/fs" -Method Get
+    #checks if the File System is at the specified URL
+    if ($fs_list -contains $FSChecking.ToString()) 
+    {
+        return $TRUE
+    }
+    else 
+    {
+        return $FALSE
+    }
+
+    
+}#ends does File System exist function
+
+
+Write-Output "`n-------------------------`n"
+
+#--------------------------------------------------------------------
+
+#Check path to smuggler
+Write-Output "Checking if Smuggler path is correct`n"
+
+$smuggler_Exists = Test-Path -Path $ravenSmugglerPath
+
+
+
+#if the path is correct, the script continues, throws an error if the path is wrong
+If($smuggler_Exists -eq $TRUE)
+{
+    Write-Output "Smuggler exists"
+
+}#ends if smuggler exists 
+else
+{
+    Write-Error "Smuggler cannot be found `nCheck the directory: $ravenSmugglerPath" -ErrorId E4
+    Exit 1
+}#ends else, smuggler can't be found
+
+Write-Output "`n-------------------------`n"
+
+#--------------------------------------------------------------------
+#Checking the version of smuggler
+
+$SmugglerVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($ravenSmugglerPath).FileVersion
+
+if($SmugglerVersion -cgt "3")
+{
+    Write-Host "Smuggler Version: $SmugglerVersion"
+}
+else
+{
+    Write-Error "The version of Smuggler that is installed can NOT complete this step. `nPlease update Smuggler before continuing" -ErrorId E4
+    Exit 1
+}
+Write-Output "`n-------------------------`n"
+
+#--------------------------------------------------------------------
+
+#Check if Source File System and destination File System exists
+Write-Output "Checking if both $sourceFileSystemName and $destinationFileSystemName exist`n"
+
+$sourceFS_exists = doesRavenFSExist -FSChecking $sourceFileSystemName -URL $sourceFileSystemURL 
+
+$DestinationFS_Exist = doesRavenFSExist -FSChecking $destinationFileSystemName -URL $destinationFileSystemURL
+
+
+#if both File System exist a backup occurs
+if(($sourceFS_exists -eq $TRUE) -and ($DestinationFS_Exist -eq $TRUE))
+{
+
+    Write-Output "Both $sourceFileSystemName and $destinationFileSystemName exist`n"
+
+}#ends if 
+#if the source File System doesn’t exist an error is throw
+elseIf(($sourceFS_exists -eq $FALSE) -and ($DestinationFS_Exist -eq $TRUE))
+{
+
+    Write-Error "$sourceFileSystemName does not exist. `nMake sure the File System exists before continuing" -ErrorId E4
+    Exit 1
+
+}
+#if the destination File System doesn’t exist an error is throw
+elseIf(($DestinationFS_Exist -eq $FALSE) -and ($sourceFS_exists -eq $TRUE))
+{
+
+    Write-Error "$destinationFileSystemName does not exist. `nMake sure the File System exists before continuing" -ErrorId E4
+    Exit 1
+
+}#ends destination FS not exists
+else
+{
+ 
+    Write-Error "Neither $sourceFileSystemName or $destinationFileSystemName exists. `nMake sure both File Systems exists" -ErrorId E4
+    Exit 1
+
+}#ends else
+
+Write-Output "`n-------------------------`n"
+
+#--------------------------------------------------------------------
+#start Backup
+
+try
+{
+    Write-Output "Attempting Backup up now"
+    Write-Output "`n-------------------------`n"
+    & $ravenSmugglerPath between $sourceFileSystemURL $destinationFileSystemURL --filesystem=$sourceFileSystemName --filesystem2=$destinationFileSystemName --api-key=$sourceFileSystemApiKey --api-key2=$destinationFileSystemAPIKey --timeout=$timeout
+    Write-Output "`n-------------------------`n"
+    Write-Output "Backup successful"
+
+
+}#ends try
+catch
+{
+    Write-Error "An error occurred during backup, please try again" -ErrorId E4
+    Exit 1
+}#ends catch


### PR DESCRIPTION
**Create RavenDB - Smuggler - Move Data Between Databases**

To move data directly between two instances (or different databases in the same instance) using the between option introduced in Smuggler version 3.

•	Checks the build number of each database as there are slight variations between builds and versions. 
•	Checks the path to the Smuggler exe, throws an error if the path isn’t valid
•	Checks the version of Smuggler, as this step relies on the between option which was introduced in version is 3.
•	Checks to see if the both database exists, throws an error based on which one doesn’t exist  
•	Allows the user to select which types in the database, they would like to operate on 
•	Moves data between two databases (backing up one database into another one)

**Azure - Upload Files to Azure**

Uploads files and folders to an Azure container from a specified location.

IMPORTANT: Azure PowerShell must be installed on the tentacle server for this step to work. This can be downloaded from http://bit.ly/AzurePowershellDownload 
 
•	Checks to see if Azure PowerShell is installed on the computer. Provides a link to a download if it isn’t installed. 
•	Loops through all child folders and files to upload them to the specified container


**RavenDB - Smuggler - Moving Data between File Systems**

To move data directly between two instances (or different file systems in the same instance) using the between option introduced in Smuggler version 3.

•	Checks the path to the Smuggler exe, throws an error if the path isn’t valid
•	Checks the version of Smuggler, as this step relies on the between option which was introduced in version is 3.
•	Checks to see if the both file systems exists, throws an error based on which one doesn’t exist  
•	Moves data between two file systems (backing up one file systems into another one)
