### PR TITLE
Add encoding to File System - Create File

### DIFF
--- a/step-templates/file-system-create-file.json
+++ b/step-templates/file-system-create-file.json
@@ -3,9 +3,9 @@
   "Name": "File System - Create File",
   "Description": "Creates a file, using the full path that is provided.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$filePath = $OctopusParameters['FilePath']\n$fileContent = $OctopusParameters['FileContent']\n\nNew-Item -ItemType file -Path $filePath -Value '' -force\n\nif(![string]::IsNullOrEmpty($fileContent))\n{\n  Set-Content -path $filePath -value $fileContent\n}",
+    "Octopus.Action.Script.ScriptBody": "$filePath = $OctopusParameters['FilePath']\n$fileContent = $OctopusParameters['FileContent']\n$encoding = $OctopusParameters['Encoding']\n\nNew-Item -ItemType file -Path $filePath -Value '' -force\n\nif(![string]::IsNullOrEmpty($fileContent))\n{\n  Set-Content -path $filePath -value $fileContent -encoding $encoding\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -27,13 +27,26 @@
       "DisplaySettings": {
         "Octopus.ControlType": "MultiLineText"
       }
+    },
+    {
+      "Id": "43aff0e0-e7ad-40cb-ae54-a49ca03adfc5",
+      "Name": "Encoding",
+      "Type": "String",
+      "Label": "",
+      "HelpText": null,
+      "DefaultValue": "UTF8",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "UTF8|UTF-8\nASCII|ASCII (7-bit)\nBigEndianUnicode|UTF-16 (big-endian)\nByte|Encodes as byte sequence\nUnicode|UTF-16 (little-endian)\nUTF7|UTF-7\nUnknown|Binary"
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedOn": "2015-09-22T15:42:28.939+00:00",
-  "LastModifiedBy": "DBloch",
+  "LastModifiedOn": "2017-04-28T10:48:34.361Z",
+  "LastModifiedBy": "carlpett",
   "$Meta": {
-    "ExportedAt": "2015-09-22T15:36:30.234+00:00",
-    "OctopusVersion": "3.0.24.0",
+    "ExportedAt": "2017-04-28T10:48:34.361Z",
+    "OctopusVersion": "3.11.15",
     "Type": "ActionTemplate"
   },
   "Category": "filesystem"


### PR DESCRIPTION
Fixes #519.

Adds an `Encoding` dropdown with the valid values for the `Set-Content` cmdlet.