### PR TITLE
Update upgrade-octopus-server.json

### DIFF
--- a/step-templates/upgrade-octopus-server.json
+++ b/step-templates/upgrade-octopus-server.json
@@ -3,13 +3,16 @@
   "Name": "Upgrade Octopus Server",
   "Description": "This step downloads the latest version of Octopus Server and upgrades an existing instance. Run this step on a tentacle that has privileges to install software and start/stop services on the target server.\n\n**Run this after a database backup step**\n\nTo Use:\n- Install a tentacle on the Octopus Server machine with privileges to install software and start/stop services\n- Add that tentacle to an environment and with a unique role\n- Setup a project for the upgrade process\n- Add a database backup step for your Octopus Server database\n- Add this step, selecting it to run on just the role previously configured\n- Create a release\n- Deploy that release whenever an upgrade is needed\n\nNB: The deployment will show as \"Timed Out\" when the server comes back online",
   "ActionType": "Octopus.Script",
-  "Version": 7,
+  "Version": 8,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\r\n$versions = Invoke-WebRequest https://octopusdeploy.com/download/upgrade/v3 -UseBasicParsing | ConvertFrom-Json\r\n$version = $versions[-1].Version\r\n$tempFile = [System.IO.Path]::GetTempFileName()\r\n\r\nWrite-Host \"Downloading Octopus $version\"\r\ntry\r\n{\r\n    (New-Object System.Net.WebClient).DownloadFile(\"https://download.octopusdeploy.com/octopus/Octopus.$version-x64.msi\", $tempFile)\r\n}\r\ncatch\r\n{\r\n    echo $_.Exception|format-list -force\r\n}\r\n\r\nWrite-Host \"Stopping Server\"\r\n. 'C:\\Program Files\\Octopus Deploy\\Octopus\\Octopus.Server.exe' service --stop --console --instance $InstanceName\r\n\r\nWrite-Host \"Installing\"\r\nmsiexec /i $tempFile /quiet | Out-Null\r\n\r\nWrite-Host \"Deleting installer\"\r\nRemove-Item $tempFile\r\n\r\nWrite-Host \"Starting Server\"\r\n. 'C:\\Program Files\\Octopus Deploy\\Octopus\\Octopus.Server.exe' service --start --console --instance $InstanceName\r\n\r\n"
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n$versions = Invoke-WebRequest https://octopusdeploy.com/download/upgrade/v3 -UseBasicParsing | ConvertFrom-Json\n$version = $versions[-1].Version\n$tempFile = [System.IO.Path]::GetTempFileName()\n$InstalledVersion = (get-item \"$InstallPath\\Octopus.Server.exe\").VersionInfo.fileversion\n\nif([version]$version -gt [version]$InstalledVersion) {\n        \n    Write-Host \"Downloading Octopus $version\"\n    try\n    {\n        (New-Object System.Net.WebClient).DownloadFile(\"https://download.octopusdeploy.com/octopus/Octopus.$version-x64.msi\", $tempFile)\n    }\n    catch\n    {\n        echo $_.Exception|format-list -force\n    }\n    \n    Write-Host \"Stopping Server\"\n    . \"$InstallPath\\Octopus.Server.exe\" service --stop --console --instance $InstanceName\n    \n    Write-Host \"Installing\"\n    msiexec /i $tempFile /quiet | Out-Null\n    \n    Write-Host \"Deleting installer\"\n    Remove-Item $tempFile\n    \n    Write-Host \"Starting Server\"\n    . \"$InstallPath\\Octopus.Server.exe\" service --start --console --instance $InstanceName\n}\nelse {\n    Write-host \"Octopus already updated to version: $version\"   \n}\n\n",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
   },
   "Parameters": [
     {
@@ -22,13 +25,23 @@
         "Octopus.ControlType": "SingleLineText"
       },
       "Links": {}
+    },
+    {
+      "Id": "18ede5ad-24a8-4796-a6e2-1b49a4cd7df2",
+      "Name": "InstallPath",
+      "Label": "InstallPath",
+      "HelpText": "The installation path to Octopus Deploy Server. Not the instance directory",
+      "DefaultValue": "C:\\Program Files\\Octopus Deploy\\Octopus",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedBy": "droyad",
   "$Meta": {
-    "ExportedAt": "2016-12-13T04:31:08.416Z",
-    "OctopusVersion": "3.7.5",
-	  "Type": "ActionTemplate"
+    "ExportedAt": "2017-09-04T14:01:35.028Z",
+    "OctopusVersion": "3.16.7",
+    "Type": "ActionTemplate"
   },
   "Category": "octopus"
 }

--- a/step-templates/upgrade-octopus-server.json
+++ b/step-templates/upgrade-octopus-server.json
@@ -38,6 +38,7 @@
       "Links": {}
     }
   ],
+  "LastModifiedBy": "McAndersDK",
   "$Meta": {
     "ExportedAt": "2017-09-04T14:01:35.028Z",
     "OctopusVersion": "3.16.7",


### PR DESCRIPTION
Fix: Only install if new version is found
Feature: Custom Installation path

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
