### PR TITLE
Improve file system grant permission

### DIFF
--- a/step-templates/file-system-grant-permissions.json
+++ b/step-templates/file-system-grant-permissions.json
@@ -1,38 +1,45 @@
 {
-  "Id": "ActionTemplates-10",
+  "Id": "ActionTemplates-5",
   "Name": "File System - Grant Permissions",
   "Description": "Grant read and write permissions to a folder or file",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$item = $OctopusParameters['Item']\n$readPermissionsTo = $OctopusParameters['ReadPermissionsTo']\n$writePermissionsTo = $OctopusParameters['WritePermissionsTo']\n\n# Check item exists\n\nif(!(Test-Path $item))\n{\n    throw \"$item does not exist\"\n}\n\n# Assign read permissions\n\nif($readPermissionsTo)\n{\n    $users = $readPermissionsTo.Split(\",\")\n    foreach($user in $users)\n    {\n        Write-Host \"Adding read permissions for $user\"\n        $acl = Get-Acl $item\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(\n                $user, \"Read\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n}\n\n# Assign write permissions\n\nif($writePermissionsTo)\n{\n    $users = $writePermissionsTo.Split(\",\")\n    foreach($user in $users)\n    {\n        Write-Host \"Adding write permissions for $user\"\n        $acl = Get-Acl $item\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(\n                $user, \"Write\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n}\n\nWrite-Host \"Complete\""
+    "Octopus.Action.Script.ScriptBody": "$path = $OctopusParameters['Path']\n$readPermissionsTo = $OctopusParameters['ReadPermissionsTo']\n$writePermissionsTo = $OctopusParameters['WritePermissionsTo']\n\n# Check item exists\n\nif(!(Test-Path $path ))\n{\n    throw \"$path does not exist\"\n}\n\n# Assign read permissions\n\nif($readPermissionsTo)\n{\n    $users = $readPermissionsTo.Split(\",\")\n    foreach($user in $users)\n    {\n        Write-Host \"Adding read permissions for $user on path $path\"\n        $acl =  (Get-Item $path).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(\n                $user, \"Read\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n        $acl.AddAccessRule($rule)\n        Set-Acl $path $acl\n    }\n}\n\n# Assign write permissions\n\nif($writePermissionsTo)\n{\n    $users = $writePermissionsTo.Split(\",\")\n    foreach($user in $users)\n    {\n        Write-Host \"Adding write permissions for $user on path $path\"\n        $acl = (Get-Item $path).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(\n                $user, \"Write\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n        $acl.AddAccessRule($rule)\n        Set-Acl $path $acl\n    }\n}\n\nWrite-Host \"Complete\"",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
-      "Name": "Item",
-      "Label": "Item",
+      "Name": "Path",
+      "Label": "Path",
       "HelpText": "The full path to the file or folder",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
     {
       "Name": "ReadPermissionsTo",
       "Label": "Read Users",
       "HelpText": "A comma separated list of users to grant read permissions to",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     },
     {
       "Name": "WritePermissionsTo",
       "Label": "Write Users",
       "HelpText": "A comma separated list of users to grant write permissions to",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2014-05-16T10:11:07.172+00:00",
-  "LastModifiedBy": "sportingsolutions",
   "$Meta": {
-    "ExportedAt": "2014-05-16T10:11:12.098Z",
-    "OctopusVersion": "2.4.5.46",
+    "ExportedAt": "2016-08-01T08:47:32.274Z",
+    "OctopusVersion": "3.3.10",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Fix bug with setting owner by not using Get-Acl. See http://stackoverflow.com/questions/6622124/why-does-set-acl-on-the-drive-root-try-to-set-ownership-of-the-object
Better logging
Better variable names