### PR TITLE
Fix StoreName select options error.

### DIFF
--- a/step-templates/ssl-certificate-install.json
+++ b/step-templates/ssl-certificate-install.json
@@ -34,7 +34,7 @@
       "DefaultValue": "My",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "AddressBook\nAuthRoot\nCertificateAuthority\nDisallowed\nMy\nRoot\nTrustedPeople\nTrustedPublisher"
+        "Octopus.SelectOptions": "AddressBook\nAuthRoot\nCA\nDisallowed\nMy\nRoot\nTrustedPeople\nTrustedPublisher"
       }
     },
     {
@@ -48,8 +48,8 @@
       }
     }
   ],
-  "LastModifiedOn": "2014-10-01T07:32:15.704+00:00",
-  "LastModifiedBy": "andrewcupper",
+  "LastModifiedOn": "2016-10-14T03:01:44.952Z",
+  "LastModifiedBy": "kp-tseng",
   "$Meta": {
     "ExportedAt": "2014-10-01T07:43:57.503Z",
     "OctopusVersion": "2.5.8.447",


### PR DESCRIPTION
The StoreName string of intermediate certificate authorities should be "CA", not "CertificateAuthority".