### PR TITLE
Fix for misnamed parameters in HTTP - Test Url Step Template

### DIFF
--- a/step-templates/http-test-url.json
+++ b/step-templates/http-test-url.json
@@ -40,9 +40,9 @@
     },
     {
       "Id": "ac0b303c-0c59-4776-be21-d93ebe9e28e7",
-      "Name": "BasicAuthUsername",
+      "Name": "AuthUsername",
       "Label": "Username",
-      "HelpText": "Username for Basic authentication. Leave blank to use Anonymous.",
+      "HelpText": "Username for authentication. Leave blank to use Anonymous.",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -50,9 +50,9 @@
     },
     {
       "Id": "38eae17a-3098-48df-b8dc-96c3185f9f40",
-      "Name": "BasicAuthPassword",
+      "Name": "AuthPassword",
       "Label": "Password",
-      "HelpText": "Password for Basic authentication. Leave blank for Anonymous.",
+      "HelpText": "Password for authentication. Leave blank for Anonymous.",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
@@ -62,7 +62,7 @@
       "Id": "60fe87fe-e96d-448e-94fa-f2ce4bfbaf3a",
       "Name": "UseWindowsAuth",
       "Label": "Use Windows Authentication",
-      "HelpText": "Should the request be made passing windows authentication (kerberos) credentials",
+      "HelpText": "Should the request be made passing windows authentication (kerberos) credentials otherwise uses basic authentication",
       "DefaultValue": "False",
       "DisplaySettings": {
         "Octopus.ControlType": "Checkbox"
@@ -79,9 +79,9 @@
       }
     }
   ],
-  "LastModifiedBy": "waynebrantley",
+  "LastModifiedBy": "georg.mueller",
   "$Meta": {
-    "ExportedAt": "2016-09-26T12:08:19.087+00:00",
+    "ExportedAt": "2017-05-08T12:00:00.000+00:00",
     "OctopusVersion": "3.4.10",
     "Type": "ActionTemplate"
   },


### PR DESCRIPTION
The HTTP - Test Url Step Template has a bug when using it with authentication. The Username and Password Parameters are misnamed