### PR TITLE
Add multiple section support when encrypting config files

### DIFF
--- a/step-templates/configuration-encrypt-web-config-section.json
+++ b/step-templates/configuration-encrypt-web-config-section.json
@@ -1,14 +1,16 @@
 {
-  "Id": "ActionTemplates-40",
-  "Name": "Configuration - Encrypt Web.config Section",
-  "Description": "Encrypts a configuration section for the specified Web.config file in a given directory.",
+  "Id": "ActionTemplates-1",
+  "Name": "Configuration - Encrypt Section",
+  "Description": "Encrypts an configuration section for the specified file in a given directory.",
   "ActionType": "Octopus.Script",
-  "Version": 13,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$ErrorActionPreference = \"Stop\" \nfunction Get-Parameter($Name, $Default, [switch]$Required) {\n    $result = $null\n\n    if ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n    }\n\n    if ($result -eq $null) {\n        if ($Required) {\n            throw \"Missing parameter value $Name\"\n        } else {\n            $result = $Default\n        }\n    }\n\n    return $result\n}\n\nfunction HandleError($message) {\n\tif (!$whatIf) {\n\t\tthrow $message\n\t} else {\n\t\tWrite-Host $message -Foreground Yellow\n\t}\n}\n\n$websiteDirectory = Get-Parameter \"WebsiteDirectory\" -Required\n$sectionToEncrypt = Get-Parameter \"SectionToEncrypt\" -Required\n$provider = Get-Parameter \"Provider\" \"\"\n$configFile = Get-Parameter \"ConfigFile\" \"web.config\"\n$otherFiles = (Get-Parameter \"OtherFiles\" \"\") -split ',' | where {$_} | %{$_.Trim()}\n\nWrite-Host \"Configuration - Encrypt .config\"\nWrite-Host \"WebsiteDirectory: $websiteDirectory\"\nWrite-Host \"SectionToEncrypt: $sectionToEncrypt\"\nWrite-Host \"Provider: $provider\"\nWrite-Host \"ConfigFile: $configFile\"\n\n\nif (!(Test-Path $websiteDirectory)) {\n\tHandleError \"The directory $websiteDirectory must exist\"\n}\n\n$configFilePath = Join-Path $websiteDirectory $configFile\nWrite-Host \"configFilePath: $configFilePath\"\nif (!(Test-Path $configFilePath)) {\n\tHandleError \"Specified file $configFile or a Web.Config file must exist in the directory $websiteDirectory\"\n}\n\n$frameworkPath = [System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory();\n$regiis = \"$frameworkPath\\aspnet_regiis.exe\"\n\nif (!(Test-Path $regiis)) {\n\tHandleError \"The tool aspnet_regiis does not exist in the directory $frameworkPath\"\n}\n\n# Create a temp directory to work out of and copy our config file to web.config\n$tempPath = Join-Path $websiteDirectory $([guid]::NewGuid()).ToString()\nif (!$whatIf) {\n\tNew-Item $tempPath -ItemType \"directory\"\n} else {\n\tWrite-Host \"WhatIf: New-Item $tempPath -ItemType \"\"directory\"\"\" -Foreground Yellow\n}\n\n$tempFile = Join-Path $tempPath \"web.config\"\nif (!$whatIf) {\n\tCopy-Item $configFilePath $tempFile\n} else {\n\tWrite-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\n}\n\nForeach($fileName in $otherFiles){\n  if (!$whatIf) {\n\t Copy-Item (Join-Path $websiteDirectory $fileName) (Join-Path $tempPath $fileName)\n  } else {\n\t Write-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\n  }\n}\n\n# Determine arguments\nif ($provider) {\n\t$args = \"-pef\", $sectionToEncrypt, $tempPath, \"-prov\", $provider\n} else {\n\t$args = \"-pef\", $sectionToEncrypt, $tempPath\n}\n\n# Encrypt Web.Config file in directory\nif (!$whatIf) {\n\t& $regiis $args\n} else {\n\tWrite-Host \"WhatIf: $regiis $args\" -Foreground Yellow\n}\n\n# Copy the web.config back to original file and delete the temp dir\nif (!$whatIf) {\n\tCopy-Item $tempFile $configFilePath -Force\n\n  Foreach($fileName in $otherFiles){\n    if (!$whatIf) {\n  \t Copy-Item (Join-Path $tempPath $fileName) (Join-Path $websiteDirectory $fileName) -Force\n    } else {\n  \t Write-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\n    }\n  }\n\n\tRemove-Item $tempPath -Recurse\n} else {\n\tWrite-Host \"WhatIf: Copy-Item $tempFile $configFilePath -Force\" -Foreground Yellow\n\tWrite-Host \"WhatIf: Remove-Item $tempPath -Recurse\" -Foreground Yellow\n}\n",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "$ErrorActionPreference = \"Stop\" \r\nfunction Get-Parameter($Name, $Default, [switch]$Required) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction HandleError($message) {\r\n\tif (!$whatIf) {\r\n\t\tthrow $message\r\n\t} else {\r\n\t\tWrite-Host $message -Foreground Yellow\r\n\t}\r\n}\r\n\r\n$websiteDirectory = Get-Parameter \"WebsiteDirectory\" -Required\r\n$sectionsToEncrypt = (Get-Parameter \"SectionsToEncrypt\" -Required) -split ',' | where {$_} | %{$_.Trim()}\r\n$provider = Get-Parameter \"Provider\" \"\"\r\n$configFile = Get-Parameter \"ConfigFile\" \"web.config\"\r\n$otherFiles = (Get-Parameter \"OtherFiles\" \"\") -split ',' | where {$_} | %{$_.Trim()}\r\n\r\nWrite-Host \"Configuration - Encrypt .config\"\r\nWrite-Host \"WebsiteDirectory: $websiteDirectory\"\r\nWrite-Host \"SectionsToEncrypt: $sectionsToEncrypt\"\r\nWrite-Host \"Provider: $provider\"\r\nWrite-Host \"ConfigFile: $configFile\"\r\n\r\n\r\nif (!(Test-Path $websiteDirectory)) {\r\n\tHandleError \"The directory $websiteDirectory must exist\"\r\n}\r\n\r\n$configFilePath = Join-Path $websiteDirectory $configFile\r\nWrite-Host \"configFilePath: $configFilePath\"\r\nif (!(Test-Path $configFilePath)) {\r\n\tHandleError \"Specified file $configFile or a Web.Config file must exist in the directory $websiteDirectory\"\r\n}\r\n\r\n$frameworkPath = [System.Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory();\r\n$regiis = \"$frameworkPath\\aspnet_regiis.exe\"\r\n\r\nif (!(Test-Path $regiis)) {\r\n\tHandleError \"The tool aspnet_regiis does not exist in the directory $frameworkPath\"\r\n}\r\n\r\n# Create a temp directory to work out of and copy our config file to web.config\r\n$tempPath = Join-Path $websiteDirectory $([guid]::NewGuid()).ToString()\r\nif (!$whatIf) {\r\n\tNew-Item $tempPath -ItemType \"directory\"\r\n} else {\r\n\tWrite-Host \"WhatIf: New-Item $tempPath -ItemType \"\"directory\"\"\" -Foreground Yellow\r\n}\r\n\r\n$tempFile = Join-Path $tempPath \"web.config\"\r\nif (!$whatIf) {\r\n\tCopy-Item $configFilePath $tempFile\r\n} else {\r\n\tWrite-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\r\n}\r\n\r\nForeach($fileName in $otherFiles){\r\n  if (!$whatIf) {\r\n\t Copy-Item (Join-Path $websiteDirectory $fileName) (Join-Path $tempPath $fileName)\r\n  } else {\r\n\t Write-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\r\n  }\r\n}\r\n\r\nForeach($sectionToEncrypt in $sectionsToEncrypt){\r\n\t# Determine arguments\r\n\tif ($provider) {\r\n\t\t$args = \"-pef\", $sectionToEncrypt, $tempPath, \"-prov\", $provider\r\n\t} else {\r\n\t\t$args = \"-pef\", $sectionToEncrypt, $tempPath\r\n\t}\r\n\r\n\t# Encrypt Web.Config file in directory\r\n\tif (!$whatIf) {\r\n\t\t& $regiis $args\r\n\t} else {\r\n\t\tWrite-Host \"WhatIf: $regiis $args\" -Foreground Yellow\r\n\t}\r\n}\r\n\r\n# Copy the web.config back to original file and delete the temp dir\r\nif (!$whatIf) {\r\n\tCopy-Item $tempFile $configFilePath -Force\r\n\r\n  Foreach($fileName in $otherFiles){\r\n    if (!$whatIf) {\r\n  \t Copy-Item (Join-Path $tempPath $fileName) (Join-Path $websiteDirectory $fileName) -Force\r\n    } else {\r\n  \t Write-Host \"WhatIf: Copy-Item $configFilePath $tempFile\" -Foreground Yellow\r\n    }\r\n  }\r\n\r\n\tRemove-Item $tempPath -Recurse\r\n} else {\r\n\tWrite-Host \"WhatIf: Copy-Item $tempFile $configFilePath -Force\" -Foreground Yellow\r\n\tWrite-Host \"WhatIf: Remove-Item $tempPath -Recurse\" -Foreground Yellow\r\n}\r\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Package.NuGetFeedId": "feeds-builtin",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false"
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
       "Name": "WebsiteDirectory",
@@ -20,9 +22,9 @@
       }
     },
     {
-      "Name": "SectionToEncrypt",
+      "Name": "SectionsToEncrypt",
       "Label": "Section to encrypt",
-      "HelpText": "The name of the section in the web config to encrypt e.g. `appSettings`, `connectionStrings` etc.",
+      "HelpText": "The name of the section in the web config to encrypt e.g. `appSettings`, `connectionStrings` etc.\nFor multiple sections, separate with a comma (,)",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -57,8 +59,8 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2015-07-28T20:16:30.475Z",
-    "OctopusVersion": "3.0.5.2124",
+    "ExportedAt": "2016-04-04T02:24:12.170Z",
+    "OctopusVersion": "3.3.1",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Updated the Web.config encrypt step template to support multiple sections.

Added `-split ',' | where {$_} | %{$_.Trim()}` for the **SectionsToEncrypt** parameter.