### PR TITLE
Added Upgrade Octopus Server Step

### DIFF
--- a/step-templates/upgrade-octopus-server.json
+++ b/step-templates/upgrade-octopus-server.json
@@ -1,0 +1,34 @@
+{
+  "Id": "4b3a1f09-1827-41bb-88a4-894c6317922b",
+  "Name": "Upgrade Octopus Server",
+  "Description": "This step downloads the latest version of Octopus Server and upgrades an existing instance. Run this step on a tentacle that has privileges to install software and start/stop services on the target server.\n\n**Run this after a database backup step**\n\nTo Use:\n- Install a tentacle on the Octopus Server machine with privileges to install software and start/stop services\n- Add that tentacle to an environment and with a unique role\n- Setup a project for the upgrade process\n- Add a database backup step for your Octopus Server database\n- Add this step, selecting it to run on just the role previously configured\n- Create a release\n- Deploy that release whenever an upgrade is needed\n\nNB: The deployment will show as \"Timed Out\" when the server comes back online",
+  "ActionType": "Octopus.Script",
+  "Version": 7,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\r\n$versions = Invoke-WebRequest https://octopusdeploy.com/download/upgrade/v3 -UseBasicParsing | ConvertFrom-Json\r\n$version = $versions[-1].Version\r\n$tempFile = [System.IO.Path]::GetTempFileName()\r\n\r\nWrite-Host \"Downloading Octopus $version\"\r\ntry\r\n{\r\n    (New-Object System.Net.WebClient).DownloadFile(\"https://download.octopusdeploy.com/octopus/Octopus.$version-x64.msi\", $tempFile)\r\n}\r\ncatch\r\n{\r\n    echo $_.Exception|format-list -force\r\n}\r\n\r\nWrite-Host \"Stopping Server\"\r\n. 'C:\\Program Files\\Octopus Deploy\\Octopus\\Octopus.Server.exe' service --stop --console --instance $InstanceName\r\n\r\nWrite-Host \"Installing\"\r\nmsiexec /i $tempFile /quiet | Out-Null\r\n\r\nWrite-Host \"Deleting installer\"\r\nRemove-Item $tempFile\r\n\r\nWrite-Host \"Starting Server\"\r\n. 'C:\\Program Files\\Octopus Deploy\\Octopus\\Octopus.Server.exe' service --start --console --instance $InstanceName\r\n\r\n"
+  },
+  "Parameters": [
+    {
+      "Id": "41442ee8-d56a-4a03-8c4b-af4c02245d9e",
+      "Name": "InstanceName",
+      "Label": "Instance Name",
+      "HelpText": "The name of your octopus instance. For the default instance use `OctopusServer`.",
+      "DefaultValue": "OctopusServer",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    }
+  ],
+  "LastModifiedBy": "droyad",
+  "$Meta": {
+    "ExportedAt": "2016-12-13T04:31:08.416Z",
+    "OctopusVersion": "3.7.5",
+	  "Type": "ActionTemplate"
+  },
+  "Category": "octopus"
+}


### PR DESCRIPTION
This step downloads the latest version of Octopus Server and upgrades an existing instance. Run this step on a tentacle that has privileges to install software and start/stop services on the target server.

**Run this after a database backup step**

To Use:
- Install a tentacle on the Octopus Server machine with privileges to install software and start/stop services
- Add that tentacle to an environment and with a unique role
- Setup a project for the upgrade process
- Add a database backup step for your Octopus Server database
- Add this step, selecting it to run on just the role previously configured
- Create a release
- Deploy that release whenever an upgrade is needed

NB: The deployment will show as "Timed Out" when the server comes back online