### PR TITLE
Add links in slack message back to Octopus server

### DIFF
--- a/step-templates/slack-notify-deployment.json
+++ b/step-templates/slack-notify-deployment.json
@@ -3,9 +3,9 @@
   "Name": "Slack - Notify Deployment",
   "Description": "Notifies Slack of deployment status. Uses the Octopus Deploy system variable to determine whether a deployment was successful.",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 5,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "function Slack-Rich-Notification ($notification)\n{\n    $payload = @{\n        channel = $OctopusParameters['Channel']\n        username = $OctopusParameters['Username'];\n        icon_url = $OctopusParameters['IconUrl'];\n        attachments = @(\n            @{\n            fallback = $notification[\"fallback\"];\n            color = $notification[\"color\"];\n            fields = @(\n                @{\n                title = $notification[\"title\"];\n                value = $notification[\"value\"];\n                });\n            };\n        );\n    }\n\n    Invoke-RestMethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['HookUrl']  -ContentType 'application/json'\n}\n\n$IncludeMachineName = [boolean]::Parse($OctopusParameters['IncludeMachineName']);\nif ($IncludeMachineName) {\n    $MachineName = $OctopusParameters['Octopus.Machine.Name'];\n    $FormattedMachineName = \"($MachineName)\";\n}\n\nif ($OctopusParameters['Octopus.Deployment.Error'] -eq $null){\n    Slack-Rich-Notification @{\n        title = \"Success\";\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName $OctopusDeploymentTenantName $FormattedMachineName\";\n        fallback = \"Deployed $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName successfully\";\n        color = \"good\";\n    };\n} else {\n    Slack-Rich-Notification @{\n        title = \"Failed\";\n        value = \"Deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName $OctopusDeploymentTenantName $FormattedMachineName\";\n        fallback = \"Failed to deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName\";\n        color = \"danger\";\n    };\n}",
+    "Octopus.Action.Script.ScriptBody": "function Slack-Rich-Notification ($notification)\n{\n    $payload = @{\n        channel = $OctopusParameters['Channel']\n        username = $OctopusParameters['Username'];\n        icon_url = $OctopusParameters['IconUrl'];\n        attachments = @(\n            @{\n            fallback = $notification[\"fallback\"];\n            color = $notification[\"color\"];\n            fields = @(\n                @{\n                title = $notification[\"title\"];\n                title_link = $notification[\"title_link\"];\n                value = $notification[\"value\"];\n                });\n            };\n        );\n    }\n\n    Invoke-RestMethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['HookUrl']  -ContentType 'application/json'\n}\n\n$IncludeMachineName = [boolean]::Parse($OctopusParameters['IncludeMachineName']);\nif ($IncludeMachineName) {\n    $MachineName = $OctopusParameters['Octopus.Machine.Name'];\n    if ($MachineName) {\n      $FormattedMachineName = \"($MachineName)\";\n    }\n}\n\nif ($OctopusParameters['Octopus.Deployment.Error'] -eq $null){\n    Slack-Rich-Notification @{\n        title = \"Success\";\n        title_link = \"$OctopusWebBaseUrl$OctopusWebDeploymentLink\";\n        value = \"Deploy <$OctopusWebBaseUrl$OctopusWebProjectLink|$OctopusProjectName> release <$OctopusWebBaseUrl$OctopusWebReleaseLink|$OctopusReleaseNumber> to $OctopusEnvironmentName $OctopusActionTargetRoles $OctopusDeploymentTenantName $FormattedMachineName\";\n        fallback = \"Deployed $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName successfully\";\n        color = \"good\";\n    };\n} else {\n    Slack-Rich-Notification @{\n        title = \"Failed\";\n        title_link = \"$OctopusWebBaseUrl$OctopusWebDeploymentLink\";\n        value = \"Deploy <$OctopusWebBaseUrl$OctopusWebProjectLink|$OctopusProjectName> release <$OctopusWebBaseUrl$OctopusWebReleaseLink|$OctopusReleaseNumber> to $OctopusEnvironmentName $OctopusActionTargetRoles $OctopusDeploymentTenantName $FormattedMachineName\";\n        fallback = \"Failed to deploy $OctopusProjectName release $OctopusReleaseNumber to $OctopusEnvironmentName\";\n        color = \"danger\";\n    };\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -48,11 +48,11 @@
       }
     }
   ],
-  "LastModifiedOn": "2016-09-23T16:58:52.884+00:00",
-  "LastModifiedBy": "jgbright",
+  "LastModifiedOn": "2017-02-18T19:11:12.785Z",
+  "LastModifiedBy": "whereisaaron",
   "$Meta": {
-    "ExportedAt": "2016-09-23T16:58:52.884+00:00",
-    "OctopusVersion": "2.6.5.1010",
+    "ExportedAt": "2017-02-18T19:11:12.785Z",
+    "OctopusVersion": "3.3.2",
     "Type": "ActionTemplate"
   },
   "Category": "slack"


### PR DESCRIPTION
-  Add links back to project and release on Octopus Deploy server
-  Include target roles in message
-  Check if target machine is blank (e.g. if step targets all roles and is running on deployment server)