### PR TITLE
New step template Wait-until-time

### DIFF
--- a/step-templates/Wait-until-time
+++ b/step-templates/Wait-until-time
@@ -1,0 +1,28 @@
+{
+  "Id": "ActionTemplates-65",
+  "Name": "Wait until time",
+  "Description": "Pauses the process until a given time",
+  "ActionType": "Octopus.Script",
+  "Version": 21,
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "if($DefaultTargetTime -eq $null-and $TargetTime -eq $null ){\n    Write-Output 'Deploy will start immediately because neither TargetTime or DefaultTargetTime is set' \n}else{\n    \n    if($TargetTime -eq $null){\n        $TargetTime = $DefaultTargetTime\n        Write-Output 'TargetTime is set to DefaultTargetTime since TargetTime is not configured for this build scope.'\n    }\n    Write-Output 'Deploy will pause until' (get-date($TargetTime))\n    \n    if((get-date) -ge (get-date $TargetTime)){\n    \tdo {\n    \t\tStart-Sleep 1\n    \t}\n    \tuntil ((get-date) -ge (get-date '23:59:59'))\n    \tStart-Sleep 3\n    }\n    \n    do {\n    \tStart-Sleep 1\n    \t}\n    until ((get-date) -ge (get-date $TargetTime))\n}\n",
+    "Octopus.Action.Script.Syntax": "PowerShell"
+  },
+  "SensitiveProperties": {},
+  "Parameters": [
+    {
+      "Name": "DefaultTargetTime",
+      "Label": "Time to deploy",
+      "HelpText": "Will deploy within the next 24 hours if only time is specified or at a specific date if that is specified\nA time set here will be used unless the project has a variable TargetTime.\nExamples:\n\n\t03:00\t\t\t\tWill deploy within 24 hours when the time is 03:00 in the morning\n\t2099-09-14 05:00\tWill deploy at that day and time\n\t2025-10-01\t\t\tWill deploy at 00:00 the first of october 2025\n\nIf the deployment time changes often it is suggested to create a variable named TargetTime and make it promptable. This will force the user to set the deployment time before the build process starts.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2016-09-14T12:02:46.481Z",
+    "OctopusVersion": "3.2.21",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
This step template will pause the octopus process until a given time.

Intended use:
Any time when the process needs to be halted. For example when using a Manual Intervention step to approve the deploy but the user wants the deploy process to continue automatically at night.

Description
It has 2 parameters: DefaultTargetTime that is a step parameter and TargetTime that is a release variable.
If no configuration is given (DefaultTargetTime and TargetTime is not set) the step will continue emmidiately.
If the step parameter DefaultTargetTime is set but not TargetTime, the step will wait until DefaultTargetTime
If TargetTime is set in the release variables for the environment that the release is targeting the step will wait until TargetTime. 
It is possible to make TargetTime as a promptable variable to force the user to enter time every time the release is deployed.