### PR TITLE
Consider all DSIM states that begin with "Disabled" to be disabled

### DIFF
--- a/step-templates/windows-ensure-features-installed.json
+++ b/step-templates/windows-ensure-features-installed.json
@@ -3,9 +3,9 @@
   "Name": "Windows - Ensure Features Installed",
   "Description": "Ensures that a set of Windows Features are installed on the system.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$requiredFeatures = $OctopusParameters['WindowsFeatures'].split(\",\") | foreach { $_.trim() }\nif(! $requiredFeatures) {\n    Write-Output \"No required Windows Features specified...\"\n    exit\n}\n$requiredFeatures | foreach { $feature = DISM.exe /ONLINE /Get-FeatureInfo /FeatureName:$_; if($feature -like \"*Feature name $_ is unknown*\") { throw $feature } }\n\nWrite-Output \"Retrieving all Windows Features...\"\n$allFeatures = DISM.exe /ONLINE /Get-Features /FORMAT:List | Where-Object { $_.StartsWith(\"Feature Name\") -OR $_.StartsWith(\"State\") } \n$features = new-object System.Collections.ArrayList\nfor($i = 0; $i -lt $allFeatures.length; $i=$i+2) {\n    $feature = $allFeatures[$i]\n    $state = $allFeatures[$i+1]\n    $features.add(@{feature=$feature.split(\":\")[1].trim();state=$state.split(\":\")[1].trim()}) | OUT-NULL\n}\n\nWrite-Output \"Checking for missing Windows Features...\"\n$missingFeatures = new-object System.Collections.ArrayList\n$features | foreach { if( $requiredFeatures -contains $_.feature -and $_.state -eq 'Disabled') { $missingFeatures.add($_.feature) | OUT-NULL } }\nif(! $missingFeatures) {\n    Write-Output \"All required Windows Features are installed\"\n    exit\n}\nWrite-Output \"Installing missing Windows Features...\"\n$featureNameArgs = \"\"\n$missingFeatures | foreach { $featureNameArgs = $featureNameArgs + \" /FeatureName:\" + $_ }\n$dism = \"DISM.exe\"\nIF ($SuppressReboot)\n{\n    $arguments = \"/NoRestart \"\n}\nELSE\n{\n    $arguments = \"\"\n}\n$arguments = $arguments + \"/ONLINE /Enable-Feature /All $featureNameArgs\"\nWrite-Output \"Calling DISM with arguments: $arguments\"\nstart-process -NoNewWindow $dism $arguments",
+    "Octopus.Action.Script.ScriptBody": "$requiredFeatures = $OctopusParameters['WindowsFeatures'].split(\",\") | foreach { $_.trim() }\nif(! $requiredFeatures) {\n    Write-Output \"No required Windows Features specified...\"\n    exit\n}\n$requiredFeatures | foreach { $feature = DISM.exe /ONLINE /Get-FeatureInfo /FeatureName:$_; if($feature -like \"*Feature name $_ is unknown*\") { throw $feature } }\n\nWrite-Output \"Retrieving all Windows Features...\"\n$allFeatures = DISM.exe /ONLINE /Get-Features /FORMAT:List | Where-Object { $_.StartsWith(\"Feature Name\") -OR $_.StartsWith(\"State\") } \n$features = new-object System.Collections.ArrayList\nfor($i = 0; $i -lt $allFeatures.length; $i=$i+2) {\n    $feature = $allFeatures[$i]\n    $state = $allFeatures[$i+1]\n    $features.add(@{feature=$feature.split(\":\")[1].trim();state=$state.split(\":\")[1].trim()}) | OUT-NULL\n}\n\nWrite-Output \"Checking for missing Windows Features...\"\n$missingFeatures = new-object System.Collections.ArrayList\n$features | foreach { if( $requiredFeatures -contains $_.feature -and $_.state.StartsWith(\"Disabled\")) { $missingFeatures.add($_.feature) | OUT-NULL } }\nif(! $missingFeatures) {\n    Write-Output \"All required Windows Features are installed\"\n    exit\n}\nWrite-Output \"Installing missing Windows Features...\"\n$featureNameArgs = \"\"\n$missingFeatures | foreach { $featureNameArgs = $featureNameArgs + \" /FeatureName:\" + $_ }\n$dism = \"DISM.exe\"\nIF ($SuppressReboot)\n{\n    $arguments = \"/NoRestart \"\n}\nELSE\n{\n    $arguments = \"\"\n}\n$arguments = $arguments + \"/ONLINE /Enable-Feature /All $featureNameArgs\"\nWrite-Output \"Calling DISM with arguments: $arguments\"\nstart-process -NoNewWindow $dism $arguments",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -29,11 +29,11 @@
       }
     }
   ],
-  "LastModifiedOn": "2014-08-30T15:17:19.861+00:00",
-  "LastModifiedBy": "cjuroz",
+  "LastModifiedOn": "2017-10-03T21:58:18.839Z",
+  "LastModifiedBy": "WesleySSmith",
   "$Meta": {
-    "ExportedAt": "2014-07-29T16:54:34.499+00:00",
-    "OctopusVersion": "2.5.5.318",
+    "ExportedAt": "2017-10-03T21:58:18.839Z",
+    "OctopusVersion": "3.17.1",
     "Type": "ActionTemplate"
   },
   "Category": "windows"


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
