### PR TITLE
u/p support and race condition fix

### DIFF
--- a/step-templates/topshelf-install.json
+++ b/step-templates/topshelf-install.json
@@ -49,9 +49,11 @@
       "Links": {}
     }
   ],
+  "LastModifiedBy": "georgiosd",
   "$Meta": {
     "ExportedAt": "2017-11-22T10:26:42.319Z",
     "OctopusVersion": "3.17.14",
     "Type": "ActionTemplate"
-  }
+  },
+  "Category": "topshelf"
 }

--- a/step-templates/topshelf-install.json
+++ b/step-templates/topshelf-install.json
@@ -3,36 +3,55 @@
   "Name": "Install TopShelf service",
   "Description": null,
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "$step = $OctopusParameters['Unpackage step']\r\n$exe = $OctopusParameters[\"Octopus.Action[$step].Package.NuGetPackageId\"] + \".exe\"\r\n\r\n$outputPath = $OctopusParameters[\"Octopus.Action[$step].Package.CustomInstallationDirectory\"]\r\nif(!$outputPath) \r\n{\r\n    $outputPath = $OctopusParameters[\"Octopus.Action[$step].Output.Package.InstallationDirectoryPath\"]\r\n}\r\n\r\n$path = Join-Path $outputPath $exe\r\nif(-not (Test-Path $path) )\r\n{\r\n    Throw \"$path was not found\"\r\n}\r\n\r\nWrite-Host \"Installing from: $path\"\r\n& $path install | Write-Host\r\n& $path start | Write-Host",
+    "Octopus.Action.Script.ScriptBody": "$step = $OctopusParameters['Unpackage step']\n$username = $OctopusParameters['Username'];\n$password = $OctopusParameters['Password'];\n$exe = $OctopusParameters[\"Octopus.Action[$step].Package.NuGetPackageId\"] + \".exe\"\n\n$outputPath = $OctopusParameters[\"Octopus.Action[$step].Package.CustomInstallationDirectory\"]\nif(!$outputPath) \n{\n    $outputPath = $OctopusParameters[\"Octopus.Action[$step].Output.Package.InstallationDirectoryPath\"]\n}\n\n$path = Join-Path $outputPath $exe\nif(-not (Test-Path $path) )\n{\n    Throw \"$path was not found\"\n}\n\nWrite-Host \"Installing from: $path\"\nif(!$username)\n{\n    Start-Process $path -ArgumentList \"install\" -NoNewWindow -Wait | Write-Host\n} \nelse \n{\n    Start-Process $path -ArgumentList @(\"install\", \"-username\", $username, \"-password\", $password) -NoNewWindow -Wait | Write-Host\n}\nStart-Process $path -ArgumentList \"start\" -NoNewWindow -Wait | Write-Host\n",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null
   },
   "Parameters": [
     {
-      "Id": "59bca262-3631-4b6d-bc0f-3689a8efc389",
+      "Id": "463159e1-62fa-4150-bdb9-dfb7dac6ecfa",
       "Name": "Unpackage step",
       "Label": "",
       "HelpText": "The step where you unpack the topshelf service",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "StepName"
       },
       "Links": {}
+    },
+    {
+      "Id": "d5d3e88e-b16a-4864-ac1e-614f11c861ed",
+      "Name": "Username",
+      "Label": "Service username",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "0fcca6af-0ba4-495c-b120-b06ac8de2ebd",
+      "Name": "Password",
+      "Label": "Service password",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedBy": "georgiosd",
   "$Meta": {
-    "ExportedAt": "2016-12-31T11:50:16.935Z",
-    "OctopusVersion": "3.7.10",
+    "ExportedAt": "2017-11-22T10:26:42.319Z",
+    "OctopusVersion": "3.17.14",
     "Type": "ActionTemplate"
-  },
-  "Category": "topshelf"
+  }
 }
-


### PR DESCRIPTION
Add username and password support and use Start-Process to avoid race-condition

### Step template guidelines

* Is the template a minor variation on an existing one? If so, please consider improving the existing template if possible.
* Is the name of the template consistent with the examples already in the library, in style ("Noun - Verb"), layout and casing?
* Are all parameters in the template consistent with the examples here, including help text documented with Markdown?
* Is the description of the template complete, correct Markdown?
* Is the `.json` filename consistent with the name of the template?
* Do scripts in the template validate required arguments and fail by returning a non-zero exit code when things go wrong?
* Do scripts in the template produce worthwhile status messages as they execute?
* Are you happy to contribute your template under the terms of the [license](https://github.com/OctopusDeploy/Library/blob/master/LICENSE)? If you produced the template while working for your employer please obtain written permission from them before submitting it here.
* Are the default values of parameters validly applicable in other user's environments? Don't use the default values as examples if the user will have to change them
* For how to deal with parameters and testing take a look at the article [Making great Octopus PowerShell step templates](http://www.lavinski.me/making-great-octopus-powershell-step-templates/)
* For another example of how to test your step template script body before submitting a PR take a look at this [gist](https://gist.github.com/JCapriotti/45639e06ba777ee974b1)

_Before submitting your PR, please delete everything above the line below._

---

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
