### PR TITLE
Handle optional parameters in drop-database-smo task

### DIFF
--- a/step-templates/sql-smo-drop-database.json
+++ b/step-templates/sql-smo-drop-database.json
@@ -3,9 +3,9 @@
   "Name": "SQL - Drop Database Using SMO",
   "Description": "This uses Sql Management Objects to drop a database if it exists. If the username and password are both empty then it will attempt a trusted connection.",
   "ActionType": "Octopus.Script",
-  "Version": 7,
+  "Version": 8,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.SMO\") | out-null\n\ntry\n{    \n    $server = new-object ('Microsoft.SqlServer.Management.Smo.Server') $SqlServer\n    \n    if ($SqlUsername -eq \"\" -and $SqlPassword -eq \"\")\n    {\n        $server.ConnectionContext.LoginSecure = $true\n    } else {\n        $server.ConnectionContext.LoginSecure = $false\n        $server.ConnectionContext.set_Login($SqlUsername)\n        $server.ConnectionContext.set_Password($SqlPassword)      \n    }\n\n\tif ($server.databases[$SqlDatabase] -ne $null)\n\t{\n    \t$server.killallprocesses($SqlDatabase)\n    \t$server.databases[$SqlDatabase].drop()\n\t}\n}\ncatch\n{    \n    $error[0] | format-list -force\n    Exit 1\n}\n    ",
+    "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.SMO\") | out-null\n\ntry\n{    \n    $server = new-object ('Microsoft.SqlServer.Management.Smo.Server') $SqlServer\n    \n    if (!$SqlUsername -and !$SqlPassword)\n    {\n        $server.ConnectionContext.LoginSecure = $true\n    } else {\n        $server.ConnectionContext.LoginSecure = $false\n        $server.ConnectionContext.set_Login($SqlUsername)\n        $server.ConnectionContext.set_Password($SqlPassword)      \n    }\n\n\tif ($server.databases[$SqlDatabase] -ne $null)\n\t{\n    \t$server.killallprocesses($SqlDatabase)\n    \t$server.databases[$SqlDatabase].drop()\n\t}\n}\ncatch\n{    \n    $error[0] | format-list -force\n    Exit 1\n}\n    ",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},


### PR DESCRIPTION
I ran into an issue with the "SQL - Drop Database Using SMO" task as `$null` was passed into step but the check for optional username and password parameters was `if ($SqlUsername -eq "" -and $SqlPassword -eq "")`.

Updated check to be `if (!$SqlUsername -and !$SqlPassword)` to handle null and empty string.

Originally discussed in an [issue](http://help.octopusdeploy.com/discussions/problems/53063-optional-parameters-are-null-rather-than) on forum.