### PR TITLE
Add support for other DacFX commands

### DIFF
--- a/step-templates/sql-deploy-dacpac.json
+++ b/step-templates/sql-deploy-dacpac.json
@@ -1,57 +1,148 @@
 {
   "Id": "ActionTemplates-12",
   "Name": "SQL - Deploy DACPAC",
-  "Description": "Deploys a DACPAC to a target database. Requires DACfx (from the Web Platform Installer) or Visual Studio and the SSDT extension to be installed.",
+  "Description": "Calls the DacFX library to perform SSDT commands such as:\n * Deploy\n * Script\n * DeployReport\n\nIf selected the deploy script and deploy report will be loaded back into Octopus Deploy as an artefact. This allows you to put in place  manual intervention step if required. It is also useful for auditing purposes.",
   "ActionType": "Octopus.Script",
-  "Version": 14,
+  "Version": 15,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "$regKeyFormat = 'HKLM:\\Software\\Wow6432Node\\Microsoft\\VisualStudio\\{0}.0'\n$ssdtSubfolder = 'Extensions\\Microsoft\\SQLDB\\DAC\\120'\n$dacfxPath = 'C:\\Program Files\\Microsoft SQL Server\\120\\DAC\\bin'\n$vsVersions = @( '14', '12' )\n\n$progressChangedEvent = \"ProgressChanged\"\n\nfunction Validate-Argument($name, $value) {\n    if (!$value) {\n        throw ('Missing required value for parameter ''{0}''.' -f $name)\n    }\n\n    return $value\n}\n\nfunction Load-DacAssembly {\n    Write-Verbose 'Testing if DACfx was installed...'\n    \n    if (Test-Path $dacfxPath) {\n        Add-Type -Path ($dacfxPath + '\\Microsoft.SqlServer.Dac.dll')\n    } else {\n        Write-Verbose 'Attempting to discover Visual Studio install folder...' \n        $regKey = $vsVersions | foreach { $regKeyFormat -f $_ } | where { Test-Path $_ } | select -First 1\n        \n        if (!$regKey) {\n            throw 'No usable Visual Studio installation found.'\n        }\n    \n        Write-Verbose 'Visual Studio found. Attempting to discover SSDT...'\n        $vsInstallDir = Get-ItemProperty -Path $regKey | select -ExpandProperty InstallDir\n        $ssdtPath = $vsInstallDir + $ssdtSubfolder\n    \n        if (!(Test-Path $ssdtPath)) {\n            throw 'SSDT not found. Please install the latest SSDT.'\n        }\n    \n        Write-Verbose 'Found SSDT, attempting to load DAC assembly...'\n        Add-Type -Path ($ssdtPath + '\\Microsoft.SqlServer.Dac.dll')\n    }\n    \n    Write-Verbose 'Loaded DAC assembly.'\n}\n\n#\n# Script\n#\n\n# Get arguments\n$dacpacPackageStepName = Validate-Argument 'DACPAC Package Step Name' $OctopusParameters['DacpacPackageStepName']\n$dacpacName = Validate-Argument 'DACPAC Name' $OctopusParameters['DacpacName']\n$targetConnectionString = Validate-Argument 'Target Connection String' $OctopusParameters['TargetConnectionString']\n$targetDatabaseName = Validate-Argument 'Target Database Name' $OctopusParameters['TargetDatabaseName']\n\n$profileName = $OctopusParameters['ProfileName']\n\n# Load the DAC assembly\nLoad-DacAssembly\n\n# Set .NET CurrentDirectory to package installation path\n$installDirPathKey = 'Octopus.Action[{0}].Output.Package.InstallationDirectoryPath' -f $dacpacPackageStepName\n$installDirPath = $OctopusParameters[$installDirPathKey]\n\n[System.Environment]::CurrentDirectory = $installDirPath\nWrite-Verbose ('Set Environment.CurrentDirectory to ''{0}''.' -f $installDirPath)\n\n# Load DacPackage\n$dacPackage = [Microsoft.SqlServer.Dac.DacPackage]::Load($dacpacName + '.dacpac')\n\n# Load DacProfile\nif ($profileName) {\n    $dacProfile = [Microsoft.SqlServer.Dac.DacProfile]::Load($profileName)\n    Write-Host ('Loaded publish profile ''{0}''.' -f $profileName)\n} else {\n    $dacProfile = New-Object Microsoft.SqlServer.Dac.DacProfile\n}\n\n# Setup DacServices\n$dacServices = New-Object Microsoft.SqlServer.Dac.DacServices -ArgumentList $targetConnectionString\nRegister-ObjectEvent $dacServices $progressChangedEvent -SourceIdentifier $progressChangedEvent -Action { Write-Verbose ('DacServices: {0}' -f $EventArgs.Message) } | Out-Null\n\n# Deploy package\ntry {\n    Write-Host 'Starting DACPAC deployment...'\n    $dacServices.Deploy($dacPackage, $targetDatabaseName, $true, $dacProfile.DeployOptions, $null)\n    Write-Host 'Deployment succeeded!'\n} catch [Microsoft.SqlServer.Dac.DacServicesException] {\n    Unregister-Event -SourceIdentifier $progressChangedEvent\n    throw ('Deployment failed: ''{0}'' Reason: ''{1}''' -f $_.Exception.Message, $_.Exception.InnerException.Message)\n}"
+    "Octopus.Action.Script.ScriptBody": "<#\r\n .SYNOPSIS\r\n Converts boolean values to boolean types\r\n\r\n .DESCRIPTION\r\n Converts boolean values to boolean types\r\n\r\n .PARAMETER Value\r\n The value to convert\r\n\r\n .EXAMPLE\r\n Format-OctopusArgument \"true\"\r\n#>\r\nFunction Format-OctopusArgument {\r\n\r\n\tParam(\r\n\t\t[string]$Value\r\n\t)\r\n\r\n\t$Value = $Value.Trim()\r\n\r\n\t# There must be a better way to do this\r\n\tSwitch -Wildcard ($Value){\r\n\r\n\t\t\"True\" { Return $True }\r\n\t\t\"False\" { Return $False }\r\n\t\t\"#{*}\" { Return $null }\r\n\t\tDefault { Return $Value }\r\n\t}\r\n}\r\n\r\n<#\r\n .SYNOPSIS\r\n Finds the DAC File that you specify\r\n\r\n .DESCRIPTION\r\n Looks through the supplied PathList array and searches for the file you specify.  It will return the first one that it finds.\r\n\r\n .PARAMETER FileName\r\n Name of the file you are looking for\r\n\r\n .PARAMETER PathList\r\n Array of Paths to search through.\r\n\r\n .EXAMPLE\r\n Find-DacFile -FileName \"Microsoft.SqlServer.TransactSql.ScriptDom.dll\" -PathList @(\"${env:ProgramFiles}\\Microsoft SQL Server\", \"${env:ProgramFiles(x86)}\\Microsoft SQL Server\")\r\n#>\r\nFunction Find-DacFile {\r\n\tParam(\r\n\t\t[Parameter(Mandatory=$true)]\r\n\t\t[string]$FileName,\r\n\t\t[Parameter(Mandatory=$true)]\r\n\t\t[string[]]$PathList\r\n\t)\r\n\r\n\t$File = $null\r\n\r\n\tForEach($Path in $PathList)\r\n\t{\r\n\t\tWrite-Debug (\"Searching: {0}\" -f $Path)\r\n\r\n\t\tIf (!($File))\r\n\t\t{\r\n\t\t\t$File = (\r\n\t\t\t\tGet-ChildItem $Path -ErrorAction SilentlyContinue -Filter $FileName -Recurse |\r\n\t\t\t\tSort-Object FullName -Descending |\r\n\t\t\t\tSelect -First 1\r\n\t\t\t\t)\r\n\r\n\t\t\tIf ($File)\r\n\t\t\t{\r\n\t\t\t\tWrite-Debug (\"Found: {0}\" -f $File.FullName)\r\n\t\t\t}\r\n\t\t}\r\n\t}\r\n\r\n\tReturn $File\r\n}\r\n\r\n<#\r\n .SYNOPSIS\r\n Adds the required types so that they can be used\r\n\r\n .DESCRIPTION\r\n Adds the DacFX types that are required to do database deploys, scripts and deployment reports from SSDT\r\n\r\n .EXAMPLE\r\n Load-DACAssemblies\r\n#>\r\nFunction Load-DACAssemblies {\r\n\r\n\tWrite-Verbose \"Loading the DacFX Assemblies\"\r\n\r\n\t$SearchPathList = @(\"${env:ProgramFiles}\\Microsoft SQL Server\", \"${env:ProgramFiles(x86)}\\Microsoft SQL Server\")\r\n\r\n\tWrite-Debug \"Searching for: Microsoft.SqlServer.TransactSql.ScriptDom.dll\"\r\n\t$ScriptDomDLL = (Find-DacFile -FileName \"Microsoft.SqlServer.TransactSql.ScriptDom.dll\" -PathList $SearchPathList)\r\n\r\n\tWrite-Debug \"Searching for: Microsoft.SqlServer.Dac.dll\"\r\n\t$DacDLL = (Find-DacFile -FileName \"Microsoft.SqlServer.Dac.dll\" -PathList $SearchPathList)\r\n\r\n\tIf (!($ScriptDomDLL))\r\n\t{\r\n\t\tThrow \"Could not find the file: Microsoft.SqlServer.TransactSql.ScriptDom.dll\"\r\n\t}\r\n\tIf (!($DacDLL))\r\n\t{\r\n\t\tThrow \"Could not find the file: Microsoft.SqlServer.Dac.dll\"\r\n\t}\r\n\r\n\tWrite-Debug (\"Adding the type: {0}\" -f $ScriptDomDLL.FullName)\r\n\tAdd-Type -Path $ScriptDomDLL.FullName\r\n\r\n\tWrite-Debug (\"Adding the type: {0}\" -f $DacDLL.FullName)\r\n\tAdd-Type -Path $DacDLL.FullName\r\n\r\n\tWrite-Host \"Loaded the DAC assemblies\"\r\n}\r\n\r\n\r\n<#\r\n .SYNOPSIS\r\n Generates a connection string\r\n\r\n .DESCRIPTION\r\n Derive a connection string from the supplied variables\r\n\r\n .PARAMETER ServerName\r\n Name of the server to connect to\r\n\r\n .PARAMETER UseIntegratedSecurity\r\n Boolean value to indicate if Integrated Security should be used or not\r\n\r\n .PARAMETER UserName\r\n User name to use if we are not using integrated security\r\n\r\n .PASSWORD Password\r\n Password to use if we are not using integrated security\r\n\r\n .EXAMPLE\r\n Get-ConnectionString -ServerName localhost -UseIntegratedSecurity -Database OctopusDeploy\r\n\r\n .EXAMPLE\r\n Get-ConnectionString -ServerName localhost -UserName sa -Password ProbablyNotSecure -Database OctopusDeploy\r\n#>\r\nFunction Get-ConnectionString {\r\n\tParam(\r\n\t\t[Parameter(Mandatory=$True)]\r\n\t\t[string]$ServerName,\r\n\t\t[bool]$UseIntegratedSecurity,\r\n\t\t[string]$UserName,\r\n\t\t[string]$Password,\r\n\t\t[string]$Database\r\n\t)\r\n\r\n\t$ApplicationName = \"OctopusDeploy\"\r\n\t$connectionString = (\"Application Name={0};Server={1}\" -f $ApplicationName, $ServerName)\r\n\r\n\tIf ($UseIntegratedSecurity)\r\n\t{\r\n\t\tWrite-Verbose \"Using integrated security\"\r\n\t\t$connectionString += \";Trusted_Connection=True\"\r\n\t}\r\n\tElse{\r\n\t\tWrite-Verbose \"Using standard security\"\r\n\t\t$connectionString += (\";Uid={0};Pwd={1}\" -f $UserName, $Password)\r\n\t}\r\n\r\n\tIf ($Database)\r\n\t{\r\n\t\t$connectionString += (\";Initial Catalog={0}\" -f $Database)\r\n\t}\r\n\r\n\tReturn $connectionString\r\n}\r\n\r\n\r\n<#\r\n .SYNOPSIS\r\n Invokes the DacPac utility\r\n\r\n .DESCRIPTION\r\n Used to invoke the actions against the DacFx library.  This utility can generate deployment reports, deployment scripts and execute a deploy\r\n\r\n .PARAMETER Report\r\n Boolean flag as to whether a deploy report should be generated\r\n\r\n .PARAMETER Script\r\n Boolean flag as to whether a deployment script should be generated\r\n\r\n .PARAMETER Deploy\r\n Boolean flag as to whether a deployment should occur\r\n\r\n .PARAMETER DacPacFilename\r\n Full path as to where we can find the DacPac to use\r\n\r\n .PARAMETER TargetServer\r\n Name of the server to run the DacPac against\r\n\r\n .PARAMETER TargetDatabase\r\n Name of the database to run the DacPac against\r\n\r\n .PARAMETER UseIntegratedSecurity\r\n Flag as to whether we should use integrate security or not\r\n\r\n .PARAMETER UserName\r\n If we are not using integrated security, we should use this user name to connect to the server\r\n\r\n .PARAMETER Password\r\n If we are not using integrated security, we should use this password to connect to the server\r\n\r\n .PARAMETER PublishProfile\r\n Full path to the publish profile we should use\r\n\r\n .EXAMPLE\r\n Invoke-DacPacUtility\r\n\r\n#>\r\nFunction Invoke-DacPacUtility {\r\n\r\n\tParam(\r\n\t\t[bool]$Report,\r\n\t\t[bool]$Script,\r\n\t\t[bool]$Deploy,\r\n\t\t[bool]$ExtractTargetDatabaseDacpac,\r\n\t\t[string]$DacPacFilename,\r\n\t\t[string]$TargetServer,\r\n\t\t[string]$TargetDatabase,\r\n\t\t[bool]$UseIntegratedSecurity,\r\n\t\t[string]$UserName,\r\n\t\t[string]$Password,\r\n\t\t[string]$PublishProfile,\r\n\t\t[string]$AdditionalDeploymentContributors,\r\n\t\t[string]$AdditionalDeploymentContributorArguments\r\n\t)\r\n\r\n\t# We output the parameters (excluding password) so that we can see what was supplied for debuging if required.  Useful for variable scoping problems\r\n\tWrite-Debug (\"Invoke-DacPacUtility called.  Parameter values supplied:\")\r\n\tWrite-Debug (\"    Dacpac Filename:                  {0}\" -f $DacPacFilename)\r\n\tWrite-Debug (\"    Dacpac Profile:                   {0}\" -f $PublishProfile)\r\n\tWrite-Debug (\"    Target server:                    {0}\" -f $TargetServer)\r\n\tWrite-Debug (\"    Target database:                  {0}\" -f $TargetDatabase)\r\n\tWrite-Debug (\"    Using integrated security:        {0}\" -f $UseIntegratedSecurity)\r\n\tWrite-Debug (\"    Username:                         {0}\" -f $UserName)\r\n\tWrite-Debug (\"    Report:                           {0}\" -f $Report)\r\n\tWrite-Debug (\"    Script:                           {0}\" -f $Script)\r\n\tWrite-Debug (\"    Deploy:                           {0}\" -f $Deploy)\r\n\tWrite-Debug (\"    Extract target database dacpac    {0}\" -f $ExtractTargetDatabaseDacpac)\r\n\tWrite-Debug (\"    Deployment contributors:          {0}\" -f $AdditionalDeploymentContributors)\r\n\tWrite-Debug (\"    Deployment contributor arguments: {0}\" -f $AdditionalDeploymentContributorArguments)\r\n\r\n\t$DateTime = ((Get-Date).ToUniversalTime().ToString(\"yyyyMMddHHmmss\"))\r\n\r\n\tLoad-DACAssemblies\r\n\r\n\tTry {\r\n\t\t$dacPac = [Microsoft.SqlServer.Dac.DacPackage]::Load($DacPacFilename)\r\n\t\t$connectionString = (Get-ConnectionString -ServerName $TargetServer -Database $TargetDatabase -UseIntegratedSecurity $UseIntegratedSecurity -UserName $UserName -Password $Password)\r\n\r\n\t\t# Load the publish profile if supplied\r\n\t\tIf ($PublishProfile)\r\n\t\t{\r\n\t\t\tWrite-Verbose (\"Attempting to load the publish profile: {0}\" -f $PublishProfile)\r\n\r\n\t\t\t#Load the publish profile\r\n\t\t\t$dacProfile = [Microsoft.SqlServer.Dac.DacProfile]::Load($PublishProfile)\r\n\t\t\tWrite-Verbose (\"Loaded publish profile: {0}\" -f $PublishProfile)\r\n\r\n\t\t\t#Load the artifact back into Octopus Deploy\r\n\t\t\t$profileArtifact = (\"{0}.{1}.{2}.{3}\" -f $TargetServer, $TargetDatabase, $DateTime, ($PublishProfile.Remove(0, $PublishProfile.LastIndexOf(\"\\\") + 1)))\r\n\t\t\tNew-OctopusArtifact -Path $PublishProfile -Name $profileArtifact\r\n\t\t\tWrite-Verbose (\"Loaded publish profile as an Octopus Deploy artifact\")\r\n\t\t}\r\n\t\tElse {\r\n\t\t\t$dacProfile = New-Object Microsoft.SqlServer.Dac.DacProfile\r\n\t\t\tWrite-Verbose (\"Created blank publish profile\")\r\n\t\t}\r\n\r\n\t\t# Specify additional deployment contributors:\r\n\t\t$dacProfile.DeployOptions.AdditionalDeploymentContributors = $AdditionalDeploymentContributors\r\n\t\t$dacProfile.DeployOptions.AdditionalDeploymentContributorArguments = $AdditionalDeploymentContributorArguments\r\n\r\n\t\t$dacServices = New-Object Microsoft.SqlServer.Dac.DacServices -ArgumentList $connectionString\r\n\r\n\t\t# Register the object events and output them to the verbose stream\r\n\t\tRegister-ObjectEvent -InputObject $dacServices -EventName \"ProgressChanged\" -SourceIdentifier \"ProgressChanged\" -Action { Write-Verbose (\"DacServices: {0}\" -f $EventArgs.Message) } | Out-Null\r\n\t\tRegister-ObjectEvent -InputObject $dacServices -EventName \"Message\" -SourceIdentifier \"Message\" -Action { Write-Host ($EventArgs.Message.Message) } | Out-Null\r\n\r\n\t\r\n\t\tIf ($Report -or $Script -or $ExtractTargetDatabaseDacpac)\r\n\t\t{\r\n\t\t\t# Extract a DACPAC so we can do reports and scripting faster (if both are done)\r\n\t\t\t# dbDacPac\r\n\t\t\t$dbDacPacFilename = (\"{0}.{1}.{2}.dacpac\" -f $TargetServer, $TargetDatabase, $DateTime)\r\n\t\t\t$dacVersion = New-Object System.Version(1, 0, 0, 0)\r\n\t\t\tWrite-Debug \"Extracting target server dacpac\"\r\n\t\t\t$dacServices.Extract($dbDacPacFilename, $TargetDatabase, $TargetDatabase, $dacVersion)\r\n\r\n\t\t\tWrite-Debug (\"Loading the target server dacpac for report and scripting. Filename: {0}\" -f $dbDacPacFilename)\r\n\t\t\t$dbDacPac = [Microsoft.SqlServer.Dac.DacPackage]::Load($dbDacPacFilename)\r\n\r\n\t\t\tIf ($ExtractTargetDatabaseDacpac)\r\n\t\t\t{\r\n\t\t\t\tNew-OctopusArtifact -Path $dbDacPacFilename -Name $dbDacPacFilename\r\n\t\t\t}\r\n\r\n\t\t\t# Generate a Deploy Report if one is asked for\r\n\t\t\tIf ($Report)\r\n\t\t\t{\r\n\t\t\t\tWrite-Host (\"Generating deploy report against server: {0}, database: {1}\" -f $TargetServer, $TargetDatabase)\r\n\t\t\t\t$deployReport = [Microsoft.SqlServer.Dac.DacServices]::GenerateDeployReport($dacPac, $dbDacPac, $TargetDatabase, $dacProfile.DeployOptions)\r\n\t\t\t\t$reportArtifact = (\"{0}.{1}.{2}.{3}\" -f $TargetServer, $TargetDatabase, $DateTime, \"DeployReport.xml\")\r\n\t\t\r\n\t\t\t\tSet-Content $reportArtifact $deployReport\r\n\r\n\t\t\t\tWrite-Host (\"Loading the deploy report to OctopusDeploy: {0}\" -f $reportArtifact)\r\n\t\t\t\tNew-OctopusArtifact -Path $reportArtifact -Name $reportArtifact\r\n\t\t\t}\r\n\r\n\t\t\t# Generate a Deploy Script if one is asked for\r\n\t\t\tIf ($Script)\r\n\t\t\t{\r\n\t\t\t\tWrite-Host (\"Generating deploy script against server: {0}, database: {1}\" -f $TargetServer, $TargetDatabase)\r\n\t\t\t\t$deployScript = [Microsoft.SqlServer.Dac.DacServices]::GenerateDeployScript($dacPac, $dbDacPac, $TargetDatabase, $dacProfile.DeployOptions)\r\n\t\t\t\t$scriptArtifact = (\"{0}.{1}.{2}.{3}\" -f $TargetServer, $TargetDatabase, $DateTime, \"DeployScript.sql\")\r\n\t\t\r\n\t\t\t\tSet-Content $scriptArtifact $deployScript\r\n\t\t\r\n\t\t\t\tWrite-Host (\"Loading the deploy script to OctopusDeploy: {0}\" -f $scriptArtifact)\r\n\t\t\t\tNew-OctopusArtifact -Path $scriptArtifact -Name $scriptArtifact\r\n\t\t\t}\r\n\t\t}\r\n\r\n\t\t\r\n\t\t# Deploy the dacpac if asked for\r\n\t\tIf ($Deploy)\r\n\t\t{\r\n\t\t\tWrite-Host (\"Starting deployment of dacpac against server: {0}, database: {1}\" -f $TargetServer, $TargetDatabase)\r\n\t\t\t$dacServices.Deploy($dacPac, $TargetDatabase, $true, $dacProfile.DeployOptions, $null)\r\n\t\t\r\n\t\t\tWrite-Host (\"Dacpac deployment complete\")\r\n\t\t}\r\n\t\t\r\n\t\tUnregister-Event -SourceIdentifier \"ProgressChanged\"\r\n\t\tUnregister-Event -SourceIdentifier \"Message\"\r\n\t}\r\n\tCatch {\r\n\t\tThrow (\"Deployment failed: {0} `r`nReason: {1}\" -f $_.Exception.Message, $_.Exception.InnerException.Message)\r\n\t}\r\n}\r\n\r\n\r\n# Get the supplied parameters\r\n$DACPACPackageStep = $OctopusParameters[\"DACPACPackageStep\"]\r\n$DACPACPackageName = $OctopusParameters[\"DACPACPackageName\"]\r\n$PublishProfile = $OctopusParameters[\"DACPACPublishProfile\"]\r\n$Report = Format-OctopusArgument -Value $OctopusParameters[\"Report\"]\r\n$Script = Format-OctopusArgument -Value $OctopusParameters[\"Script\"]\r\n$Deploy = Format-OctopusArgument -Value $OctopusParameters[\"Deploy\"]\r\n$ExtractTargetDatabaseDacpac = Format-OctopusArgument -Value $OctopusParameters[\"ExtractTargetDatabaseDacPac\"]\r\n$TargetServer = $OctopusParameters[\"TargetServer\"]\r\n$TargetDatabase = $OctopusParameters[\"TargetDatabase\"]\r\n$UseIntegratedSecurity = Format-OctopusArgument -Value $OctopusParameters[\"UseIntegratedSecurity\"]\r\n$Username = $OctopusParameters[\"SQLUsername\"]\r\n$Password = $OctopusParameters[\"SQLPassword\"]\r\n$AdditionalDeploymentContributors = $OctopusParameters[\"AdditionalContributors\"]\r\n$AdditionalDeploymentContributorArguments = $OctopusParameters[\"AdditionalContributorArguments\"]\r\n\r\n$InstallPathKey = (\"Octopus.Action[{0}].Output.Package.InstallationDirectoryPath\" -f $DACPACPackageStep)\r\n$InstallPath = $OctopusParameters[$InstallPathKey]\r\n\r\n# Expand the publish dacpac filename\r\n$DACPACPackageName = ($InstallPath + \"\\\" + $DACPACPackageName)\r\n\r\n# Expand the publish profile filename\r\n$PublishProfile = ($InstallPath + \"\\\" + $PublishProfile)\r\n\r\n# Invoke the DacPac utility\r\nInvoke-DacPacUtility -Report $Report -Script $Script -Deploy $Deploy -ExtractTargetDatabaseDacpac $ExtractTargetDatabaseDacpac -DacPacFilename $DACPACPackageName -TargetServer $TargetServer -TargetDatabase $TargetDatabase -UseIntegratedSecurity $UseIntegratedSecurity -Username $Username -Password $Password -PublishProfile $PublishProfile -AdditionalDeploymentContributors $AdditionalDeploymentContributors -AdditionalDeploymentContributorArguments $AdditionalDeploymentContributorArguments",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
-      "Name": "DacpacPackageStepName",
+      "Name": "DACPACPackageStep",
       "Label": "DACPAC Package Step Name",
-      "HelpText": "The step in which the DACPAC package was installed.",
+      "HelpText": "The step that downloaded the DACPAC to the tentacle",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "StepName"
       }
     },
     {
-      "Name": "DacpacName",
-      "Label": "DACPAC Name",
-      "HelpText": "Name of the .dacpac file, without the .dacpac extension.",
-      "DefaultValue": null,
-      "DisplaySettings": {}
+      "Name": "DACPACPackageName",
+      "Label": "DACPAC Package Name",
+      "HelpText": "The name of the .dacpac file that contains the SSDT model.  Include the .dacpac extensions.",
+      "DefaultValue": "#{PackageName}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
     {
-      "Name": "TargetConnectionString",
-      "Label": "Target Connection String",
-      "HelpText": "Connection string of the target database server.",
-      "DefaultValue": null,
-      "DisplaySettings": {}
+      "Name": "DACPACPublishProfile",
+      "Label": "Publish profile name",
+      "HelpText": "Name of the publish profile to use",
+      "DefaultValue": "#{PublishProfile}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
     {
-      "Name": "TargetDatabaseName",
-      "Label": "Target Database Name",
-      "HelpText": "Name of the target database the DACPAC should be deployed to.",
-      "DefaultValue": null,
-      "DisplaySettings": {}
+      "Name": "Report",
+      "Label": "Report",
+      "HelpText": "Whether a deploy script should be generated and loaded into OctopusDeploy as an artifact",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
     },
     {
-      "Name": "ProfileName",
-      "Label": "Profile Name",
-      "HelpText": "Optional: name of the publish profile XML file.",
-      "DefaultValue": null,
-      "DisplaySettings": {}
+      "Name": "Script",
+      "Label": "Script",
+      "HelpText": "Whether a deploy script should be generated and loaded into OctopusDeploy as an artifact",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "Deploy",
+      "Label": "Deploy",
+      "HelpText": "Whether a deployment of the dacpac should occur",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "ExtractTargetDatabaseDacPac",
+      "Label": "Extract target database to dacpac",
+      "HelpText": "Extracts the target database to a dacpac and loads it back into Octopus Deploy",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "TargetServer",
+      "Label": "Target Servername",
+      "HelpText": "Name of the server to target this deployment against",
+      "DefaultValue": "#{ServerName}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "TargetDatabase",
+      "Label": "Target Database",
+      "HelpText": "Name of the database to target this deployment against",
+      "DefaultValue": "#{DatabaseName}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "UseIntegratedSecurity",
+      "Label": "Use Integrated Security",
+      "HelpText": "Whether or not to use Integrated Security",
+      "DefaultValue": "#{IntegratedSecurity}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Name": "SQLUsername",
+      "Label": "Username",
+      "HelpText": "User name to use to connect to the server if we are not using Integrated Security",
+      "DefaultValue": "#{Username}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "SQLPassword",
+      "Label": "Password",
+      "HelpText": "Password to use to connect to the server if we are not using Integrated Security",
+      "DefaultValue": "#{Password}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Name": "AdditionalContributors",
+      "Label": "Additional deployment contributors",
+      "HelpText": "Specify any additional deployment contributors here.  Use the same format as you would for SqlPackage.exe /p:AdditionalDeploymentContributors=[what you would put here]",
+      "DefaultValue": "#{AdditionalDeploymentContributors}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "AdditionalContributorArguments",
+      "Label": "Additional deployment contributor arguments",
+      "HelpText": "Specify any additional deployment contributors here.  Use the same format as you would for SqlPackage.exe /p:AdditionalDeploymentContributorArguments=[what you would put here]",
+      "DefaultValue": "#{AdditionalDeploymentContributorArguments}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
-  "LastModifiedBy": "mlowijs",
   "$Meta": {
-    "ExportedAt": "2015-09-06T09:10:53.821Z",
-    "OctopusVersion": "3.0.21.0",
+    "ExportedAt": "2016-04-27T12:17:40.414Z",
+    "OctopusVersion": "3.3.10",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Can now generate deployment reports and deployment scripts which are loaded back into Octopus Deploy as artefacts.  This gives the option of creating a multi step process with manual intervention in the middle.

Dropped support of VS version of SSDT.  The script now searches %Program Files% looking for the most recent version of DacFX deployed on the server.

This is quite a substantial set of changes from the previous version and may warrant its own template within the library.  If that is preferred I will create a separate PR for that - just let me know.