### PR TITLE
optional permissions reset for transaction queue

### DIFF
--- a/step-templates/msmq-create-transactional-queue.json
+++ b/step-templates/msmq-create-transactional-queue.json
@@ -1,11 +1,11 @@
 {
-  "Id": "c4f9c69a-b18b-44e4-b86d-e733f7527cb8",
+  "Id": "4c22f201-c634-4a22-aa55-ae24dc83d588",
   "Name": "MSMQ - Create Transactional Queue",
   "Description": "Create one or more MSMQ transactional queues and configure permissions.",
   "ActionType": "Octopus.Script",
-  "Version": 6,
+  "Version": 7,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n        \n        if($resetPermissions)\n        {\n            foreach($domain in $resetDomains.split(\";\"))\n            {\n                # reset permissions\n                $QueuePermissions = $thisQueue | Get-MsmqQueueACL\n                foreach ($AccessItem in $QueuePermissions)\n                {\n                    $domain = \"$($domain)*\" #append * to end of domain\n                    if ($AccessItem.AccountName -like $domain){\n                    Write-Output \"Resetting Permissions for domain: \" $AccessItem.AccountName \n                    #Something like\n                    $thisQueue | Set-MsmqQueueACL -UserName $AccessItem.AccountName -Remove $AccessItem.Right | Out-Null\n                  }\n                }\n            }\n        }\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
+    "Octopus.Action.Script.ScriptBody": "#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n        \n        if($ResetPermissions)\n        {\n            foreach($domain in $ResetDomains.split(\";\"))\n            {\n                # reset permissions\n                $QueuePermissions = $thisQueue | Get-MsmqQueueACL\n                foreach ($AccessItem in $QueuePermissions)\n                {\n                    $domain = \"$($domain)*\" #append * to end of domain\n                    if ($AccessItem.AccountName -like $domain){\n                    Write-Output \"Resetting Permissions for domain: \" $AccessItem.AccountName \n                    #Something like\n                    $thisQueue | Set-MsmqQueueACL -UserName $AccessItem.AccountName -Remove $AccessItem.Right | Out-Null\n                  }\n                }\n            }\n        }\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
@@ -34,7 +34,7 @@
     },
     {
       "Id": "3e2e1512-6f75-4e36-80cc-d350a3563a09",
-      "Name": "$MSMQPermAllow",
+      "Name": "MSMQPermAllow",
       "Label": "Allowed permissions",
       "HelpText": "Permissions granted to the queue users, separated by semicolons. Example: _DeleteMessage;PeekMessage;ReceiveMessage_",
       "DefaultValue": "DeleteMessage;PeekMessage;ReceiveMessage;WriteMessage",
@@ -42,7 +42,8 @@
       "Links": {}
     },
     {
-      "Name": "$MSMQPermDeny",
+      "Id": "2063989e-587f-4787-b3ce-6865501316b2",
+      "Name": "MSMQPermDeny",
       "Label": "Denied permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
       "DefaultValue": "TakeQueueOwnership",
@@ -50,6 +51,7 @@
       "Links": {}
     },
     {
+      "Id": "42ec591d-9631-4ff4-ac56-94a1ac7c5994",
       "Name": "MSMQAdminUsers",
       "Label": "Admin queue users",
       "HelpText": "Users with access to the queue separated by semicolons. Example: _DOMAIN\\User1;DOMAIN\\User2_",
@@ -58,6 +60,7 @@
       "Links": {}
     },
     {
+      "Id": "47dee55f-9d5a-4798-a61c-b4c7350774a5",
       "Name": "MSMQPermAdminAllow",
       "Label": "Allowed admin permissions",
       "HelpText": "Permissions granted to the queue admin users, separated by semicolons. Example: _DeleteMessage;PeekMessage;ReceiveMessage_",
@@ -66,6 +69,7 @@
       "Links": {}
     },
     {
+      "Id": "949b3efb-5fb7-4350-8336-1dfff67172aa",
       "Name": "MSMQPermAdminDeny",
       "Label": "Denied admin permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
@@ -74,7 +78,8 @@
       "Links": {}
     },
     {
-      "Name": "$resetPermissions",
+      "Id": "2be54d36-3b81-4a39-8685-adfe8d98ebbb",
+      "Name": "ResetPermissions",
       "Label": "Reset Permissions",
       "HelpText": "Remove all existing permissions from the Queue if it already exists",
       "DefaultValue": "false",
@@ -84,7 +89,8 @@
       "Links": {}
     },
     {
-      "Name": "$resetDomains",
+      "Id": "54143721-075f-4270-89c1-154719ee0b3c",
+      "Name": "ResetDomains",
       "Label": "Reset Permissions Domains",
       "HelpText": "This is used if Reset Permissions is set.\nExample: YOURDOMAIN1;YOURDOMAIN2",
       "DefaultValue": null,
@@ -94,10 +100,10 @@
       "Links": {}
     }
   ],
-  "LastModifiedOn": "2016-12-14T14:11:17.934Z",
+  "LastModifiedOn": "2016-12-15T09:41:00.000Z",
   "LastModifiedBy": "fireydude",
   "$Meta": {
-    "ExportedAt": "2016-12-14T14:11:17.934Z",
+    "ExportedAt": "2016-12-15T09:39:26.862Z",
     "OctopusVersion": "3.5.7",
     "Type": "ActionTemplate"
   },

--- a/step-templates/msmq-create-transactional-queue.json
+++ b/step-templates/msmq-create-transactional-queue.json
@@ -1,69 +1,104 @@
 {
-  "Id": "4c22f201-c634-4a22-aa55-ae24dc83d588",
+  "Id": "c4f9c69a-b18b-44e4-b86d-e733f7527cb8",
   "Name": "MSMQ - Create Transactional Queue",
   "Description": "Create one or more MSMQ transactional queues and configure permissions.",
   "ActionType": "Octopus.Script",
   "Version": 6,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        #keep rolling\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n        \n        if($resetPermissions)\n        {\n            foreach($domain in $resetDomains.split(\";\"))\n            {\n                # reset permissions\n                $QueuePermissions = $thisQueue | Get-MsmqQueueACL\n                foreach ($AccessItem in $QueuePermissions)\n                {\n                    $domain = \"$($domain)*\" #append * to end of domain\n                    if ($AccessItem.AccountName -like $domain){\n                    Write-Output \"Resetting Permissions for domain: \" $AccessItem.AccountName \n                    #Something like\n                    $thisQueue | Set-MsmqQueueACL -UserName $AccessItem.AccountName -Remove $AccessItem.Right | Out-Null\n                  }\n                }\n            }\n        }\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
+      "Id": "35154cac-d005-4a7b-85c9-8eab276e726b",
       "Name": "$MSMQQueues",
       "Label": "Queue names",
       "HelpText": "Queue names, separated by semicolons. Example: _Queue1;Queue2;Queue3_",
       "DefaultValue": "",
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
+      "Id": "6f3a90b7-df04-4884-9cd1-f04ad7a1f97b",
       "Name": "$MSMQUsers",
       "Label": "Queue users",
       "HelpText": "Users with access to the queue separated by semicolons. Example: _DOMAIN\\User1;DOMAIN\\User2_",
       "DefaultValue": "",
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
+      "Id": "3e2e1512-6f75-4e36-80cc-d350a3563a09",
       "Name": "$MSMQPermAllow",
       "Label": "Allowed permissions",
       "HelpText": "Permissions granted to the queue users, separated by semicolons. Example: _DeleteMessage;PeekMessage;ReceiveMessage_",
       "DefaultValue": "DeleteMessage;PeekMessage;ReceiveMessage;WriteMessage",
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
       "Name": "$MSMQPermDeny",
       "Label": "Denied permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
       "DefaultValue": "TakeQueueOwnership",
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
       "Name": "MSMQAdminUsers",
       "Label": "Admin queue users",
       "HelpText": "Users with access to the queue separated by semicolons. Example: _DOMAIN\\User1;DOMAIN\\User2_",
       "DefaultValue": null,
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
       "Name": "MSMQPermAdminAllow",
       "Label": "Allowed admin permissions",
       "HelpText": "Permissions granted to the queue admin users, separated by semicolons. Example: _DeleteMessage;PeekMessage;ReceiveMessage_",
       "DefaultValue": "FullControl",
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
     },
     {
       "Name": "MSMQPermAdminDeny",
       "Label": "Denied admin permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
       "DefaultValue": null,
-      "DisplaySettings": {}
+      "DisplaySettings": {},
+      "Links": {}
+    },
+    {
+      "Name": "$resetPermissions",
+      "Label": "Reset Permissions",
+      "HelpText": "Remove all existing permissions from the Queue if it already exists",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    },
+    {
+      "Name": "$resetDomains",
+      "Label": "Reset Permissions Domains",
+      "HelpText": "This is used if Reset Permissions is set.\nExample: YOURDOMAIN1;YOURDOMAIN2",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedBy": "RehanSaeed",
+  "LastModifiedOn": "2016-12-14T14:11:17.934Z",
+  "LastModifiedBy": "fireydude",
   "$Meta": {
-    "ExportedAt": "2016-01-21T17:32:57.038+00:00",
-    "OctopusVersion": "3.2.19",
+    "ExportedAt": "2016-12-14T14:11:17.934Z",
+    "OctopusVersion": "3.5.7",
     "Type": "ActionTemplate"
   },
   "Category": "windows"


### PR DESCRIPTION
# MSMQ - Create Transactional Queue

_Remove additional permission which may have been added to the Queue without deleting any of the existing messages._

- A new checkbox has been added which will remove existing permissions for a Queue if it already exists
- Only users which belong to the specified domain will have their permissions removed

Deleting and re-creating the Queue may result in you loosing messages.