### PR TITLE
Copy migrate.exe to ASP.NET project's bin folder and also replace connectionString by connectionStringName

### DIFF
--- a/step-templates/run-entity-framework-migrations.json
+++ b/step-templates/run-entity-framework-migrations.json
@@ -3,11 +3,12 @@
   "Name": "Run Entity Framework migrations (Update-Database)",
   "Description": "Runs `Update-Database` to update the database to the latest Entity Framework migrations",
   "ActionType": "Octopus.Script",
-  "Version": 9,
+  "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# A collection of functions that can be used by script steps to determine where packages installed\r\n# by previous steps are located on the filesystem.\r\n \r\nfunction Find-InstallLocations {\r\n    $result = @()\r\n    $OctopusParameters.Keys | foreach {\r\n        if ($_.EndsWith('].Output.Package.InstallationDirectoryPath')) {\r\n            $result += $OctopusParameters[$_]\r\n        }\r\n    }\r\n    return $result\r\n}\r\n \r\nfunction Find-InstallLocation($stepName) {\r\n    $result = $OctopusParameters.Keys | where {\r\n        $_.Equals(\"Octopus.Action[$stepName].Output.Package.InstallationDirectoryPath\",  [System.StringComparison]::OrdinalIgnoreCase)\r\n    } | select -first 1\r\n \r\n    if ($result) {\r\n        return $OctopusParameters[$result]\r\n    }\r\n \r\n    throw \"No install location found for step: $stepName\"\r\n}\r\n \r\nfunction Find-SingleInstallLocation {\r\n    $all = @(Find-InstallLocations)\r\n    if ($all.Length -eq 1) {\r\n        return $all[0]\r\n    }\r\n    if ($all.Length -eq 0) {\r\n        throw \"No package steps found\"\r\n    }\r\n    throw \"Multiple package steps have run; please specify a single step\"\r\n}\r\n\r\nfunction Test-LastExit($cmd) {\r\n    if ($LastExitCode -ne 0) {\r\n        Write-Host \"##octopus[stderr-error]\"\r\n        write-error \"$cmd failed with exit code: $LastExitCode\"\r\n    }\r\n}\r\n\r\n\r\n\r\n\r\n$stepName = $OctopusParameters['NugetPackageStepName']\r\n\r\n$stepPath = \"\"\r\nif (-not [string]::IsNullOrEmpty($stepName)) {\r\n    Write-Host \"Finding path to package step: $stepName\"\r\n    $stepPath = Find-InstallLocation $stepName\r\n} else {\r\n    $stepPath = Find-SingleInstallLocation\r\n}\r\nWrite-Host \"Package was installed to: $stepPath\"\r\n\r\n\r\n\r\n#Locate Migrate.exe\r\n$efToolsFolder = $OctopusParameters['EfToolsFolder']\r\n$migrateExe = Join-Path $efToolsFolder \"migrate.exe\"\r\nif (-Not(Test-Path $migrateExe)){\r\n\tthrow (\"Unable to locate migrate.exe file. Specifed path $migrateExe does not exist.\")\r\n}\r\nWrite-Host(\"Using Migrate.Exe from $migrateExe\")\r\n\r\n\r\n#Locate Assembly with DbContext class\r\n$contextDllName = $OctopusParameters['AssemblyDllName']\r\n$binPath = Join-Path $stepPath \"bin\"\r\n$contextDllPath = Join-Path $binPath $contextDllName\r\nif (-Not(Test-Path $contextDllPath)){\r\n\tthrow (\"Unable to locate assembly file with DbContext class. Specifed path $contextDllPath does not exist.\")\r\n}\r\nWrite-Host(\"Using $contextDllName from $contextDllPath\")\r\n\r\n#Locate web.config. Migrate.exe needs it for some reason, even if connection string is provided\r\n$webConfigPath = Join-Path $stepPath \"web.config\"\r\nif (-Not(Test-Path $webConfigPath)){\r\n\tthrow (\"Unable to locate web.config file. Specifed path $webConfigPath does not exist.\")\r\n}\r\n\r\n\r\n$connectionString = $OctopusParameters['ConnectionString']\r\n\r\n$migrateCommand = \"& \"\"$migrateExe\"\" \"\"$contextDllName\"\" /connectionString=\"\"$connectionString\"\" /connectionProviderName=\"\"System.Data.SqlClient\"\" /startupConfigurationFile=\"\"$webConfigPath\"\" /startUpDirectory=\"\"$binPath\"\" /Verbose\"\r\n\r\nWrite-Host \"##octopus[stderr-error]\"        # Stderr is an error\r\nWrite-Host \"Executing: \" $migrateCommand\r\nWrite-Host \r\n\r\nInvoke-Expression $migrateCommand | Write-Host\r\n\r\n"
+    "Octopus.Action.Script.ScriptBody": "# A collection of functions that can be used by script steps to determine where packages installed\r\n# by previous steps are located on the filesystem.\r\n \r\nfunction Find-InstallLocations {\r\n    $result = @()\r\n    $OctopusParameters.Keys | foreach {\r\n        if ($_.EndsWith('].Output.Package.InstallationDirectoryPath')) {\r\n            $result += $OctopusParameters[$_]\r\n        }\r\n    }\r\n    return $result\r\n}\r\n \r\nfunction Find-InstallLocation($stepName) {\r\n    $result = $OctopusParameters.Keys | where {\r\n        $_.Equals(\"Octopus.Action[$stepName].Output.Package.InstallationDirectoryPath\",  [System.StringComparison]::OrdinalIgnoreCase)\r\n    } | select -first 1\r\n \r\n    if ($result) {\r\n        return $OctopusParameters[$result]\r\n    }\r\n \r\n    throw \"No install location found for step: $stepName\"\r\n}\r\n \r\nfunction Find-SingleInstallLocation {\r\n    $all = @(Find-InstallLocations)\r\n    if ($all.Length -eq 1) {\r\n        return $all[0]\r\n    }\r\n    if ($all.Length -eq 0) {\r\n        throw \"No package steps found\"\r\n    }\r\n    throw \"Multiple package steps have run; please specify a single step\"\r\n}\r\n\r\nfunction Test-LastExit($cmd) {\r\n    if ($LastExitCode -ne 0) {\r\n        Write-Host \"##octopus[stderr-error]\"\r\n        write-error \"$cmd failed with exit code: $LastExitCode\"\r\n    }\r\n}\r\n\r\n\r\n\r\n\r\n$stepName = $OctopusParameters['NugetPackageStepName']\r\n\r\n$stepPath = \"\"\r\nif (-not [string]::IsNullOrEmpty($stepName)) {\r\n    Write-Host \"Finding path to package step: $stepName\"\r\n    $stepPath = Find-InstallLocation $stepName\r\n} else {\r\n    $stepPath = Find-SingleInstallLocation\r\n}\r\nWrite-Host \"Package was installed to: $stepPath\"\r\n\r\n$binPath = Join-Path $stepPath \"bin\"\r\n\r\n#Locate Migrate.exe\r\n$efToolsFolder = $OctopusParameters['EfToolsFolder']\r\n$originalMigrateExe = Join-Path $efToolsFolder \"migrate.exe\"\r\n\r\nif (-Not(Test-Path $originalMigrateExe)){\r\n    throw (\"Unable to locate migrate.exe file. Specifed path $originalMigrateExe does not exist.\")\r\n}\r\nWrite-Host(\"Found Migrate.Exe from $originalMigrateExe\")\r\n\r\n# Move migrate.exe to ASP.NET Project's bin folder as per https://msdn.microsoft.com/de-de/data/jj618307.aspx?f=255&MSPPError=-2147217396\r\nCopy-Item $originalMigrateExe -Destination $binPath\r\n\r\n$migrateExe = Join-Path $binPath \"migrate.exe\"\r\nWrite-Host(\"Copied $originalMigrateExe into $binPath\")\r\n\r\n#Locate Assembly with DbContext class\r\n$contextDllName = $OctopusParameters['AssemblyDllName']\r\n$contextDllPath = Join-Path $binPath $contextDllName\r\nif (-Not(Test-Path $contextDllPath)){\r\n    throw (\"Unable to locate assembly file with DbContext class. Specifed path $contextDllPath does not exist.\")\r\n}\r\nWrite-Host(\"Using $contextDllName from $contextDllPath\")\r\n\r\n#Locate web.config. Migrate.exe needs it for some reason, even if connection string is provided\r\n$webConfigPath = Join-Path $stepPath \"web.config\"\r\nif (-Not(Test-Path $webConfigPath)){\r\n    throw (\"Unable to locate web.config file. Specifed path $webConfigPath does not exist.\")\r\n}\r\n\r\n$connectionStringName = $OctopusParameters['ConnectionStringName']\r\n\r\n$migrateCommand = \"& \"\"$migrateExe\"\" \"\"$contextDllName\"\" /connectionStringName=\"\"$connectionStringName\"\" /startupConfigurationFile=\"\"$webConfigPath\"\" /startUpDirectory=\"\"$binPath\"\" /Verbose\"\r\n\r\nWrite-Host \"##octopus[stderr-error]\"        # Stderr is an error\r\nWrite-Host \"Executing: \" $migrateCommand\r\nWrite-Host \r\n\r\nInvoke-Expression $migrateCommand | Write-Host\r\n\r\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline"
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
       "Name": "EfToolsFolder",
