### PR TITLE
Make "IIS Website - Stop" synchronous like "IIS AppPool - Stop"

### DIFF
--- a/step-templates/iis-website-stop.json
+++ b/step-templates/iis-website-stop.json
@@ -1,27 +1,48 @@
 {
-  "Id": "9eb40453-ac5d-4cb0-8666-046ff6305a3a",
+  "Id": "6eed1052-dd7c-4189-b03a-eeea93421ae6",
   "Name": "IIS Website - Stop",
   "Description": "Stops a website in IIS.",
   "ActionType": "Octopus.Script",
-  "Version": 6,
+  "Version": 7,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Load IIS module:\nImport-Module WebAdministration\n\n# Set a name of the site we want to stop\n$webSiteName = $OctopusParameters['webSiteName']\n\n# Get web site object\n$webSite = Get-Item \"IIS:\\Sites\\$webSiteName\"\n\nWrite-Output \"Stopping IIS web site $webSiteName\"\n$webSite.Stop()",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "# Load IIS module:\r\nImport-Module WebAdministration\r\n\r\n# Get WebSite Name\r\n$webSiteName = $OctopusParameters['webSiteName']\r\n# Get the number of retries\r\n$retries = $OctopusParameters['webSiteCheckRetries']\r\n# Get the number of attempts\r\n$delay = $OctopusParameters['webSiteCheckDelay']\r\n\r\n# Check if exists\r\nif(Test-Path IIS:\\Sites\\$webSiteName) {\r\n\r\n    # Stop Website if not already stopped\r\n    if ((Get-WebSiteState $webSiteName).Value -ne \"Stopped\") {\r\n        Write-Output \"Stopping IIS Website $webSiteName\"\r\n        Stop-WebSite $webSiteName\r\n    \r\n        $state = (Get-WebSiteState $webSiteName).Value\r\n        $counter = 1\r\n        \r\n        # Wait for the Website to the \"Stopped\" before proceeding\r\n        do{ \r\n            $state = (Get-WebSiteState $webSiteName).Value\r\n            Write-Output \"$counter/$retries Waiting for IIS Website $webSiteName to shut down completely. Current status: $state\"\r\n            $counter++\r\n            Start-Sleep -Milliseconds $delay\r\n        }\r\n        while($state -ne \"Stopped\" -and $counter -le $retries)  \r\n        \r\n        # Throw an error if the Website is not stopped\r\n        if($counter -gt $retries) { \r\n            throw \"Could not shut down IIS Website $webSiteName. `nTry to increase the number of retries ($retries) or delay between attempts ($delay milliseconds).\" }\r\n    }\r\n}\r\nelse {\r\n    Write-Output \"IIS Website $webSiteName doesn't exist\"\r\n}",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.NuGetFeedId": null,
+    "Octopus.Action.Package.NuGetPackageId": null
   },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
+  "Parameters": [{
       "Name": "WebsiteName",
       "Label": "Website name",
       "HelpText": "The name of the site in IIS",
-      "DefaultValue": null
+      "DefaultValue": null,
+      "DisplaySettings": {}
+    },
+    {
+      "Name": "WebSiteCheckDelay",
+      "Label": "Status check interval",
+      "HelpText": "The delay, in milliseconds, between each attempt to query the website to see if its status is \"Stopped\"",
+      "DefaultValue": "500",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "WebSiteCheckRetries",
+      "Label": "Status check retries",
+      "HelpText": "The number of retries before an error is thrown.",
+      "DefaultValue": "20",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
-  "LastModifiedOn": "2014-05-16T06:17:00.914+00:00",
-  "LastModifiedBy": "pascaln2",
+  "LastModifiedOn": "2017-02-09T23:04:46.440Z",
+  "LastModifiedBy": "novascreen",
   "$Meta": {
-    "ExportedAt": "2014-05-16T06:22:19.434+00:00",
-    "OctopusVersion": "2.4.5.46",
+    "ExportedAt": "2017-02-09T23:04:46.440Z",
+    "OctopusVersion": "3.3.17",
     "Type": "ActionTemplate"
   },
   "Category": "iis"


### PR DESCRIPTION
I had the problem that the Website wasn't stopped completely before the next step. So i followed the example of https://library.octopus.com/step-templates/3aaf34a5-90eb-4ea1-95db-15ec93c1e54d/actiontemplate-iis-apppool-stop to apply the same technique for waiting until the Website is stopped before completing the step.