### PR TITLE
Update url reservation template for handling username with spaces

### DIFF
--- a/step-templates/network-add-url-reservation.json
+++ b/step-templates/network-add-url-reservation.json
@@ -3,9 +3,9 @@
   "Name": "Network - Add URL Reservation",
   "Description": "Creates an HTTP URL reservation (ACL) using NETSH.",
   "ActionType": "Octopus.Script",
-  "Version": 9,
+  "Version": 10,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$url = $OctopusParameters['Url']\n$user = $OctopusParameters['User']\n$delegate = if ('True' -eq $OctopusParameters['Delegate']) { 'yes' } else { 'no'}\n\n$delacl = \"http delete urlacl url=$url\"\n$addacl = \"http add urlacl url=$url user=$user delegate=$delegate\"\n\nwrite-host \"Removing ACL: $delacl\"\n$delacl | netsh | out-host\n\nwrite-host \"Creating ACL: $addacl\"\n$addacl | netsh | out-host\n",
+    "Octopus.Action.Script.ScriptBody": "$url = $OctopusParameters['Url']\n$user = $OctopusParameters['User']\n$delegate = if ('True' -eq $OctopusParameters['Delegate']) { 'yes' } else { 'no'}\n\n$delacl = \"http delete urlacl url=$url\"\n$addacl = \"http add urlacl url=$url user=\"\"$user\"\" delegate=$delegate\"\n\nwrite-host \"Removing ACL: $delacl\"\n$delacl | netsh | out-host\n\nwrite-host \"Creating ACL: $addacl\"\n$addacl | netsh | out-host\n",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -29,7 +29,7 @@
       "DefaultValue": ""
     }
   ],
-  "LastModifiedOn": "2014-05-20T22:24:12.131+00:00",
+  "LastModifiedOn": "2017-04-07T09:02:31.100+00:00",
   "LastModifiedBy": "jonnii",
   "$Meta": {
     "ExportedAt": "2014-05-27T18:53:32.929+00:00",


### PR DESCRIPTION
Task was failing with error _parameter incorrect_ when trying to assign urlacl reservation for user "NT Authority\Local Service".

Resolved issue by updating script to wrap `username` parameter in quotes so it becomes:

`http add urlacl url=http://+:8888/ user="NT Authority\Local Service" -delegate=no` 
rather than
`http add urlacl url=http://+:8888/ user=NT Authority\Local Service -delegate=no` 