### PR TITLE
IIS Set Authentication on IIS Applications

### DIFF
--- a/step-templates/iis-set-authentication.steptemplate.json
+++ b/step-templates/iis-set-authentication.steptemplate.json
@@ -50,6 +50,7 @@
       }
     }
   ],
+  "LastModifiedBy": "adz21c",
   "$Meta": {
     "ExportedAt": "2016-06-28T10:02:16.931Z",
     "OctopusVersion": "3.3.10",

--- a/step-templates/iis-set-authentication.steptemplate.json
+++ b/step-templates/iis-set-authentication.steptemplate.json
@@ -1,13 +1,16 @@
 {
-  "Id": "ActionTemplates-722",
+  "Id": "ActionTemplates-38",
   "Name": "IIS - Enable or Disable Authentication Methods",
   "Description": "Step template to set the desired IIS Authentication (Anonymous, Windows, Digest) State for IIS site(s)",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "#requires -version 3\n\n\n\n\n\nfunction Update-IISSiteAuthentication {\n    param\n    (\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [boolean]$State,\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [string]$SitePath,\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [string]$AuthMethod\n    )\n    \n    # check if WebAdministration module exists on the server\n    $cmd = (Get-Command \"Get-Website\" -errorAction SilentlyContinue)\n    if ($null -eq $cmd) {\n        throw \"The Windows PowerShell snap-in 'WebAdministration' is not installed on this server. Details can be found at https://technet.microsoft.com/en-us/library/ee790599.aspx.\"\n    }\n    \n    $IISSecurityPath = \"/system.WebServer/security/authentication/$AuthMethod\"\n    $separator = \"`r\",\"`n\",\",\"\n    $IISSites = $sitepath.split($separator, [System.StringSplitOptions]::RemoveEmptyEntries).Trim(' ')\n\n    $IISValidSites = Get-Website\n    $IISValidSiteNames = $IISValidSites.Name -join ', '\n\n    foreach($Site in $IISSites) {\n        $IISSiteAvailable = $IISValidSites | Where-Object { $_.Name -eq $Site }\n\n        if ($IISSiteAvailable) {\n            Set-WebConfigurationProperty -Filter $IISSecurityPath -Name Enabled -Value $State -PSPath IIS:\\ -Location $Site\n            Write-Output \"$AuthMethod for site '$Site' set successfully to '$State'.\"\n        }\n        else {\n            Write-Output \"The IISSitePath '$Site' cannot be found. The valid sites are $IISValidSiteNames\"\n            throw \"The IISSitePath '$Site' cannot be found. The valid sites are $IISValidSiteNames\"\n        }\n    }\n}\n\nif (Test-Path Variable:OctopusParameters) {\n    Update-IISSiteAuthentication -State ($AnonymousAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"AnonymousAuthentication\"\n    Update-IISSiteAuthentication -State ($WindowsAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"WindowsAuthentication\"\n    Update-IISSiteAuthentication -State ($DigestAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"DigestAuthentication\"\n}",
+    "Octopus.Action.Script.ScriptBody": "#requires -version 3\n\n\n\n\n\nfunction Update-IISSiteAuthentication {\n    param\n    (\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [boolean]$State,\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [string]$SitePath,\n        [ValidateNotNullOrEmpty()]\n        [Parameter(Mandatory = $true)]\n        [string]$AuthMethod\n    )\n    \n    # check if WebAdministration module exists on the server\n    $cmd = (Get-Command \"Get-Website\" -errorAction SilentlyContinue)\n    if ($null -eq $cmd) {\n        throw \"The Windows PowerShell snap-in 'WebAdministration' is not installed on this server. Details can be found at https://technet.microsoft.com/en-us/library/ee790599.aspx.\"\n    }\n    \n    $IISSecurityPath = \"/system.WebServer/security/authentication/$AuthMethod\"\n    $separator = \"`r\",\"`n\",\",\"\n    $IISSites = $sitepath.split($separator, [System.StringSplitOptions]::RemoveEmptyEntries).Trim(' ')\n\n    $IISValidSites = New-Object System.Collections.ArrayList\n\tforeach ($website in Get-Website) {\n\t\tforeach ($app in Get-WebApplication -Site $website.name) {\n\t\t\t$path = $website.name + $app.path\n\t\t\t$IISValidSites.Add($path)\n\t\t}\n\t}\n    $IISValidSiteNames = $IISValidSites -join ', '\n\n    foreach($Site in $IISSites) {\n        $IISSiteAvailable = $IISValidSites | Where-Object { $_ -eq $Site }\n\n        if ($IISSiteAvailable) {\n            Set-WebConfigurationProperty -Filter $IISSecurityPath -Name Enabled -Value $State -PSPath IIS:\\\\ -Location $Site\n            Write-Output \"$AuthMethod for site '$Site' set successfully to '$State'.\"\n        }\n        else {\n            Write-Output \"The IISSitePath '$Site' cannot be found. The valid sites are $IISValidSiteNames\"\n            throw \"The IISSitePath '$Site' cannot be found. The valid sites are $IISValidSiteNames\"\n        }\n    }\n}\n\nif (Test-Path Variable:OctopusParameters) {\n    Update-IISSiteAuthentication -State ($AnonymousAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"AnonymousAuthentication\"\n    Update-IISSiteAuthentication -State ($WindowsAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"WindowsAuthentication\"\n    Update-IISSiteAuthentication -State ($DigestAuth -eq \"True\") -SitePath $IISSitePaths -AuthMethod \"DigestAuthentication\"\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptSource": "Inline"
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
   "Parameters": [
     {
@@ -47,10 +50,9 @@
       }
     }
   ],
-  "LastModifiedBy": "benithao",
   "$Meta": {
-    "ExportedAt": "2016-06-07T10:55:20.076Z",
-    "OctopusVersion": "3.3.4",
+    "ExportedAt": "2016-06-28T10:02:16.931Z",
+    "OctopusVersion": "3.3.10",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Previously the list of valid IIS sets only included websites. This change also identifies all the applications within that website as valid paths.