### PR TITLE
Adding step template to replace Sitecore configuration settings

### DIFF
--- a/step-templates/sitecore-settings-variable-replacement.json
+++ b/step-templates/sitecore-settings-variable-replacement.json
@@ -1,0 +1,33 @@
+{
+  "Id": "sitecore-settings-variable-replacement",
+  "Name": "Sitecore - Settings & Variable Replacement",
+  "Description": "The default [Configuration Variables](http://docs.octopusdeploy.com/display/OD/Configuration+files#Configurationfiles-ConfigurationVariables) functionality replaces **appSettings** and **connectionStrings** entries. This step template extends this functionality to the Sitecore configuration **settings** and **sc.variable** nodes within the Sitecore.config or Web.config file that you specify. Variables that are defined for the Octopus project will automatically replace those defined in the target Sitecore configuration file.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "$configPath = $OctopusParameters[\"Sitecore.SettingsFile\"]\r\n\r\nif ([string]::IsNullOrEmpty($configPath)) {\r\n    throw [System.ArgumentNullException] \"Sitecore.SettingsFile\"\r\n}\r\n\r\nif (-not (Test-Path $configPath)) {\r\n    throw [System.IO.FileNotFoundException] \"$configPath was not found. Please double check your Sitcore.SettingsFile parameter.\"\r\n}\r\n\r\n$configXml = [xml](Get-Content $configPath)\r\n\r\nforeach ($key in $OctopusParameters.Keys) {\r\n\r\n    $sitecoreNode = $configXml.sitecore\r\n\r\n    # Look for sitecore node for versions prior to 8.1\r\n    if ($sitecoreNode -eq $null) {\r\n        $sitecoreNode = $configXml.configuration.sitecore\r\n    }\r\n\r\n    # Ensure that we have a sitecore node to work from\r\n    if ($sitecoreNode -eq $null -or $sitecoreNode.settings -eq $null) {\r\n        throw [System.Xml.XmlException] \"The sitecore settings node was not found in $configPath\"\r\n    }\r\n\r\n    # Replace Sitecore settings\r\n    $setting = $sitecoreNode.settings.setting | where { $_.name -ceq $key }\r\n    if ($setting -ne $null) {\r\n        Write-Host $setting.name \"setting will be updated from\" $setting.value \"to\" $OctopusParameters[$key]\r\n        $setting.value = $OctopusParameters[$key]\r\n    }\r\n\r\n    # Replace Sitecore variables\r\n    $variable = $sitecoreNode.'sc.variable' | where { $_.name -ceq $key }\r\n    if ($variable -ne $null) {\r\n        Write-Host $variable.name \"Sitecore variable will be updated from\" $settingsNode.value \"to\" $OctopusParameters[$key]\r\n        $variable.value = $OctopusParameters[$key]\r\n    }\r\n\r\n}\r\n\r\n$configXml.Save($configPath)",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
+  },
+  "Parameters": [
+    {
+      "Name": "Sitecore.SettingsFile",
+      "Label": "Sitecore.SettingsFile",
+      "HelpText": "Enter the full path to your Sitecore configuration file that contains the **sitecore** node. For versions of Sitecore prior to 8.1, this should point to your primary Web.config at the root of your website, and for versions 8.1+, to the Sitecore.config file within your App_Config folder. Alternatively, this value can be left empty and defined within your Octopus project's variable collection using the variable name **Sitecore.SettingsFile**.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2016-06-07T08:33:13.982Z",
+  "LastModifiedBy": "dthunziker",
+  "$Meta": {
+    "ExportedAt": "2016-06-07T08:33:13.982Z",
+    "OctopusVersion": "3.3.10",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/sitecore-settings-variable-replacement.json
+++ b/step-templates/sitecore-settings-variable-replacement.json
@@ -7,7 +7,7 @@
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "$configPath = $OctopusParameters[\"Sitecore.SettingsFile\"]\r\n\r\nif ([string]::IsNullOrEmpty($configPath)) {\r\n    throw [System.ArgumentNullException] \"Sitecore.SettingsFile\"\r\n}\r\n\r\nif (-not (Test-Path $configPath)) {\r\n    throw [System.IO.FileNotFoundException] \"$configPath was not found. Please double check your Sitcore.SettingsFile parameter.\"\r\n}\r\n\r\n$configXml = [xml](Get-Content $configPath)\r\n\r\nforeach ($key in $OctopusParameters.Keys) {\r\n\r\n    $sitecoreNode = $configXml.sitecore\r\n\r\n    # Look for sitecore node for versions prior to 8.1\r\n    if ($sitecoreNode -eq $null) {\r\n        $sitecoreNode = $configXml.configuration.sitecore\r\n    }\r\n\r\n    # Ensure that we have a sitecore node to work from\r\n    if ($sitecoreNode -eq $null -or $sitecoreNode.settings -eq $null) {\r\n        throw [System.Xml.XmlException] \"The sitecore settings node was not found in $configPath\"\r\n    }\r\n\r\n    # Replace Sitecore settings\r\n    $setting = $sitecoreNode.settings.setting | where { $_.name -ceq $key }\r\n    if ($setting -ne $null) {\r\n        Write-Host $setting.name \"setting will be updated from\" $setting.value \"to\" $OctopusParameters[$key]\r\n        $setting.value = $OctopusParameters[$key]\r\n    }\r\n\r\n    # Replace Sitecore variables\r\n    $variable = $sitecoreNode.'sc.variable' | where { $_.name -ceq $key }\r\n    if ($variable -ne $null) {\r\n        Write-Host $variable.name \"Sitecore variable will be updated from\" $settingsNode.value \"to\" $OctopusParameters[$key]\r\n        $variable.value = $OctopusParameters[$key]\r\n    }\r\n\r\n}\r\n\r\n$configXml.Save($configPath)",
+    "Octopus.Action.Script.ScriptBody": "$configPath = $OctopusParameters[\"Sitecore.SettingsFile\"]\r\n\r\nif ([string]::IsNullOrEmpty($configPath)) {\r\n    throw [System.ArgumentNullException] \"Sitecore.SettingsFile\"\r\n}\r\n\r\nif (-not (Test-Path $configPath)) {\r\n    throw [System.IO.FileNotFoundException] \"$configPath was not found. Please double check your Sitcore.SettingsFile parameter.\"\r\n}\r\n\r\n$configXml = [xml](Get-Content $configPath)\r\n$sitecoreNode = $configXml.sitecore\r\n\r\n# Look for sitecore node for versions prior to 8.1\r\nif ($sitecoreNode -eq $null) {\r\n    $sitecoreNode = $configXml.configuration.sitecore\r\n}\r\n\r\n# Ensure that we have a sitecore node to work from\r\nif ($sitecoreNode -eq $null -or $sitecoreNode.settings -eq $null) {\r\n    throw [System.Xml.XmlException] \"The sitecore settings node was not found in $configPath\"\r\n}\r\n\r\nforeach ($key in $OctopusParameters.Keys) {\r\n\r\n    # Replace Sitecore settings\r\n    $setting = $sitecoreNode.settings.setting | where { $_.name -ceq $key }\r\n    if ($setting -ne $null) {\r\n        Write-Host $setting.name \"setting will be updated from\" $setting.value \"to\" $OctopusParameters[$key]\r\n        $setting.value = $OctopusParameters[$key]\r\n    }\r\n\r\n    # Replace Sitecore variables\r\n    $variable = $sitecoreNode.'sc.variable' | where { $_.name -ceq $key }\r\n    if ($variable -ne $null) {\r\n        Write-Host $variable.name \"Sitecore variable will be updated from\" $settingsNode.value \"to\" $OctopusParameters[$key]\r\n        $variable.value = $OctopusParameters[$key]\r\n    }\r\n\r\n}\r\n\r\n$configXml.Save($configPath)",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.NuGetFeedId": null,
     "Octopus.Action.Package.NuGetPackageId": null
@@ -23,10 +23,10 @@
       }
     }
   ],
-  "LastModifiedOn": "2016-06-07T08:33:13.982Z",
+  "LastModifiedOn": "2016-06-08T18:00:16.379Z",
   "LastModifiedBy": "dthunziker",
   "$Meta": {
-    "ExportedAt": "2016-06-07T08:33:13.982Z",
+    "ExportedAt": "2016-06-08T18:00:16.379Z",
     "OctopusVersion": "3.3.10",
     "Type": "ActionTemplate"
   }

--- a/step-templates/sitecore-settings-variable-replacement.json
+++ b/step-templates/sitecore-settings-variable-replacement.json
@@ -1,32 +1,32 @@
 {
   "Id": "sitecore-settings-variable-replacement",
   "Name": "Sitecore - Settings & Variable Replacement",
-  "Description": "The default [Configuration Variables](http://docs.octopusdeploy.com/display/OD/Configuration+files#Configurationfiles-ConfigurationVariables) functionality replaces **appSettings** and **connectionStrings** entries. This step template extends this functionality to the Sitecore configuration **settings** and **sc.variable** nodes within the Sitecore.config or Web.config file that you specify. Variables that are defined for the Octopus project will automatically replace those defined in the target Sitecore configuration file.",
+  "Description": "The default [Configuration Variables](http://docs.octopusdeploy.com/display/OD/Configuration+files#Configurationfiles-ConfigurationVariables) functionality replaces **appSettings** and **connectionStrings** entries. This step template extends this functionality to the Sitecore configuration **settings** and **sc.variable** nodes within the configuration file(s) that you specify. Variables that are defined for the Octopus project will automatically replace those defined in the target Sitecore configuration file(s).",
   "ActionType": "Octopus.Script",
   "Version": 1,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "$configPath = $OctopusParameters[\"Sitecore.SettingsFile\"]\r\n\r\nif ([string]::IsNullOrEmpty($configPath)) {\r\n    throw [System.ArgumentNullException] \"Sitecore.SettingsFile\"\r\n}\r\n\r\nif (-not (Test-Path $configPath)) {\r\n    throw [System.IO.FileNotFoundException] \"$configPath was not found. Please double check your Sitcore.SettingsFile parameter.\"\r\n}\r\n\r\n$configXml = [xml](Get-Content $configPath)\r\n$sitecoreNode = $configXml.sitecore\r\n\r\n# Look for sitecore node for versions prior to 8.1\r\nif ($sitecoreNode -eq $null) {\r\n    $sitecoreNode = $configXml.configuration.sitecore\r\n}\r\n\r\n# Ensure that we have a sitecore node to work from\r\nif ($sitecoreNode -eq $null -or $sitecoreNode.settings -eq $null) {\r\n    throw [System.Xml.XmlException] \"The sitecore settings node was not found in $configPath\"\r\n}\r\n\r\nforeach ($key in $OctopusParameters.Keys) {\r\n\r\n    # Replace Sitecore settings\r\n    $setting = $sitecoreNode.settings.setting | where { $_.name -ceq $key }\r\n    if ($setting -ne $null) {\r\n        Write-Host $setting.name \"setting will be updated from\" $setting.value \"to\" $OctopusParameters[$key]\r\n        $setting.value = $OctopusParameters[$key]\r\n    }\r\n\r\n    # Replace Sitecore variables\r\n    $variable = $sitecoreNode.'sc.variable' | where { $_.name -ceq $key }\r\n    if ($variable -ne $null) {\r\n        Write-Host $variable.name \"Sitecore variable will be updated from\" $settingsNode.value \"to\" $OctopusParameters[$key]\r\n        $variable.value = $OctopusParameters[$key]\r\n    }\r\n\r\n}\r\n\r\n$configXml.Save($configPath)",
+    "Octopus.Action.Script.ScriptBody": "$ErrorActionPreference = \"Stop\" \r\n$configFiles = $OctopusParameters[\"Sitecore.ReplaceConfigFiles\"]\r\n\r\nif ([string]::IsNullOrEmpty($configFiles)) {\r\n    throw [System.ArgumentNullException] \"Sitecore.ReplaceConfigFiles\"\r\n}\r\n\r\n($configFiles -split '[\\r\\n]') | ForEach-Object {\r\n    \r\n    $configPath = $_\r\n\r\n    if ([string]::IsNullOrEmpty($configPath)) { \r\n        return\r\n    }\r\n    \r\n    $configPath = $configPath.Trim()\r\n\r\n    if (-not (Test-Path -LiteralPath $configPath)) {\r\n        Write-Host \"$configPath was not found.\"\r\n        return\r\n    }\r\n\r\n    Write-Host \"Searching Sitecore config file for replacement variables:\" $configPath\r\n        \r\n    $configXml = [xml](Get-Content $configPath)\r\n    $sitecoreNode = $configXml.sitecore\r\n    \r\n    # Look for sitecore node for versions prior to 8.1\r\n    if ($sitecoreNode -eq $null) {\r\n        $sitecoreNode = $configXml.configuration.sitecore\r\n    }\r\n    \r\n    # Ensure that we have a sitecore node to work from\r\n    if ($sitecoreNode -eq $null -or $sitecoreNode.settings -eq $null) {\r\n        Write-Host \"The sitecore settings node was not found in\" $configPath \". Skipping this file...\"\r\n        return\r\n    }\r\n    \r\n    foreach ($key in $OctopusParameters.Keys) {\r\n    \r\n        # Replace Sitecore settings\r\n        $setting = $sitecoreNode.settings.setting | where { $_.name -ceq $key }\r\n        if ($setting -ne $null) {\r\n            Write-Host $setting.name \"setting will be updated from\" $setting.value \"to\" $OctopusParameters[$key] \"in\" $configPath\r\n            $setting.value = $OctopusParameters[$key]\r\n        }\r\n    \r\n        # Replace Sitecore variables\r\n        $variable = $sitecoreNode.'sc.variable' | where { $_.name -ceq $key }\r\n        if ($variable -ne $null) {\r\n            Write-Host $variable.name \"Sitecore variable will be updated from\" $settingsNode.value \"to\" $OctopusParameters[$key] \"in\" $configPath\r\n            $variable.value = $OctopusParameters[$key]\r\n        }\r\n    \r\n    }\r\n    \r\n    $configXml.Save($configPath)\r\n}",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.NuGetFeedId": null,
     "Octopus.Action.Package.NuGetPackageId": null
   },
   "Parameters": [
     {
-      "Name": "Sitecore.SettingsFile",
-      "Label": "Sitecore.SettingsFile",
-      "HelpText": "Enter the full path to your Sitecore configuration file that contains the **sitecore** node. For versions of Sitecore prior to 8.1, this should point to your primary Web.config at the root of your website, and for versions 8.1+, to the Sitecore.config file within your App_Config folder. Alternatively, this value can be left empty and defined within your Octopus project's variable collection using the variable name **Sitecore.SettingsFile**.",
+      "Name": "Sitecore.ReplaceConfigFiles",
+      "Label": "Sitecore.ReplaceConfigFiles",
+      "HelpText": "Enter the full path to your Sitecore configuration file(s) that contains the **sitecore** node, one per line. For versions of Sitecore prior to 8.1, this should point to your primary Web.config at the root of your website, and for versions 8.1+, to the Sitecore.config file within your App_Config folder. Alternatively, this value can be left empty and defined within your Octopus project's variable collection using the variable name **Sitecore.ReplaceConfigFiles**.",
       "DefaultValue": null,
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+        "Octopus.ControlType": "MultiLineText"
       }
     }
   ],
-  "LastModifiedOn": "2016-06-08T18:00:16.379Z",
+  "LastModifiedOn": "2016-06-13T17:19:09.003Z",
   "LastModifiedBy": "dthunziker",
   "$Meta": {
-    "ExportedAt": "2016-06-08T18:00:16.379Z",
+    "ExportedAt": "2016-06-13T17:19:09.003Z",
     "OctopusVersion": "3.3.10",
     "Type": "ActionTemplate"
   }


### PR DESCRIPTION
This step template iterates over the $OctopusParameters collection and replaces matching keys in the specified Sitecore configuration file(s). This is intended to extend the functionality of [Configuration Variables](http://docs.octopusdeploy.com/display/OD/Configuration+files#Configurationfiles-ConfigurationVariables) to the Sitecore configuration files.

Sitecore is a content and experience management system that requires a purchased license to operate, however, the functionality of this step template does not rely on it - it simply replaces values in XML files under a specific node structure that matches the Sitecore config files.