### PR TITLE
ClickOnce related step templates

### DIFF
--- a/step-templates/clickonce-sign-file.json
+++ b/step-templates/clickonce-sign-file.json
@@ -1,0 +1,75 @@
+{
+  "Id": "ActionTemplates-103",
+  "Name": "ClickOnce - Sign file",
+  "Description": "Sign file with given code sign certificate using mage.exe.",
+  "ActionType": "Octopus.Script",
+  "Version": 2,
+  "Properties": {
+    "Octopus.Action.Package.NuGetFeedId": "feeds-builtin",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "$find = Get-ChildItem \"$PackagePath\\$SignFileFilter\"\n$PathToFile = $find.FullName\n\n$splittedParams = $AdvencedMageParameters.Split(\" \")\n& \"$MagePath\\mage.exe\" -Sign \"$PathToFile\" -CertFile $SignCert -Password $SignCertPass $splittedParams"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "SignFileFilter",
+      "Label": "Filter to find file to sign",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "SignCert",
+      "Label": "Path to the certification file",
+      "HelpText": "Path to the certification pfx file",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "SignCertPass",
+      "Label": "Password of the certification file",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AdvencedMageParameters",
+      "Label": "Addition parameters for mage.exe",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "PackagePath",
+      "Label": "Path to the root directory of ClickOnce package",
+      "HelpText": "Path to the root drectory of ClickOnce package. This is where you can find the setup.exe, and *.application files and the \"Application Files\" folder",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "MagePath",
+      "Label": "Path to mage.exe",
+      "HelpText": "Path to mage.exe which is used to update manifest and .application files and sign them.",
+      "DefaultValue": "c:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2016-04-05T14:42:48.861Z",
+    "OctopusVersion": "3.3.0-beta0001",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/clickonce-update-application-file.json
+++ b/step-templates/clickonce-update-application-file.json
@@ -1,0 +1,57 @@
+{
+  "Id": "ActionTemplates-104",
+  "Name": "ClickOnce - Update .application file",
+  "Description": "Update .application file after updating the manifest file.",
+  "ActionType": "Octopus.Script",
+  "Version": 3,
+  "Properties": {
+    "Octopus.Action.Package.NuGetFeedId": "feeds-builtin",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "$xml = [xml](Get-Content \"$PackagePath\\$AppName.application\")\n$manifestpath = $xml.assembly.dependency.dependentAssembly.codebase\n\n$splittedParams = $AdvencedMageParameters.Split(\" \")\ncd \"$PackagePath\"\n& \"$MagePath\\mage.exe\" -Update \".\\$AppName.application\" -AppManifest \".\\$manifestpath\" $splittedParams\n\n"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "PackagePath",
+      "Label": "Path to the root directory of ClickOnce package",
+      "HelpText": "Path to the root drectory of ClickOnce package. This is where you can find the setup.exe, and *.application files and the \"Application Files\" folder",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AppName",
+      "Label": "Name of the ClickOnce application",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AdvencedMageParameters",
+      "Label": "Addition parameters for mage.exe",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "MagePath",
+      "Label": "Path to mage.exe",
+      "HelpText": "Path to mage.exe which is used to update manifest and .application files and sign them.",
+      "DefaultValue": "c:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2016-04-05T14:43:35.076Z",
+    "OctopusVersion": "3.3.0-beta0001",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/clickonce-update-manifest-file.json
+++ b/step-templates/clickonce-update-manifest-file.json
@@ -1,0 +1,57 @@
+{
+  "Id": "ActionTemplates-102",
+  "Name": "ClickOnce - Update manifest file",
+  "Description": "Update manifest file after changing the configuration files of the ClickOnce application.",
+  "ActionType": "Octopus.Script",
+  "Version": 3,
+  "Properties": {
+    "Octopus.Action.Package.NuGetFeedId": "feeds-builtin",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "$xml = [xml](Get-Content \"$PackagePath\\$AppName.application\")\n$manifestpath = $xml.assembly.dependency.dependentAssembly.codebase\n$ApplicationWithVersion = $manifestpath.Split('\\\\')[1]\n\n$splittedParams = $AdvencedMageParameters.Split(\" \")\n& \"$MagePath\\mage.exe\" -Update \"$PackagePath\\$manifestpath\" -FromDirectory \"$PackagePath\\Application Files\\$ApplicationWithVersion\" $splittedParams"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "PackagePath",
+      "Label": "Path to the root directory of ClickOnce package",
+      "HelpText": "Path to the root drectory of ClickOnce package. This is where you can find the setup.exe, and *.application files and the \"Application Files\" folder",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AppName",
+      "Label": "Name of the ClickOnce application",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AdvencedMageParameters",
+      "Label": "Addition parameters for mage.exe",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "MagePath",
+      "Label": "Path to mage.exe",
+      "HelpText": "Path to mage.exe which is used to update manifest and .application files and sign them.",
+      "DefaultValue": "c:\\Program Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.6.1 Tools\\",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2016-04-05T14:46:10.321Z",
+    "OctopusVersion": "3.3.0-beta0001",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Contains three scripts which are useful if you want to manipulate clickonce manifest and application files during a deployment. There is an exsisting ClickOnceRe-Sign template but it has some hardcoded path and tightly couples all individual steps. I created separate steps for each action and add extra parameters to be more flexible.