### PR TITLE
Added Retention Policy script.

### DIFF
--- a/step-templates/retention-policy.json
+++ b/step-templates/retention-policy.json
@@ -3,18 +3,18 @@
   "Name": "Retention Policy",
   "Description": "Applies retention policy for built-in package repository by specified package id. Useful when you are using variables in PackageId parameter of deploy package step and built-in retention policy for package repository is not deleting packages.",
   "ActionType": "Octopus.Script",
-  "Version": 8,
+  "Version": 13,
   "Properties": {
-    "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "Write-Host \"Start RetentionPolicy\"\n\n$packagesRootDirectoryPath = $OctopusParameters[\"RetentionPackagesRootDirectory\"] #\"D:\\Octopus\\Packages\"\n$retentionCriteria = $OctopusParameters[\"RetentionCriteria\"] # \"days\" or \"number\"\n$retentionValue = [int] $OctopusParameters[\"RetentionValue\"] # Days or number of packages to keep\n$retentionPackageId = $OctopusParameters[\"RetentionPackageId\"]\n\nWrite-Host \"Retention criteria: $retentionCriteria\"\nWrite-Host \"Retention value: $retentionValue\"\n\n# Validations\n$validationsSuccessful = $true\nIf ([string]::IsNullOrEmpty($retentionCriteria)) {\n    Write-Warning \"Retention Criteria not specified: $retentionCriteria!\"\n    $validationsSuccessful = $false\n} Else {\n    If ($retentionCriteria.ToLower() -eq \"days\") {\n        If ($retentionValue -lt 3) {\n            Write-Warning \"Retention Value not specified or must be greater than 3 days!\"\n            $validationsSuccessful = $false\n        }\n    } ElseIf ($retentionCriteria.ToLower() -eq \"number\") {\n        If ($retentionValue -lt 10) {\n            Write-Warning \"Retention Value not specified or must be greater than 9 packages!\"\n            $validationsSuccessful = $false\n        }\n    } Else {\n        Write-Warning \"Retention Criteria must be 'days' or 'number'!\"\n        $validationsSuccessful = $false\n    }\n}\nIf (-Not (Test-Path $packagesRootDirectoryPath)) {\n    Write-Warning \"Packages root directory not found: $packagesRootDirectoryPath!\"\n    $validationsSuccessful = $false\n}\n\nIf ($validationsSuccessful) {\n\n    # Select package directories\n    $packageDirectories = Get-ChildItem $packagesRootDirectoryPath | ?{ $_.PSIsContainer }\n\n    # Filter out package folders by name if parameter specified\n    If ([string]::IsNullOrEmpty($retentionPackageId)){\n        Write-Host \"Retention Package Id not specified: $retentionPackageId!\"\n    } Else {\n        $packageDirectories = $packageDirectories | ?{ $_.Name -eq $retentionPackageId }\n\n        If ($packageDirectories.Length -le 0) {\n            Write-Host \"No package directories found!\"\n        } Else {\n            ForEach ($packageDirectory in $packageDirectories) {\n                $packageFiles = Get-ChildItem $packageDirectory.FullName\n                If ($packageFiles.Length -gt 0) {\n                    Write-Host (\"Package files found in directory: \" + $packageDirectory.FullName + \" \" + $packageFiles.Length)\n                    $packageFilesObsolete = @()\n\n                    If ($retentionCriteria -eq \"days\") {\n                        $packageFilesObsolete = $packageFiles | ?{ $_.LastWriteTime -le ((Get-Date).AddDays($retentionValue * -1)) }\n                    } ElseIf ($retentionCriteria -eq \"number\") {\n                        $filesToDelete = ($packageFiles.Length - $retentionValue)\n                        If ($filesToDelete -gt 0) {\n                            $packageFilesObsolete = $packageFiles | Sort-Object LastWriteTime | Select-Object -First $filesToDelete\n                        }\n                    }\n\n                    If ($packageFilesObsolete.Length -gt 0) {\n                        Write-Host (\"Applying retention policy for \" + $packageFilesObsolete.Length + \" obsolete files in directory: \" + $packageDirectory.FullName)\n                        ForEach ($packageVersionFileObsolete in $packageFilesObsolete) {\n                            Remove-Item -Path $packageVersionFileObsolete.FullName -Force -Recurse\n                        }\n                    }\n                } Else {\n                    Write-Host (\"No files found, removing empty directory: \" + $packageDirectory.FullName)\n                    Remove-Item -Path $packageDirectory.FullName -Force -Recurse\n                }\n            }\n        }\n    }\n}\n\nWrite-Host \"End RetentionPolicy\"\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Get-Parameter($Name, [switch]$Required, $Default, [switch]$FailOnValidate) {\n    $result = $null\n    $errMessage = [string]::Empty\n\n    If ($OctopusParameters -ne $null) {\n        $octopusParameterName = (\"Retention.\" + $Name)\n        $result = $OctopusParameters[$octopusParameterName]\n        Write-Host \"Octopus paramter value for $octopusParameterName : $result\"\n    }\n\n    If ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue\n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    If ($result -eq $null) {\n        If ($Required) {\n            $errMessage = \"Missing parameter value $Name\"\n        } Else {\n            $result = $Default\n        }\n    } \n\n    If (-Not [string]::IsNullOrEmpty($errMessage)) {\n        If ($FailOnValidate) {\n            Throw $errMessage\n        } Else {\n            Write-Warning $errMessage\n        }\n    }\n\n    return $result\n}\n\nFunction Validate-Paramters([switch]$FailOnValidate) {\n    $errMessage = [string]::Empty\n\n    If ($retentionCriteria.ToLower() -eq \"days\") {\n        If ($retentionValue -lt 3) {\n            $errMessage = \"Retention Value not specified or must be greater than 3 days!\"\n        }\n    } ElseIf ($retentionCriteria.ToLower() -eq \"number\") {\n        If ($retentionValue -lt 10) {\n            $errMessage = \"Retention Value not specified or must be greater than 9 packages!\"\n        }\n    } Else {\n        $errMessage = \"Retention Criteria must be 'days' or 'number'!\"\n    }\n    \n    If ([string]::IsNullOrEmpty($errMessage)) {\n       return $true;\n    } Else {\n        If ($FailOnValidate) {\n            Throw $errMessage\n        } Else {\n            Write-Warning $errMessage\n            return $false;\n        }\n    }\n}\n\n& {\n    Write-Host \"Start RetentionPolicy\"\n\n    $retentionFailOnValidate = [System.Convert]::ToBoolean([string](Get-Parameter \"FailOnValidate\" $false \"False\" $false))\n    $packagesRootDirectoryPath = [string] (Get-Parameter \"PackagesRootDirectory\" $true [string]::Empty $retentionFailOnValidate)\n    $retentionCriteria = [string] (Get-Parameter \"Criteria\" $true \"days\" $retentionFailOnValidate)\n    $retentionValue = [int] (Get-Parameter \"Value\" $true 30 $retentionFailOnValidate)\n    $retentionPackageId = [string] (Get-Parameter \"PackageId\" $true [string]::Empty $retentionFailOnValidate)\n\n    If ((Validate-Paramters $retentionFailOnValidate)) {\n\n        # Filter out package folders by name if parameter specified\n        $packageDirectories = Get-ChildItem $packagesRootDirectoryPath | ?{ $_.PSIsContainer } | ?{ $_.Name -eq $retentionPackageId }\n\n        If ($packageDirectories.Length -le 0) {\n            Write-Warning \"No package directories found!\"\n        } Else {\n            ForEach ($packageDirectory in $packageDirectories) {\n                $packageFiles = Get-ChildItem $packageDirectory.FullName\n                If ($packageFiles.Length -gt 0) {\n                    Write-Host (\"Package files found in directory: \" + $packageDirectory.FullName + \" - \" + $packageFiles.Length)\n                    $packageFilesObsolete = @()\n\n                    If ($retentionCriteria -eq \"days\") {\n                        $packageFilesObsolete = $packageFiles | ?{ $_.LastWriteTime -le ((Get-Date).AddDays($retentionValue * -1)) }\n                    } ElseIf ($retentionCriteria -eq \"number\") {\n                        $filesToDelete = ($packageFiles.Length - $retentionValue)\n                        If ($filesToDelete -gt 0) {\n                            $packageFilesObsolete = $packageFiles | Sort-Object LastWriteTime | Select-Object -First $filesToDelete\n                        }\n                    }\n\n                    If ($packageFilesObsolete.Length -gt 0) {\n                        Write-Host (\"Applying retention policy for \" + $packageFilesObsolete.Length + \" obsolete files in directory: \" + $packageDirectory.FullName)\n                        ForEach ($packageVersionFileObsolete in $packageFilesObsolete) {\n                            Remove-Item -Path $packageVersionFileObsolete.FullName -Force -Recurse\n                        }\n                    }\n                } Else {\n                    Write-Host (\"No files found, removing empty directory: \" + $packageDirectory.FullName)\n                    Remove-Item -Path $packageDirectory.FullName -Force -Recurse\n                }\n            }\n        }\n    } ElseIf ($retentionFailOnValidate -eq $true) {\n        throw \"Missing or invalid parameter values!\"\n    }\n\n    Write-Host \"End RetentionPolicy\"\n}\n\n",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.NuGetFeedId": null,
     "Octopus.Action.Package.NuGetPackageId": null
   },
   "Parameters": [
     {
-      "Name": "RetentionPackagesRootDirectory",
+      "Name": "Retention.PackagesRootDirectory",
       "Label": "Packages root directory",
       "HelpText": "Packages directory path on Octopus server (e.g. D:\\Octopus\\Packages).",
       "DefaultValue": null,
@@ -23,7 +23,7 @@
       }
     },
     {
-      "Name": "RetentionCriteria",
+      "Name": "Retention.Criteria",
       "Label": "Criteria",
       "HelpText": "Criteria by which to apply retention policy - days or number of packages.",
       "DefaultValue": "days",
@@ -33,7 +33,7 @@
       }
     },
     {
-      "Name": "RetentionValue",
+      "Name": "Retention.Value",
       "Label": "Value",
       "HelpText": "Value for selected criteria.\nMin value for days criteria - 3.\nMin value for number criteria - 10.",
       "DefaultValue": "30",
@@ -42,18 +42,27 @@
       }
     },
     {
-      "Name": "RetentionPackageId",
+      "Name": "Retention.PackageId",
       "Label": "Package Id",
       "HelpText": null,
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
+    },
+    {
+      "Name": "Retention.FailOnValidate",
+      "Label": "Fail on validate",
+      "HelpText": "If true throws exception when parameter validation fails. If false just outputs warning messages to deployment log and doesn't fail whole deployment.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
     }
   ],
   "LastModifiedBy": "sarbis",
   "$Meta": {
-    "ExportedAt": "2016-08-19T13:57:46.732Z",
+    "ExportedAt": "2016-08-19T16:14:15.382Z",
     "OctopusVersion": "3.3.16",
     "Type": "ActionTemplate"
   }

