### PR TITLE
Get Azure Web App Publishing Credentials

### DIFF
--- a/step-templates/Azure-Get-Publishing-Credentials.json
+++ b/step-templates/Azure-Get-Publishing-Credentials.json
@@ -1,0 +1,44 @@
+{
+  "Id": "ActionTemplates-62",
+  "Name": "Get Azure Web App Publishing Credentials",
+  "Description": "Gets the publishing credentials for an Azure Web App.",
+  "ActionType": "Octopus.AzurePowerShell",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "$creds = Invoke-AzureRmResourceAction -ResourceGroupName $ResourceGroup -ResourceType Microsoft.Web/sites/config `\r\n            -ResourceName $fWebApp/publishingCredentials -Action list -ApiVersion 2015-08-01 -Force\r\n\r\nSet-OctopusVariable -name \"PublishingUsername\" -value $creds.PublishingUsername\r\n\r\nSet-OctopusVariable -name \"PublishingPassword\" -value $creds.PublishingPassword\r\n        ",
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "5a1d5a50-a950-42a4-85d6-25c2b9c45e91",
+      "Name": "ResourceGroup",
+      "Label": "Resource group",
+      "HelpText": "The name of the resource group that contains the web app for which publishing credentials are required.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "0f86965c-1f40-4778-8378-197ff4199330",
+      "Name": "WebApp",
+      "Label": "Web app",
+      "HelpText": "The name of the web app for which publishing credentials are required.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2017-08-23T04:26:50.568Z",
+    "OctopusVersion": "3.16.0",
+    "Type": "ActionTemplate"
+  }
+}

--- a/step-templates/Azure-Get-Publishing-Credentials.json
+++ b/step-templates/Azure-Get-Publishing-Credentials.json
@@ -1,5 +1,5 @@
 {
-  "Id": "ActionTemplates-62",
+  "Id": "6792fd3a-2557-4cdc-81e9-29f006f236a5",
   "Name": "Get Azure Web App Publishing Credentials",
   "Description": "Gets the publishing credentials for an Azure Web App.",
   "ActionType": "Octopus.AzurePowerShell",

--- a/step-templates/Azure-Get-Publishing-Credentials.json
+++ b/step-templates/Azure-Get-Publishing-Credentials.json
@@ -1,13 +1,14 @@
 {
-  "Id": "6792fd3a-2557-4cdc-81e9-29f006f236a5",
+  "Id": "ActionTemplates-62",
   "Name": "Get Azure Web App Publishing Credentials",
   "Description": "Gets the publishing credentials for an Azure Web App.",
   "ActionType": "Octopus.AzurePowerShell",
-  "Version": 1,
+  "Version": 8,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "$creds = Invoke-AzureRmResourceAction -ResourceGroupName $ResourceGroup -ResourceType Microsoft.Web/sites/config `\r\n            -ResourceName $fWebApp/publishingCredentials -Action list -ApiVersion 2015-08-01 -Force\r\n\r\nSet-OctopusVariable -name \"PublishingUsername\" -value $creds.PublishingUsername\r\n\r\nSet-OctopusVariable -name \"PublishingPassword\" -value $creds.PublishingPassword\r\n        ",
+    "Octopus.Action.Script.ScriptBody": "$creds = Invoke-AzureRmResourceAction -ResourceGroupName $ResourceGroup -ResourceType Microsoft.Web/sites/config `\r\n            -ResourceName $WebApp/publishingCredentials -Action list -ApiVersion 2015-08-01 -Force\r\n\r\nSet-OctopusVariable -name \"PublishingUsername\" -value $creds.Properties.PublishingUsername\r\nSet-OctopusVariable -name \"PublishingPassword\" -value $creds.Properties.PublishingPassword",
+    "Octopus.Action.Azure.AccountId": "#{AzureAccount}",
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.PackageId": null
@@ -34,10 +35,21 @@
         "Octopus.ControlType": "SingleLineText"
       },
       "Links": {}
+    },
+    {
+      "Id": "572ee191-a035-47ab-aec3-ef805e690868",
+      "Name": "AzureAccount",
+      "Label": "Azure account",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
     }
   ],
   "$Meta": {
-    "ExportedAt": "2017-08-23T04:26:50.568Z",
+    "ExportedAt": "2017-08-23T06:42:23.412Z",
     "OctopusVersion": "3.16.0",
     "Type": "ActionTemplate"
   }


### PR DESCRIPTION
A step template for obtaining the publishing credentials used for a Web App in a resource group.

I'm planning on using this in conjunction with the community step template for deploying Azure Functions... at least until Octopus Deploy's 'Deploy Azure Web App' step supports this natively.

One potential issue... this step template sets output variables for the username and password; will the password appear in Octopus Deploy logs? `Set-OctopusVariable` doesn't appear to support a way to indicate that the variable is sensitive.