### PR TITLE
Trivial/minor typos fix

### DIFF
--- a/step-templates/Azure-Backup-TableStorage-to-Blob.json
+++ b/step-templates/Azure-Backup-TableStorage-to-Blob.json
@@ -7,16 +7,16 @@
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "if($IsEnabled -eq \"True\")\r\n{\r\nWrite-Output \"Starting Backup the Azure table 'https://$sourceStorageAccoutName.table.core.windows.net/$sourceTableName' to the Blob 'https://$destinationStorageAccoutName.blob.core.windows.net/$destinationBlobContainer'\"\r\n\r\n& \"${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Azure\\AzCopy\\azCopy.exe\" `\r\n    /Source:https://$sourceStorageAccoutName.table.core.windows.net/$sourceTableName/ `\r\n    /Dest:https://$destinationStorageAccoutName.blob.core.windows.net/$sourceStorageAccoutName-$sourceTableName/ `\r\n    /SourceKey:$sourceStorageAccountKey `\r\n    /Destkey:$destinationStorageAccountKey `\r\n    /y\r\n\r\nWrite-Output \"Backup Completed\"\r\n}\r\nelse\r\n{\r\n    Write-Output \"This Step is disabled\"\r\n}",
+    "Octopus.Action.Script.ScriptBody": "if($IsEnabled -eq \"True\")\r\n{\r\nWrite-Output \"Starting Backup the Azure table 'https://$sourceStorageAccountName.table.core.windows.net/$sourceTableName' to the Blob 'https://$destinationStorageAccoutName.blob.core.windows.net/$destinationBlobContainer'\"\r\n\r\n& \"${Env:ProgramFiles(x86)}\\Microsoft SDKs\\Azure\\AzCopy\\azCopy.exe\" `\r\n    /Source:https://$sourceStorageAccountName.table.core.windows.net/$sourceTableName/ `\r\n    /Dest:https://$destinationStorageAccoutName.blob.core.windows.net/$sourceStorageAccountName-$sourceTableName/ `\r\n    /SourceKey:$sourceStorageAccountKey `\r\n    /Destkey:$destinationStorageAccountKey `\r\n    /y\r\n\r\nWrite-Output \"Backup Completed\"\r\n}\r\nelse\r\n{\r\n    Write-Output \"This Step is disabled\"\r\n}",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.NuGetFeedId": null,
     "Octopus.Action.Package.NuGetPackageId": null
   },
   "Parameters": [
     {
-      "Name": "sourceStorageAccoutName",
-      "Label": "Source Storage Accout Name",
-      "HelpText": "Storage Account Key of the source storage account",
+      "Name": "sourceStorageAccountName",
+      "Label": "Source Storage Account Name",
+      "HelpText": "Storage Account Name of the source storage account",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"


### PR DESCRIPTION
Fixed a typo in the `ScriptBody`, Parameters `Name`, `Label` & `HelpText`.