### PR TITLE
Changing variable names to something less generic

### DIFF
--- a/step-templates/file-system-backup-directory.json
+++ b/step-templates/file-system-backup-directory.json
@@ -1,24 +1,27 @@
 {
-  "Id": "ActionTemplates-43",
+  "Id": "ActionTemplates-224",
   "Name": "File System - Backup Directory",
   "Description": "Uses Robocopy to backup directories and files from a source to a destination.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "function Get-Stamped-Destination($destination) {\n\t$stampedFolderName = get-date -format \"yyyy-MM-dd\"\n\t$count = 1\n\t$stampedDestination = Join-Path $destination $stampedFolderName\n\twhile(Test-Path $stampedDestination) {\n\t\t$count++\n\t\t$stamped = $stampedFolderName + \"(\" + $count + \")\"\n\t\t$stampedDestination = Join-Path $destination $stamped\n\t}\n\treturn $stampedDestination\n}\n\n$source = $OctopusParameters['Source']\n$destination = $OctopusParameters['Destination']\n$CreateStampedBackupFolder = $OctopusParameters['CreateStampedBackupFolder']\nif($CreateStampedBackupFolder -like \"True\" ) {\n\t$destination = get-stamped-destination $destination\n}\n\n$options = $OctopusParameters['Options'] -split \"\\s+\"\n\nif(Test-Path -Path $source) {\n    robocopy $source $destination $options\n}\n\nif($LastExitCode -gt 8) {\n    exit 1\n}\nelse {\n    exit 0\n}\n",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "function Get-Stamped-Destination($BackupDestination) {\r\n\t$stampedFolderName = get-date -format \"yyyy-MM-dd\"\r\n\t$count = 1\r\n\t$stampedDestination = Join-Path $BackupDestination $stampedFolderName\r\n\twhile(Test-Path $stampedDestination) {\r\n\t\t$count++\r\n\t\t$stamped = $stampedFolderName + \"(\" + $count + \")\"\r\n\t\t$stampedDestination = Join-Path $BackupDestination $stamped\r\n\t}\r\n\treturn $stampedDestination\r\n}\r\n\r\n$BackupSource = $OctopusParameters['BackupSource']\r\n$BackupDestination = $OctopusParameters['BackupDestination']\r\n$CreateStampedBackupFolder = $OctopusParameters['CreateStampedBackupFolder']\r\nif($CreateStampedBackupFolder -like \"True\" ) {\r\n\t$BackupDestination = get-stamped-destination $BackupDestination\r\n}\r\n\r\n$options = $OctopusParameters['Options'] -split \"\\s+\"\r\n\r\nif(Test-Path -Path $BackupSource) {\r\n    robocopy $BackupSource $BackupDestination $options\r\n}\r\n\r\nif($LastExitCode -gt 8) {\r\n    exit 1\r\n}\r\nelse {\r\n    exit 0\r\n}\r\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
-      "Name": "Source",
+      "Name": "BackupSource",
       "Label": "Source",
       "HelpText": "The source directory where files and folders will be copied from",
       "DefaultValue": null,
       "DisplaySettings": {}
     },
     {
-      "Name": "Destination",
+      "Name": "BackupDestination",
       "Label": "Destination folder",
       "HelpText": "The Destination where the files will be copied to.",
       "DefaultValue": null,
@@ -39,10 +42,9 @@
       "DisplaySettings": {}
     }
   ],
-  "LastModifiedBy": "CarlosSardo",
   "$Meta": {
-    "ExportedAt": "2015-09-02T18:10:57.214Z",
-    "OctopusVersion": "3.0.9.2259",
+    "ExportedAt": "2016-08-25T15:50:24.584Z",
+    "OctopusVersion": "3.3.27",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
Changed variable names to something less generic ti avoid clashes with
project/library variables

"Source" => "BackupSource"
"Destination" => "BackupDestination"

Ticket: https://secure.helpscout.net/conversation/240474620/9153 (and
this has happened at least 1 more time with this template)