--- a/step-templates/retention-policy.json
+++ b/step-templates/retention-policy.json
@@ -1,0 +1,60 @@
+{
+  "Id": "ActionTemplates-221",
+  "Name": "Retention Policy",
+  "Description": "Applies retention policy for built-in package repository by specified package id. Useful when you are using variables in PackageId parameter of deploy package step and built-in retention policy for package repository is not deleting packages.",
+  "ActionType": "Octopus.Script",
+  "Version": 8,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "Write-Host \"Start RetentionPolicy\"\n\n$packagesRootDirectoryPath = $OctopusParameters[\"RetentionPackagesRootDirectory\"] #\"D:\\Octopus\\Packages\"\n$retentionCriteria = $OctopusParameters[\"RetentionCriteria\"] # \"days\" or \"number\"\n$retentionValue = [int] $OctopusParameters[\"RetentionValue\"] # Days or number of packages to keep\n$retentionPackageId = $OctopusParameters[\"RetentionPackageId\"]\n\nWrite-Host \"Retention criteria: $retentionCriteria\"\nWrite-Host \"Retention value: $retentionValue\"\n\n# Validations\n$validationsSuccessful = $true\nIf ([string]::IsNullOrEmpty($retentionCriteria)) {\n    Write-Warning \"Retention Criteria not specified: $retentionCriteria!\"\n    $validationsSuccessful = $false\n} Else {\n    If ($retentionCriteria.ToLower() -eq \"days\") {\n        If ($retentionValue -lt 3) {\n            Write-Warning \"Retention Value not specified or must be greater than 3 days!\"\n            $validationsSuccessful = $false\n        }\n    } ElseIf ($retentionCriteria.ToLower() -eq \"number\") {\n        If ($retentionValue -lt 10) {\n            Write-Warning \"Retention Value not specified or must be greater than 9 packages!\"\n            $validationsSuccessful = $false\n        }\n    } Else {\n        Write-Warning \"Retention Criteria must be 'days' or 'number'!\"\n        $validationsSuccessful = $false\n    }\n}\nIf (-Not (Test-Path $packagesRootDirectoryPath)) {\n    Write-Warning \"Packages root directory not found: $packagesRootDirectoryPath!\"\n    $validationsSuccessful = $false\n}\n\nIf ($validationsSuccessful) {\n\n    # Select package directories\n    $packageDirectories = Get-ChildItem $packagesRootDirectoryPath | ?{ $_.PSIsContainer }\n\n    # Filter out package folders by name if parameter specified\n    If ([string]::IsNullOrEmpty($retentionPackageId)){\n        Write-Host \"Retention Package Id not specified: $retentionPackageId!\"\n    } Else {\n        $packageDirectories = $packageDirectories | ?{ $_.Name -eq $retentionPackageId }\n\n        If ($packageDirectories.Length -le 0) {\n            Write-Host \"No package directories found!\"\n        } Else {\n            ForEach ($packageDirectory in $packageDirectories) {\n                $packageFiles = Get-ChildItem $packageDirectory.FullName\n                If ($packageFiles.Length -gt 0) {\n                    Write-Host (\"Package files found in directory: \" + $packageDirectory.FullName + \" \" + $packageFiles.Length)\n                    $packageFilesObsolete = @()\n\n                    If ($retentionCriteria -eq \"days\") {\n                        $packageFilesObsolete = $packageFiles | ?{ $_.LastWriteTime -le ((Get-Date).AddDays($retentionValue * -1)) }\n                    } ElseIf ($retentionCriteria -eq \"number\") {\n                        $filesToDelete = ($packageFiles.Length - $retentionValue)\n                        If ($filesToDelete -gt 0) {\n                            $packageFilesObsolete = $packageFiles | Sort-Object LastWriteTime | Select-Object -First $filesToDelete\n                        }\n                    }\n\n                    If ($packageFilesObsolete.Length -gt 0) {\n                        Write-Host (\"Applying retention policy for \" + $packageFilesObsolete.Length + \" obsolete files in directory: \" + $packageDirectory.FullName)\n                        ForEach ($packageVersionFileObsolete in $packageFilesObsolete) {\n                            Remove-Item -Path $packageVersionFileObsolete.FullName -Force -Recurse\n                        }\n                    }\n                } Else {\n                    Write-Host (\"No files found, removing empty directory: \" + $packageDirectory.FullName)\n                    Remove-Item -Path $packageDirectory.FullName -Force -Recurse\n                }\n            }\n        }\n    }\n}\n\nWrite-Host \"End RetentionPolicy\"\n",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
+  },
+  "Parameters": [
+    {
+      "Name": "RetentionPackagesRootDirectory",
+      "Label": "Packages root directory",
+      "HelpText": "Packages directory path on Octopus server (e.g. D:\\Octopus\\Packages).",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "RetentionCriteria",
+      "Label": "Criteria",
+      "HelpText": "Criteria by which to apply retention policy - days or number of packages.",
+      "DefaultValue": "days",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "days|Days\nnumber|Number of packages"
+      }
+    },
+    {
+      "Name": "RetentionValue",
+      "Label": "Value",
+      "HelpText": "Value for selected criteria.\nMin value for days criteria - 3.\nMin value for number criteria - 10.",
+      "DefaultValue": "30",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "RetentionPackageId",
+      "Label": "Package Id",
+      "HelpText": null,
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedBy": "sarbis",
+  "$Meta": {
+    "ExportedAt": "2016-08-19T13:57:46.732Z",
+    "OctopusVersion": "3.3.16",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Applies retention policy for built-in package repository by specified package id. Useful when you are using variables in PackageId parameter of deploy package step and built-in retention policy for package repository is not deleting packages.