### PR TITLE
Lets Encrypt - Create SSL Certificate

### DIFF
--- a/step-templates/letsencrypt-create-ssl-certificate.json
+++ b/step-templates/letsencrypt-create-ssl-certificate.json
@@ -1,0 +1,92 @@
+{
+  "Id": "bc81b8a6-dc56-4769-87b5-650af7a38162",
+  "Name": "Lets Encrypt - Create SSL Certificate",
+  "Description": "Procures an X.509 SSL Certificate from the [Let’s Encrypt](https://letsencrypt.org) Certificate Authority using the [Automatic Certificate Management Environment (ACME)](https://ietf-wg-acme.github.io/acme/) protocol.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptBody": "<#\n ----- Lets Encrypt - Create SSL Certificate ----- \n    Paul Marston @paulmarsy (paul@marston.me)\nLinks\n    https://github.com/OctopusDeploy/Library/commits/master/step-templates/letsencrypt-create-ssl-certificate.json\n#>\n\n$ErrorActionPreference = 'Stop'\n\nfunction Get-OctopusSetting {\n    param([Parameter(Position = 0, Mandatory)][string]$Name, [Parameter(Position = 1)]$DefaultValue)\n    $formattedName = 'Octopus.Action.{0}' -f $Name\n    if ($OctopusParameters.ContainsKey($formattedName)) {\n        $value = $OctopusParameters[$formattedName]\n        if ($DefaultValue -is [int]) { return ([int]::Parse($value)) }\n        if ($DefaultValue -is [bool]) { return ([System.Convert]::ToBoolean($value)) }\n        if ($DefaultValue -is [array] -or $DefaultValue -is [hashtable] -or $DefaultValue -is [pscustomobject]) { return (ConvertFrom-Json -InputObject $value) }\n        return $value\n    }\n    else { return $DefaultValue }\n}\nfunction Test-String {\n    param([Parameter(Position=0)]$InputObject,[switch]$ForAbsence)\n\n    $hasNoValue = [System.String]::IsNullOrWhiteSpace($InputObject)\n    if ($ForAbsence) { $hasNoValue }\n    else { -not $hasNoValue }\n}\nfilter Out-Verbose {\n    Write-Verbose ($_ | Out-String)\n}\nfilter Out-Indented {\n    $_ | Out-String | % Trim | % Split \"`n\" | % { \"`t$_\" }  \n}\nif (!(Get-Module ACMESharp -ListAvailable)) {\n    Write-Host 'Installing ACME PowerShell Module...'\n    Install-Module -Name ACMESharp -AllowClobber -Force\n}\nWrite-Host 'Importing ACME PowerShell Module...'\nImport-Module ACMESharp\n\n$BaseService = Get-OctopusSetting BaseService 'LetsEncrypt'\nWrite-Host \"Initializing ACME Vault for $BaseService...\"\nInitialize-ACMEVault -BaseService $BaseService -Force\n\nWrite-Host 'Creating new registration...'\nNew-ACMERegistration -Contacts ('mailto:{0}' -f $Param_MailTo) -AcceptTos | Out-Indented\n\nWrite-Host \"Requesting Domain Identifier for $Param_Domain...\"\nNew-ACMEIdentifier -Dns $Param_Domain -Alias $Param_Domain | Out-Indented\n\nWrite-Host 'Initiating Domain Ownership Challenge...'\n$challengeType = ($Param_ChallengeType -split ',')[0]\n$handler = ($Param_ChallengeType -split ',')[1]\n$handlerParameters = @{}\nif (Test-String $Param_WebSiteRef) {\n    $handlerParameters.Add('WebSiteRef', $Param_WebSiteRef)\n}\n$instructionsPath = [System.IO.Path]::GetTempFileName()\nif ($handler -ieq 'manual') {\n    $handlerParameters.Add('WriteOutPath', $instructionsPath)\n    Remove-Item -Path $instructionsPath -Force\n}\n$identifier = Complete-ACMEChallenge -IdentifierRef $Param_Domain -ChallengeType $challengeType -Handler $handler -HandlerParameters $handlerParameters -Repeat\n\nif ($handler -ieq 'manual') {\n    Get-Content -Path $instructionsPath -Raw | Tee-Object -Variable challenge | Out-Indented\n    Remove-Item -Path $instructionsPath -Force\n    \n    Set-OctopusVariable ACMEChallenge $challenge\n    $waitTime = Get-OctopusSetting ManualWait 300\n    Write-Host \"Domain Verification instructions added to Octopus variable 'Octopus.Action[$($OctopusParameters['Octopus.Action.Name'])].Output.ACMEChallenge\"\n    Write-Host \"Waiting $waitTime seconds before submitting challenge completion...\"\n    Start-Sleep -Seconds $waitTime\n}\n\n$identifier = Submit-ACMEChallenge -IdentifierRef $Param_Domain -ChallengeType $challengeType\nwhile ($identifier.Status -eq 'pending') {\n    Write-Host \"Domain Verification is $($identifier.Status), waiting...\"\n    Start-Sleep -Seconds 20\n    $identifier = Update-ACMEIdentifier -IdentifierRef $Param_Domain    \n}\n\nWrite-Host \"Domain Verification is $($identifier.Status)\"\n$identifier.Challenges | ? Status -ne pending | % ChallengePart | Out-Indented\nif ($identifier.Status -ne 'valid') {\n    $errorJson = $identifier.Challenges | ? Status -eq invalid | % ChallengePart | % Error | ConvertTo-Json\n    Get-ACMEVaultProfile | % VaultParameters | % RootPath | Get-ChildItem -File -Filter '00-VAULT' | Get-Content | Out-Verbose\n    throw \"Domain Verification is $($identifier.Status)`n$errorJson\"\n}\n\nWrite-Host 'Generating CSR...'\nNew-ACMECertificate -Alias $Param_Domain -IdentifierRef $Param_Domain -Generate | Out-Verbose\n\nWrite-Host 'Submitting CSR...'\nSubmit-ACMECertificate -CertificateRef $Param_Domain | Out-Indented\n\nwhile (Test-String $certificate.IssuerSerialNumber -ForAbsence) {\n    Write-Host 'Waiting for certificate to be issued...'\n    Start-Sleep -Seconds 20\n    $certificate = Update-ACMECertificate -CertificateRef $Param_Domain\n}\n\nWrite-Host 'Certificate has been issued...'\n$certificate | Out-Indented\n\nWrite-Host \"Exporting PFX (PKCS#12) certificate file to $Param_PfxFilePath...\"\nGet-ACMECertificate -CertificateRef $Param_Domain -ExportPkcs12 $Param_PfxFilePath -Overwrite | Out-Verbose\n\nif ($Param_ImportCert -ieq 'True') {\n    Write-Host 'Importing certificate to local machine store...'\n    Import-PfxCertificate -CertStoreLocation Cert:\\LocalMachine\\My -Exportable -FilePath $Param_PfxFilePath\n    \n    Get-ChildItem -Path Cert:\\LocalMachine\\My | ? Thumbprint -eq $certificate.Thumbprint | % {\n        Write-Host \"Setting certificate Friendly Name...\"\n        $_.FriendlyName = $Param_Domain\n    }\n}\n\n",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "55492aee-ce09-4738-8f25-a8d824a70f4a",
+      "Name": "Param_Domain",
+      "Label": "Domain",
+      "HelpText": "Domain the certificate should be issued to e.g. **octopus.com**",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "eaaf9e98-e0fa-4c31-a0ae-7a1ec42a3198",
+      "Name": "Param_MailTo",
+      "Label": "Contact Email",
+      "HelpText": "Contact email address used during registration for certificate [expiration emails](https://letsencrypt.org/docs/expiration-emails/) and to accept the [terms of service](https://letsencrypt.org/repository/).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "dc1caf22-dca3-444f-822a-d06648ab275e",
+      "Name": "Param_ChallengeType",
+      "Label": "Domain Verification Challenge Type",
+      "HelpText": "If running on a Web server that answers to the domain name, and using Windows IIS 7.0 or greater, IIS can be updated automatically to serve content that will prove domain ownership and control.\n\nAlternatively if a manual verification option is selected instructions will be displayed in the log.\n\nAdditional information can be found in the [ACME PowerShell Module Documentation](https://github.com/ebekker/ACMESharp/wiki/Quick-Start#5-handle-the-challenge-to-prove-domain-ownership).",
+      "DefaultValue": "http-01,iis",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "http-01,iis|HTTP Challenge (Automated via IIS)\nhttp-01,manual|HTTP Challenge (Manual)\ndns-01,manual|DNS Challenge (Manual)"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "06fba5b5-7589-4e68-a5f3-d4e9ce60bf79",
+      "Name": "Param_WebSiteRef",
+      "Label": "IIS Web Site Name",
+      "HelpText": "Name of the IIS Web Site that handles HTTP traffic for the domain when using the **HTTP Challenge (Automated via IIS)** verification option e.g. **Default Web Site**",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "25aca461-0ca5-486c-978a-605caf5ec66b",
+      "Name": "Param_PfxFilePath",
+      "Label": "PFX Export File",
+      "HelpText": "Exports the certificate and related assets in PKCS#12 archive (.PFX used by Windows and IIS) e.g. **D:\\octopus.com.pfx**",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "fb3813cc-577f-4f4f-9985-d75cc90ebd8a",
+      "Name": "Param_ImportCert",
+      "Label": "Import Certificate?",
+      "HelpText": "Imports the certificate to the local machine store and sets the **Friendly Name** attribute to the domain name.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    }
+  ],
+  "LastModifiedBy": "paulmarsy",
+  "$Meta": {
+    "ExportedAt": "2017-05-30T23:40:56.177Z",
+    "OctopusVersion": "3.13.7",
+    "Type": "ActionTemplate"
+  },
+  "Category": "ssl"
+}


### PR DESCRIPTION
Procures an X.509 SSL Certificate from the [Let’s Encrypt](https://letsencrypt.org) Certificate Authority using the [Automatic Certificate Management Environment (ACME)](https://ietf-wg-acme.github.io/acme/) protocol.

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
