### PR TITLE
Allow assigning multiple roles to a user and fail the script on exception

### DIFF
--- a/step-templates/sql-smo-create-login-and-user.json
+++ b/step-templates/sql-smo-create-login-and-user.json
@@ -1,11 +1,11 @@
 {
   "Id": "7ed93dfa-b137-4341-9c6c-84fa0565d865",
-  "Name": "Create Database Login and User using SMO",
+  "Name": "SQL - Create Database Login and User using SMO",
   "Description": "Requires SMO to be installed on the machine where this step will be run.",
   "ActionType": "Octopus.Script",
-  "Version": 6,
+  "Version": 7,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.SMO\") | out-null\r\n\r\ntry\r\n{    \r\n    $server = new-object ('Microsoft.SqlServer.Management.Smo.Server') $SqlServer\r\n    \r\n    $server.ConnectionContext.LoginSecure = $true \r\n\r\n    if ($server.Logins.Contains($LoginName))  \r\n    {\r\n        write-host \"Login $LoginName already exists\"   \r\n    }\r\n    else \r\n    {\r\n        write-host \"Login does not exist, creating\"\r\n        $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $SqlServer, $LoginName\r\n        $login.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser\r\n        $login.PasswordExpirationEnabled = $false\r\n        $login.Create()\r\n        Write-Host(\"Login $LoginName created successfully.\")\r\n    }\r\n\r\n    if($server.Databases.Contains($SqlDatabase)) \r\n    {\r\n        $database = $server.Databases[$SqlDatabase]\r\n        \r\n        if (!$database.Users[$LoginName])\r\n        {\r\n            $dbUser = New-Object -TypeName Microsoft.SqlServer.Management.Smo.User -ArgumentList $database, $LoginName\r\n            $dbUser.Login = $LoginName\r\n            $dbUser.Create()\r\n            Write-Host(\"User $dbUser created successfully.\")\r\n\r\n            if($SqlRole -ne $null) \r\n            {\r\n                #assign database role for a new user\r\n                $dbrole = $database.Roles[$SqlRole]\r\n                $dbrole.AddMember($LoginName)\r\n                $dbrole.Alter()\r\n                Write-Host(\"User $LoginName successfully added to $SqlRole role.\")\r\n            }\r\n        }\r\n    }\r\n    else \r\n    {\r\n        write-host \"Database $SqlDatabase does not exist\"\r\n    }\r\n}\r\ncatch\r\n{    \r\n    $error[0] | format-list -force\r\n    #Exit 1\r\n}",
+    "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.SMO\") | out-null\r\n\r\ntry\r\n{    \r\n    $server = new-object ('Microsoft.SqlServer.Management.Smo.Server') $SqlServer\r\n    \r\n    $server.ConnectionContext.LoginSecure = $true \r\n\r\n    if ($server.Logins.Contains($LoginName))  \r\n    {\r\n        write-host \"Login $LoginName already exists\"   \r\n    }\r\n    else \r\n    {\r\n        write-host \"Login does not exist, creating\"\r\n        $login = New-Object -TypeName Microsoft.SqlServer.Management.Smo.Login -ArgumentList $SqlServer, $LoginName\r\n        $login.LoginType = [Microsoft.SqlServer.Management.Smo.LoginType]::WindowsUser\r\n        $login.PasswordExpirationEnabled = $false\r\n        $login.Create()\r\n        Write-Host(\"Login $LoginName created successfully.\")\r\n    }\r\n\r\n    if($server.Databases.Contains($SqlDatabase)) \r\n    {\r\n        $database = $server.Databases[$SqlDatabase]\r\n        \r\n        if (!$database.Users[$LoginName])\r\n        {\r\n            $dbUser = New-Object -TypeName Microsoft.SqlServer.Management.Smo.User -ArgumentList $database, $LoginName\r\n            $dbUser.Login = $LoginName\r\n            $dbUser.Create()\r\n            Write-Host(\"User $dbUser created successfully.\")\r\n\r\n            if($SqlRole -ne $null) \r\n            {\r\n                $SqlRole.Split(\",\") | ForEach {\r\n                    #assign database role for a new user\r\n                    $dbrole = $database.Roles[$_]\r\n                    $dbrole.AddMember($LoginName)\r\n                    $dbrole.Alter()\r\n                    Write-Host(\"User $LoginName successfully added to $_ role.\")\r\n                }\r\n            }\r\n        }\r\n    }\r\n    else \r\n    {\r\n        write-host \"Database $SqlDatabase does not exist\"\r\n    }\r\n}\r\ncatch\r\n{    \r\n    $error[0] | format-list -force\r\n    Exit 1\r\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -39,19 +39,19 @@
     },
     {
       "Name": "SqlRole",
-      "Label": "Database Role Name",
-      "HelpText": "We default to db_owner, you might want to change this to suit your needs.",
+      "Label": "Database Role Names",
+      "HelpText": "We default to `db_owner`, you might want to change this to suit your needs. You may specify multiple roles separated by a comma (e.g. `db_datareader,db_datawriter`)",
       "DefaultValue": "db_owner",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     }
   ],
-  "LastModifiedOn": "2015-06-05T08:54:47.852+00:00",
-  "LastModifiedBy": "lavaeater",
+  "LastModifiedOn": "2017-05-22T08:51:35.841+00:00",
+  "LastModifiedBy": "trevorpilley",
   "$Meta": {
-    "ExportedAt": "2015-06-05T08:54:50.228+00:00",
-    "OctopusVersion": "2.6.5.1010",
+    "ExportedAt": "2017-05-22T08:51:35.841Z",
+    "OctopusVersion": "3.12.5",
     "Type": "ActionTemplate"
   },
   "Category": "sql"


### PR DESCRIPTION
We have many apps where we prefer to assign a few different roles (e.g. db_datareader and db_datawriter) so I propose an update which allows multiple roles if comma separated. Also I've uncommented the Exit 1 statement in the catch block, the script should fail the deployment in my opinion if it can't create the user or login otherwise you end up with a successful deployment which didn't actually succeed in one of the key steps.

---

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