@@ -37,20 +38,18 @@
       }
     },
     {
-      "Name": "ConnectionString",
-      "Label": "Connection String",
-      "HelpText": "Connection string to the database where the migration should be applied.",
+      "Name": "ConnectionStringName",
+      "Label": "ConnectionStringName",
+      "HelpText": "Name of the key in <connectionStrings> section in Web.Config",
       "DefaultValue": null,
       "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
+        "Octopus.ControlType": "SingleLineText"
       }
     }
   ],
-  "LastModifiedOn": "2015-03-25T08:44:38.238+00:00",
-  "LastModifiedBy": "trailmax",
   "$Meta": {
-    "ExportedAt": "2015-03-25T08:53:16.012Z",
-    "OctopusVersion": "2.6.3.886",
+    "ExportedAt": "2016-09-20T07:45:17.818Z",
+    "OctopusVersion": "3.3.6",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
**Run Entity Framework migrations (Update-Database)** currently has a problem described in [my comments to this library](https://library.octopusdeploy.com/step-template/actiontemplate-run-entity-framework-migrations-(update-database))

Long story short. This library should follow [the official EF migration guide](https://msdn.microsoft.com/en-us/data/jj618307.aspx?f=255&MSPPError=-2147217396) that **Once you have migrate.exe then you need to copy it to the location of the assembly that contains your migrations.**

Right now, this library generates a command looks like this:

    & "C:\TeamCity\buildAgent\work\43efbaad108eb32f\packages\EntityFramework.6.1.3\tools\migrate.exe" "FHT.Infrastructure.MsSqlConfigurations.dll" /connectionString="" /connectionProviderName="System.Data.SqlClient" /startupConfigurationFile="D:\Octopus\Applications\Development\FHT.Web\1.0.1228_1\web.config" /startUpDirectory="D:\Octopus\Applications\Development\FHT.Web\1.0.1228_1\bin" /Verbose

This will result in the following error because running `migrate.exe` in its original location will always result in this error even if you run `migrate.exe /?`:

    System.IO.FileNotFoundException: Could not load file or assembly 'EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' or one of its dependencies. The system cannot find the file specified.

Since the pull request shows diff of the json file instead of the original powershell file, I attached the original ps file and the modified version here too.

[original.txt](https://github.com/OctopusDeploy/Library/files/481908/original.txt)
[modified.txt](https://github.com/OctopusDeploy/Library/files/481909/modified.txt)
