### PR TITLE
Fixed wrong parameter name

### DIFF
--- a/step-templates/windows-scheduled-task-create.json
+++ b/step-templates/windows-scheduled-task-create.json
@@ -110,7 +110,7 @@
       }
     },
     {
-      "Name": "Password",
+      "Name": "RunAsPassword",
       "Label": "Password",
       "HelpText": "Specifying a password allows the task to run when the user is not logged on to the server.",
       "DefaultValue": null,


### PR DESCRIPTION
The powershell script expects variable name "RunAsPassword", but Octopus variable name is "Password".