### PR TITLE
Step template for generating a changelog from Mercurial commit messages

### DIFF
--- a/step-templates/hg-get-changelog.json
+++ b/step-templates/hg-get-changelog.json
@@ -1,0 +1,45 @@
+{
+  "Id": "ActionTemplates-41",
+  "Name": "HG - Get Changelog",
+  "Description": "Generate exact changelog from Mercurial commit history. It is stored in the output variable \"Changelog\".\n\nRequirement: each release must have been labeled in the repository as \"release-OctopusReleaseNumber\" (for instance using VCS labeling feature of TeamCity).\n\nSee http://hgbook.red-bean.com/read/customizing-the-output-of-mercurial.html for template format.",
+  "ActionType": "Octopus.Script",
+  "Version": 17,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptBody": "If ($OctopusParameters[\"Octopus.Release.CurrentForEnvironment.Number\"]) {\n    $prm = @('log',\n    \t'-r',\"ancestors('release-$($OctopusParameters[\"Octopus.Release.Number\"])') - ancestors('release-$($OctopusParameters[\"Octopus.Release.CurrentForEnvironment.Number\"])')\",\n    \t'-T',$Template,\n    \t'--repository',$HgRepository)\n    Write-Host Getting changelog on $prm[6] '[' $prm[2] ']'\n    $changelog = & hg $prm\n}\nElse {\n    $changelog = \"<li><i>(no changelog available)</i></li>\"\n}\nWrite-Verbose $changelog\nSet-OctopusVariable -name \"Changelog\" -value $changelog",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "9a308d93-915c-4216-a0a6-cbe8de108064",
+      "Name": "HgRepository",
+      "Label": "Repository Path",
+      "HelpText": "The Mercurial repository to use for generating the changelog.\n\nThe repo path needs to be local to where the step is executed because Mercurial does not support remote log listing.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "57f225d5-4579-442f-ac3c-725743952f09",
+      "Name": "Template",
+      "Label": "",
+      "HelpText": "Default template generates HTML &lt;li&gt; elements for inclusion in a &lt;ul&gt; (not part of the step output).",
+      "DefaultValue": "<li>{date|shortdate} ({date|age} in {branch|escape}): {desc|strip|escape|addbreaks}</li>",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedOn": "2016-09-19T18:10:00.000Z",
+  "LastModifiedBy": "avonwyss",
+  "$Meta": {
+    "ExportedAt": "2016-09-19T18:10:27.463Z",
+    "OctopusVersion": "3.4.9",
+    "Type": "ActionTemplate"
+  }
+}


### PR DESCRIPTION
Creates a changelog (based on Mercurial source control commit messages) as HTML fragment which can be used for instance in a mail notification after a successful deployment.

The script is made so that it takes into account the currently deployed version on the target environment, thus producing a log of changes since the last deployment.