### PR TITLE
User Start-process instead of &

### DIFF
--- a/step-templates/topshelf-uninstall.json
+++ b/step-templates/topshelf-uninstall.json
@@ -27,9 +27,11 @@
       "Links": {}
     }
   ],
+  "LastModifiedBy": "georgiosd",
   "$Meta": {
     "ExportedAt": "2017-11-22T10:28:26.087Z",
     "OctopusVersion": "3.17.14",
     "Type": "ActionTemplate"
-  }
+  },
+  "Category": "topshelf"
 }

--- a/step-templates/topshelf-uninstall.json
+++ b/step-templates/topshelf-uninstall.json
@@ -3,35 +3,33 @@
   "Name": "Uninstall TopShelf service",
   "Description": "This step can be used before unpacking a package with your TopShelf service to stop and remove the previous installation, if there is one.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "$step = $OctopusParameters['Unpackage step']\r\n$previous = $OctopusParameters[\"Octopus.Action[$step].Package.CustomInstallationDirectory\"]\r\n\r\nif(!$previous -or (-not (Test-Path $previous)) )\r\n{\r\n    Write-Host \"No installation found in: $previous\"\r\n\t\r\n    $previous = $OctopusParameters[\"Octopus.Action[$step].Output.Package.InstallationDirectoryPath\"]\r\n    if(!$previous -or (-not (Test-Path $previous)) )\r\n    {\r\n        Write-Host \"No installation found in: $previous\"\r\n        Break\r\n    }\r\n}\r\n\r\n$exe = $OctopusParameters[\"Octopus.Action[$step].Package.NuGetPackageId\"] + \".exe\"\r\n$path = Join-Path $previous $exe\r\n\r\nWrite-Host \"Previous installation: $path\"\r\n\r\n& $path stop | Write-Host\r\n& $path uninstall | Write-Host\r\n",
+    "Octopus.Action.Script.ScriptBody": "$step = $OctopusParameters['Unpackage step']\n$previous = $OctopusParameters[\"Octopus.Action[$step].Package.CustomInstallationDirectory\"]\n\nif(!$previous -or (-not (Test-Path $previous)) )\n{\n    Write-Host \"No installation found in: $previous\"\n\t\n    $previous = $OctopusParameters[\"Octopus.Action[$step].Output.Package.InstallationDirectoryPath\"]\n    if(!$previous -or (-not (Test-Path $previous)) )\n    {\n        Write-Host \"No installation found in: $previous\"\n        Break\n    }\n}\n\n$exe = $OctopusParameters[\"Octopus.Action[$step].Package.NuGetPackageId\"] + \".exe\"\n$path = Join-Path $previous $exe\n\nWrite-Host \"Previous installation: $path\"\n\nStart-Process $path -ArgumentList \"stop\" -NoNewWindow -Wait | Write-Host\nStart-Process $path -ArgumentList \"uninstall\" -NoNewWindow -Wait | Write-Host\n",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null
   },
   "Parameters": [
     {
-      "Id": "7f8499a8-d364-40bd-83b9-70513bd11171",
+      "Id": "14d4b5e5-98ff-48ee-aeba-c062e294a18c",
       "Name": "Unpackage step",
       "Label": "",
       "HelpText": "The step where you unpack the topshelf service",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "StepName"
       },
       "Links": {}
     }
   ],
-  "LastModifiedBy": "georgiosd",
   "$Meta": {
-    "ExportedAt": "2016-12-31T11:50:16.935Z",
-    "OctopusVersion": "3.7.10",
+    "ExportedAt": "2017-11-22T10:28:26.087Z",
+    "OctopusVersion": "3.17.14",
     "Type": "ActionTemplate"
-  },
-  "Category": "topshelf"
+  }
 }


### PR DESCRIPTION
Fixes race condition

### Step template guidelines

* Is the template a minor variation on an existing one? If so, please consider improving the existing template if possible.
* Is the name of the template consistent with the examples already in the library, in style ("Noun - Verb"), layout and casing?
* Are all parameters in the template consistent with the examples here, including help text documented with Markdown?
* Is the description of the template complete, correct Markdown?
* Is the `.json` filename consistent with the name of the template?
* Do scripts in the template validate required arguments and fail by returning a non-zero exit code when things go wrong?
* Do scripts in the template produce worthwhile status messages as they execute?
* Are you happy to contribute your template under the terms of the [license](https://github.com/OctopusDeploy/Library/blob/master/LICENSE)? If you produced the template while working for your employer please obtain written permission from them before submitting it here.
* Are the default values of parameters validly applicable in other user's environments? Don't use the default values as examples if the user will have to change them
* For how to deal with parameters and testing take a look at the article [Making great Octopus PowerShell step templates](http://www.lavinski.me/making-great-octopus-powershell-step-templates/)
* For another example of how to test your step template script body before submitting a PR take a look at this [gist](https://gist.github.com/JCapriotti/45639e06ba777ee974b1)

_Before submitting your PR, please delete everything above the line below._

---

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
