### PR TITLE
Add test for missing last modified details

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -26,6 +26,7 @@ import yargs from 'yargs';
 import rev from 'gulp-rev';
 import glob from 'glob';
 import envify from 'envify/custom';
+import jasmine from 'gulp-jasmine';
 
 const clientDir = 'app';
 const serverDir = 'server';
@@ -70,7 +71,15 @@ gulp.task('lint:step-templates', () => {
     .pipe($.expect({ errorOnFailure: true }, glob.sync('step-templates/*.json')));
 });
 
-gulp.task('step-templates', ['lint:step-templates'], () => {
+gulp.task('jasmine-tests:step-templates', [], () => {
+  return gulp.src('./spec/*-tests.js')
+        // gulp-jasmine works on filepaths so you can't have any plugins before it
+        .pipe(jasmine({
+            includeStackTrace: true
+        }))
+});
+
+gulp.task('step-templates', ['lint:step-templates', 'jasmine-tests:step-templates'], () => {
   return gulp.src('./step-templates/*.json')
     .pipe(concat('step-templates.json', {newLine: ','}))
     .pipe(header('{"items": ['))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "normalize.css": "^4.1.1",
     "react": "^15.0.1",
     "react-copy-to-clipboard": "^4.1.0",
-    "react-disqus-thread": "^0.3.1",
+    "react-disqus-thread": "^0.4.0",
     "react-dom": "^15.0.1",
     "react-router": "^2.3.0",
     "react-syntax-highlighter": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "gulp-if": "^2.0.0",
     "gulp-inject": "^4.0.0",
     "gulp-jade": "^1.1.0",
+    "gulp-jasmine": "^2.4.0",
     "gulp-live-server": "0.0.29",
     "gulp-load-plugins": "^1.2.2",
     "gulp-rename": "^1.2.2",

--- a/spec/step-template-validation-tests.js
+++ b/spec/step-template-validation-tests.js
@@ -1,0 +1,53 @@
+var fs = require('fs');
+
+describe("step-templates", function() {
+  beforeEach(function(){
+    jasmine.addMatchers({
+      toHaveValidLastModified: function() {
+        return {
+          compare: function(template){
+            if(typeof template.LastModifiedOn == 'undefined')  {
+              return { pass: false, message: 'Expected template "' + template.Name + '" to have a valid LastModifiedOn date, but it was undefined.' }
+            } else if(typeof template.LastModifiedBy == 'undefined')  {
+              return { pass: false, message: 'Expected template "' + template.Name + '" to have a valid LastModifiedBy field, but it was undefined.' }
+            } else {
+              return { pass: true, message: 'Expected template "' + template.Name + '" to have a valid LastModified details.' }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it("step templates have valid last modified details", function(done) {
+    var filenameCounter = 0;
+    var stepTemplateCount = 0;
+    var dirname = './step-templates/';
+
+    fs.readdir(dirname, function(err, filenames) {
+      if (err) {
+        console.log('error listing files in dir: ' + err);
+        return;
+      }
+      stepTemplateCount = filenames.length;
+      filenames.forEach(function(filename) {
+        fs.readFile(dirname + filename, 'utf-8', function(err, content) {
+          if (err) {
+            console.log('error reading file ' + filename + ': ' + err);
+            return;
+          }
+          try {
+            var template = JSON.parse(content);
+            expect(template).toHaveValidLastModified();
+          }
+          catch(e) {
+            console.log('error reading file ' + dirname + filename + ': ' + e + ' - it might be UTF 8 with a BOM. Please resave without the BOM.')
+          }
+          if (filenameCounter++ == stepTemplateCount) {
+            done();
+          };
+        });
+      });
+    });
+  });
+});

--- a/step-templates/readyroll-deploy-database-package.json
+++ b/step-templates/readyroll-deploy-database-package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "Id": "ActionTemplates-1",
   "Name": "ReadyRoll - Deploy Database Package",
   "Description": "Deploy database changes packaged with Redgate's [ReadyRoll](http://www.ready-roll.com/). Requires the Microsoft SQL Command Line Utilities 11 or later to be installed on the tentacle.\r\n\r\n*Version date: 14th January, 2016*",

--- a/step-templates/redgate-create-database-release.json
+++ b/step-templates/redgate-create-database-release.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Id":  "ActionTemplates-34",
     "Name":  "Redgate - Create Database Release",
     "Description":  "Creates the resources (including the SQL update script) to deploy database changes using Redgate\u0027s [DLM Automation](http://www.red-gate.com/dlma/productpage), and exports them as Octopus artifacts so you can review the changes before deploying.\r\n\r\nRequires DLM Automation version 1.5.0.0 or later.\r\n\r\n*Version date: 16th July, 2016*",

--- a/step-templates/redgate-deploy-from-database-release.json
+++ b/step-templates/redgate-deploy-from-database-release.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Id":  "ActionTemplates-33",
     "Name":  "Redgate - Deploy from Database Release",
     "Description":  "Uses the deployment resources from the \u0027Redgate - Create Database Release\u0027 step to deploy the database changes using Redgate\u0027s [DLM Automation](http://www.red-gate.com/dlma/productpage).\r\n\r\nRequires DLM Automation version 1.5.0.0 or later.\r\n\r\n*Version date: 16th July, 2016*",

--- a/step-templates/redgate-deploy-from-database.json
+++ b/step-templates/redgate-deploy-from-database.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Id":  "ActionTemplates-2",
     "Name":  "Redgate - Deploy from Database",
     "Description":  "Uses Redgate\u0027s [DLM Automation](http://www.red-gate.com/dlma/productpage) to deploy a source schema to a SQL Server database without a review step.\r\n\r\nRequires DLM Automation version 1.5.0.0 or later.\r\n\r\n*Version date: 16th July, 2016*",

--- a/step-templates/redgate-deploy-from-package.json
+++ b/step-templates/redgate-deploy-from-package.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Id":  "ActionTemplates-35",
     "Name":  "Redgate - Deploy from Package",
     "Description":  "Uses Redgate\u0027s [DLM Automation](http://www.red-gate.com/dlma/productpage) to deploy a package containing a database schema (created by Redgate\u0027s DLM tools) to a SQL Server database, without a review step.\r\n\r\nRequires DLM Automation version 1.5.0.0 or later.\r\n\r\n*Version date: 16th July, 2016*",


### PR DESCRIPTION
As LastModifiedOn/LastModifiedBy details are no longer exported, this
causes issues when we display on the community library.

This will/should cause a build failure.

Related to #354.