### PR TITLE
Wrap rest call in try catch to allow allow deployment even though call to elmah.io fails

### DIFF
--- a/step-templates/elmahio-notify-deployment.json
+++ b/step-templates/elmahio-notify-deployment.json
@@ -8,7 +8,7 @@
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "$version = $OctopusReleaseNumber\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nInvoke-RestMethod -Method Post -Uri $url -Body $body",
+    "Octopus.Action.Script.ScriptBody": "$version = $OctopusReleaseNumber\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nTry {\n  Invoke-RestMethod -Method Post -Uri $url -Body $body\n}\nCatch {\n  Write-Error $_.Exception.Message -ErrorAction Continue\n}",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null

--- a/step-templates/elmahio-notify-deployment.json
+++ b/step-templates/elmahio-notify-deployment.json
@@ -3,7 +3,7 @@
   "Name": "elmah.io - Register Deployment",
   "Description": "Step template for notifying elmah.io about deployments on Octopus.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",


### PR DESCRIPTION
Wrap call to rest api in try catch, since creating deployments can fail. This usually happen if user inputted the wrong api key or when running the same process on multiple deployment targets (results in 409 from the api)