### PR TITLE
Allow passing property names with any character case and also handle different types of web site properties in a better way

### DIFF
--- a/step-templates/iis-website-update-property.json
+++ b/step-templates/iis-website-update-property.json
@@ -41,9 +41,9 @@
       }
     }
   ],
-  "$Meta": {
-    "LastModifiedOn": "2016-05-30T11:42:50.429Z",
-    "LastModifiedBy": "ylashin78",
+  "LastModifiedOn": "2016-05-30T11:42:50.429Z",
+  "LastModifiedBy": "ylashin",
+  "$Meta": {    
     "ExportedAt": "2016-05-30T11:42:50.429Z",
     "OctopusVersion": "3.3.15",
     "Type": "ActionTemplate"

--- a/step-templates/iis-website-update-property.json
+++ b/step-templates/iis-website-update-property.json
@@ -3,11 +3,15 @@
   "Name": "IIS WebSite - Update Property",
   "Description": "Updates property for specified WebSite",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 5,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [string]$propertyName,\r\n    [object]$propertyValue,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName,\r\n        [string]$propertyName,\r\n        [object]$propertyValue\r\n    ) \r\n\r\n    Write-Host \"Setting $webSiteName property $propertyName to $propertyValue\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName | Select-Object -ExpandProperty \"Value\"\r\n         $oldValueString = \"\"\r\n\r\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\r\n         {\r\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\");\r\n         }\r\n         else \r\n         {\r\n             $oldValueString = $oldValue\r\n         }\r\n\r\n         Write-Host \"Old value $oldValueString\"\r\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName -Value $propertyValue\r\n         Write-Host \"New value $propertyValue\"\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem setting property\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\r\n"
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\nparam(\n    [string]$webSiteName,\n    [string]$propertyName,\n    [object]$propertyValue,\n    [switch]$whatIf\n) \n\n$ErrorActionPreference = \"Stop\" \n\nfunction Get-Param($Name, [switch]$Required, $Default) {\n    $result = $null\n\n    if ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n    }\n\n    if ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue   \n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    if ($result -eq $null -or $result -eq \"\") {\n        if ($Required) {\n            throw \"Missing parameter value $Name\"\n        } else {\n            $result = $Default\n        }\n    }\n\n    return $result\n}\n\n& {\n    param(\n        [string]$webSiteName,\n        [string]$propertyName,\n        [object]$propertyValue\n    ) \n\n    Write-Host \"Setting $webSiteName property $propertyName to $propertyValue\"\n\n    try {\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\n         \n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName\n         $oldValueString = \"\"\n\n         \n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\n         {\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\")\n         }\n         elseif ($oldValue.GetType() -eq [System.String])\n         {\n             $oldValueString = $oldValue\n         }\n         elseif ($oldValue.GetType() -eq [System.Management.Automation.PSCustomObject])\n         {\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty $propertyName)\n         }\n\n         Write-Host \"Old value $oldValueString\"\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\" -Name $propertyName -Value $propertyValue\n         Write-Host \"New value $propertyValue\"\n         Write-Host \"Done\"\n    } catch {\n        Write-Host $_.Exception|format-list -force\n        Write-Host \"There was a problem setting property\"    \n    }\n\n } `\n (Get-Param 'webSiteName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
       "Name": "webSiteName",
@@ -37,11 +41,11 @@
       }
     }
   ],
-  "LastModifiedOn": "2015-10-23T01:00:50.788+00:00",
-  "LastModifiedBy": "jmalczak",
   "$Meta": {
-    "ExportedAt": "2015-10-23T02:15:40.676Z",
-    "OctopusVersion": "2.6.5.1010",
+    "LastModifiedOn": "2016-05-30T11:42:50.429Z",
+    "LastModifiedBy": "ylashin78",
+    "ExportedAt": "2016-05-30T11:42:50.429Z",
+    "OctopusVersion": "3.3.15",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Previous version was failing with properties like applicationPool with below error :
System.Management.Automation.PSArgumentException: Property "Value" cannot be found.

The following shows different combinations handled by this change :

(Get-ItemProperty "IIS:\Sites\Default Web Site" -Name "ApplicationPool").GetType().Name
PSCustomObject

(Get-ItemProperty "IIS:\Sites\Default Web Site" -Name "applicationPool").GetType().Name
String

(Get-ItemProperty "IIS:\Sites\Default Web Site" -Name "logFile.directory").GetType().Name
ConfigurationAttribute


Example test cases with properties name/value pairs:

- applicationPool : pool1
- logFile.directory : C:\Temp
- traceFailedRequestsLoggin.enabled : True