### PR TITLE
Update file-system-grant-permissions.json - Added folder path output

### DIFF
--- a/step-templates/file-system-grant-permissions.json
+++ b/step-templates/file-system-grant-permissions.json
@@ -16,7 +16,7 @@
   },
   "Parameters": [
     {
-      "Id": "a1a4cd15-cd00-4ef6-99cc-78a08739de42",
+      "Id": "e67e2b43-b1e4-482d-bb5d-e4b6acb2b90f",
       "Name": "Items",
       "Label": "Items",
       "HelpText": "A comma seperated list of full paths to the files or folders",
@@ -27,7 +27,7 @@
       "Links": {}
     },
     {
-      "Id": "d38272e1-109f-4803-8b2b-01aa5582059d",
+      "Id": "b830e92e-ceaa-472e-b1ac-e70a19d9386b",
       "Name": "ReadPermissionsTo",
       "Label": "Read Users",
       "HelpText": "A comma separated list of users to grant read permissions to",
@@ -38,7 +38,7 @@
       "Links": {}
     },
     {
-      "Id": "4b7798cd-a71a-46da-bae2-548d52891506",
+      "Id": "141f465e-6998-4715-be65-6d5df2604239",
       "Name": "WritePermissionsTo",
       "Label": "Write Users",
       "HelpText": "A comma separated list of users to grant write permissions to",
@@ -49,7 +49,7 @@
       "Links": {}
     },
     {
-      "Id": "7996fe11-a95d-477c-bc60-f0ee654b7fee",
+      "Id": "c150331e-ea88-4170-8bca-52a8cfd30220",
       "Name": "ModifyPermissionsTo",
       "Label": "Modify Users",
       "HelpText": "A comma separated list of users to grant modify permissions to",

--- a/step-templates/file-system-grant-permissions.json
+++ b/step-templates/file-system-grant-permissions.json
@@ -1,5 +1,5 @@
 {
-  "Id": "10165c6b-d3b1-4e40-9364-868feda425ae",
+  "Id": "b77d55ae-7f54-45ab-ba57-7afff97c93a2",
   "Name": "File System - Grant Permissions",
   "Description": "Grant read, write and modify permissions to folders or files",
   "ActionType": "Octopus.Script",

--- a/step-templates/file-system-grant-permissions.json
+++ b/step-templates/file-system-grant-permissions.json
@@ -1,12 +1,12 @@
 {
-  "Id": "b77d55ae-7f54-45ab-ba57-7afff97c93a2",
+  "Id": "10165c6b-d3b1-4e40-9364-868feda425ae",
   "Name": "File System - Grant Permissions",
   "Description": "Grant read, write and modify permissions to folders or files",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 5,
   "CommunityActionTemplateId": null,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$itemsParameter = $OctopusParameters['Items']\n$readPermissionsTo = $OctopusParameters['ReadPermissionsTo']\n$writePermissionsTo = $OctopusParameters['WritePermissionsTo']\n$modifyPermissionsTo = $OctopusParameters['ModifyPermissionsTo']\n\nif($readPermissionsTo)\n{\n    $readUsers = $readPermissionsTo.Split(\",\")\n}\n\nif($writePermissionsTo)\n{\n    $writeUsers = $writePermissionsTo.Split(\",\")\n}\n\nif($modifyPermissionsTo)\n{\n    $modifyUsers = $modifyPermissionsTo.Split(\",\")\n}\n\n$items = $itemsParameter.Split(\",\")\nforeach($item in $items) \n{\n    # Check path exists\n    if(!(Test-Path $item))\n    {\n        throw \"$item does not exist\"\n    }\n\n    # Assign read permissions\n    foreach($user in $readUsers)\n    {\n        Write-Host \"Adding read permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Read\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Read\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n\n    # Assign write permissions\n    foreach($user in $writeUsers)\n    {\n        Write-Host \"Adding write permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Write\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Write\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n\n    # Assign modify permissions\n    foreach($user in $modifyUsers)\n    {\n        Write-Host \"Adding modify permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Modify\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Modify\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n}\n\nWrite-Host \"Complete\"\n",
+    "Octopus.Action.Script.ScriptBody": "$itemsParameter = $OctopusParameters['Items']\n$readPermissionsTo = $OctopusParameters['ReadPermissionsTo']\n$writePermissionsTo = $OctopusParameters['WritePermissionsTo']\n$modifyPermissionsTo = $OctopusParameters['ModifyPermissionsTo']\n\nif($readPermissionsTo)\n{\n    $readUsers = $readPermissionsTo.Split(\",\")\n}\n\nif($writePermissionsTo)\n{\n    $writeUsers = $writePermissionsTo.Split(\",\")\n}\n\nif($modifyPermissionsTo)\n{\n    $modifyUsers = $modifyPermissionsTo.Split(\",\")\n}\n\n$items = $itemsParameter.Split(\",\")\nforeach($item in $items) \n{\n    # Check path exists\n    if(!(Test-Path $item))\n    {\n        throw \"$item does not exist\"\n    }\n\n    Write-Host \"Path: $item\"\n    # Assign read permissions\n    foreach($user in $readUsers)\n    {\n        Write-Host \"  Adding read permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Read\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Read\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n\n    # Assign write permissions\n    foreach($user in $writeUsers)\n    {\n        Write-Host \"  Adding write permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Write\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Write\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n\n    # Assign modify permissions\n    foreach($user in $modifyUsers)\n    {\n        Write-Host \"  Adding modify permissions for $user\"\n        $acl = (Get-Item $item).GetAccessControl('Access')\n        $acl.SetAccessRuleProtection($False, $False)\n        $rule = \n            if ($acl -is [System.Security.AccessControl.DirectorySecurity])\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Modify\", \"ContainerInherit, ObjectInherit\", \"None\", \"Allow\")\n                }\n                else\n                {\n                    New-Object System.Security.AccessControl.FileSystemAccessRule($user, \"Modify\", \"Allow\")\n                }\n        $acl.AddAccessRule($rule)\n        Set-Acl $item $acl\n    }\n}\n\nWrite-Host \"Complete\"\n",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
@@ -16,7 +16,7 @@
   },
   "Parameters": [
     {
-      "Id": "e67e2b43-b1e4-482d-bb5d-e4b6acb2b90f",
+      "Id": "a1a4cd15-cd00-4ef6-99cc-78a08739de42",
       "Name": "Items",
       "Label": "Items",
       "HelpText": "A comma seperated list of full paths to the files or folders",
@@ -27,7 +27,7 @@
       "Links": {}
     },
     {
-      "Id": "b830e92e-ceaa-472e-b1ac-e70a19d9386b",
+      "Id": "d38272e1-109f-4803-8b2b-01aa5582059d",
       "Name": "ReadPermissionsTo",
       "Label": "Read Users",
       "HelpText": "A comma separated list of users to grant read permissions to",
@@ -38,7 +38,7 @@
       "Links": {}
     },
     {
-      "Id": "141f465e-6998-4715-be65-6d5df2604239",
+      "Id": "4b7798cd-a71a-46da-bae2-548d52891506",
       "Name": "WritePermissionsTo",
       "Label": "Write Users",
       "HelpText": "A comma separated list of users to grant write permissions to",
@@ -49,7 +49,7 @@
       "Links": {}
     },
     {
-      "Id": "c150331e-ea88-4170-8bca-52a8cfd30220",
+      "Id": "7996fe11-a95d-477c-bc60-f0ee654b7fee",
       "Name": "ModifyPermissionsTo",
       "Label": "Modify Users",
       "HelpText": "A comma separated list of users to grant modify permissions to",
@@ -60,10 +60,11 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy": "HumanPrinter",
+  "LastModifiedOn": "2017-10-26T07:11:38.851Z",
+  "LastModifiedBy": "mcfozzy", 
   "$Meta": {
-    "ExportedAt": "2016-12-28T07:39:51.851Z",
-    "OctopusVersion": "3.7.6",
+    "ExportedAt": "2017-10-26T07:11:38.851Z",
+    "OctopusVersion": "3.15.8",
     "Type": "ActionTemplate"
   },
   "Category": "filesystem"


### PR DESCRIPTION
Added folder path output

### Step template guidelines

* Is the template a minor variation on an existing one? If so, please consider improving the existing template if possible.
* Is the name of the template consistent with the examples already in the library, in style ("Noun - Verb"), layout and casing?
* Are all parameters in the template consistent with the examples here, including help text documented with Markdown?
* Is the description of the template complete, correct Markdown?
* Is the `.json` filename consistent with the name of the template?
* Do scripts in the template validate required arguments and fail by returning a non-zero exit code when things go wrong?
* Do scripts in the template produce worthwhile status messages as they execute?
* Are you happy to contribute your template under the terms of the [license](https://github.com/OctopusDeploy/Library/blob/master/LICENSE)? If you produced the template while working for your employer please obtain written permission from them before submitting it here.
* Are the default values of parameters validly applicable in other user's environments? Don't use the default values as examples if the user will have to change them
* For how to deal with parameters and testing take a look at the article [Making great Octopus PowerShell step templates](http://www.lavinski.me/making-great-octopus-powershell-step-templates/)
* For another example of how to test your step template script body before submitting a PR take a look at this [gist](https://gist.github.com/JCapriotti/45639e06ba777ee974b1)

_Before submitting your PR, please delete everything above the line below._

---

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
