### PR TITLE
Write SQL Info message as verbose output

### DIFF
--- a/step-templates/sql-execute-script.json
+++ b/step-templates/sql-execute-script.json
@@ -1,58 +1,64 @@
 {
-  "Id": "73f89638-51d1-4fbb-b68f-b71ba9e86720",
+  "Id": "ActionTemplates-101",
   "Name": "SQL - Execute Script",
   "Description": "Execute a SQL script",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 0,
+  "CommunityActionTemplateId": null,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$connection = New-Object System.Data.SqlClient.SqlConnection\r\n$connection.ConnectionString = $OctopusParameters['ConnectionString']\r\n$continueOnError = $($($OctopusParameters['ContinueOnError']).ToLower() -eq 'true')\r\nRegister-ObjectEvent -inputobject $connection -eventname InfoMessage -action {\r\n    write-host $event.SourceEventArgs\r\n} | Out-Null\r\n\r\nfunction Execute-SqlQuery($query) {\r\n    $queries = [System.Text.RegularExpressions.Regex]::Split($query, \"^\\s*GO\\s*`$\", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Multiline)\r\n\r\n    $queries | ForEach-Object {\r\n        $q = $_\r\n        if ((-not [String]::IsNullOrWhiteSpace($q)) -and ($q.Trim().ToLowerInvariant() -ne \"go\")) {            \r\n            $command = $connection.CreateCommand()\r\n            $command.CommandText = $q\r\n            $command.CommandTimeout = $OctopusParameters['CommandTimeout']\r\n            $command.ExecuteNonQuery() | Out-Null\r\n        }\r\n    }\r\n\r\n}\r\n\r\nWrite-Host \"Connecting\"\r\ntry {\r\n    $connection.Open()\r\n\r\n    Write-Host \"Executing script\"\r\n    Execute-SqlQuery -query $OctopusParameters['SqlScript']\r\n}\r\ncatch {\r\n\tif ($continueOnError) {\r\n\t\tWrite-Host $_.Exception.Message\r\n\t}\r\n\telse {\r\n\t\tthrow\r\n\t}\r\n}\r\nfinally {\r\n    Write-Host \"Closing connection\"\r\n    $connection.Dispose()\r\n}",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "$connection = New-Object System.Data.SqlClient.SqlConnection\n$connection.ConnectionString = $OctopusParameters['ConnectionString']\n$continueOnError = $($($OctopusParameters['ContinueOnError']).ToLower() -eq 'true')\nRegister-ObjectEvent -inputobject $connection -eventname InfoMessage -action {\n    write-host $event.SourceEventArgs\n} | Out-Null\n\nfunction Execute-SqlQuery($query) {\n    $queries = [System.Text.RegularExpressions.Regex]::Split($query, \"^\\s*GO\\s*`$\", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Multiline)\n\n    $queries | ForEach-Object {\n        $q = $_\n        if ((-not [String]::IsNullOrWhiteSpace($q)) -and ($q.Trim().ToLowerInvariant() -ne \"go\")) {            \n            $command = $connection.CreateCommand()\n            $command.CommandText = $q\n            $command.CommandTimeout = $OctopusParameters['CommandTimeout']\n            $command.ExecuteNonQuery() | Out-Null\n        }\n    }\n\n}\n\n$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] {param($sender, $event) Write-Verbose $event.Message }\n\ntry {\n\t\n    Write-Host \"Attach InfoMessage event handler\"\n\t$connection.add_InfoMessage($handler)\n    \n\tWrite-Host \"Connecting\"\n    $connection.Open()\n\n    Write-Host \"Executing script\"\n    Execute-SqlQuery -query $OctopusParameters['SqlScript']\n}\ncatch {\n\tif ($continueOnError) {\n\t\tWrite-Host $_.Exception.Message\n\t}\n\telse {\n\t\tthrow\n\t}\n}\nfinally {\n\t\n    Write-Host \"Detach InfoMessage event handler\"\n\t$connection.remove_InfoMessage($handler)\n    Write-Host \"Closing connection\"\n    $connection.Dispose()\n}",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline"
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
+      "Id": "802db0cd-f6eb-4cc6-9388-c5f6a4ae63ea",
       "Name": "ConnectionString",
       "Label": "Connection string",
       "HelpText": "Connection string for the SQL connection. Example:\n\n    Server=.\\SQLExpress;Database=OctoFX;Integrated Security=True;\n\nBind to a variable to provide different values for different environments.",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
-      }
+      },
+      "Links": {}
     },
     {
+      "Id": "ec5a5223-3415-4cda-a888-3655f2b3e98c",
       "Name": "SqlScript",
       "Label": "SQL Script",
       "HelpText": "Script to run. Can be bound to a variable split over multiple lines. Text output by the PRINT statement in SQL will be logged to the deployment log. Use 'GO' to separate multiple commands\n\nExample:\n\n    USE MASTER\n    go\n\n    BACKUP DATABASE [OctoFX] TO DISK = N'#{FilePath}' WITH  COPY_ONLY, NOFORMAT, NOINIT,  NAME = N'Backup created by Octopus', SKIP, NOREWIND, NOUNLOAD,  STATS = 10",
       "DefaultValue": "PRINT 'Hello from SQL'",
       "DisplaySettings": {
         "Octopus.ControlType": "MultiLineText"
-      }
+      },
+      "Links": {}
     },
     {
+      "Id": "1360f453-ad5b-4cc9-bf56-c565f62e2542",
       "Name": "ContinueOnError",
       "Label": "Continue On Error",
       "HelpText": "If set to true, an error with the SQL statement will simply write to the log and not cause an error in the deployment.",
       "DefaultValue": "False",
       "DisplaySettings": {
         "Octopus.ControlType": "Checkbox"
-      }
+      },
+      "Links": {}
     },
     {
+      "Id": "d2f77e7a-a3d2-453c-a784-e3587db28e12",
       "Name": "CommandTimeout",
       "Label": "Command Timeout",
       "HelpText": "The SQL Command Timeout. By default is 30 seconds.",
       "DefaultValue": "30",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
-      }
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedOn": "2017-03-15T02:20:16+00:00",
-  "LastModifiedBy": "jaymickey",
   "$Meta": {
-    "ExportedAt": "2016-01-13T20:04:21.021+00:00",
-    "OctopusVersion": "3.2.14",
+    "ExportedAt": "2017-12-13T10:43:07.699Z",
+    "OctopusVersion": "4.1.1",
     "Type": "ActionTemplate"
-  },
-  "Category": "sql"
+  }
 }

--- a/step-templates/sql-execute-script.json
+++ b/step-templates/sql-execute-script.json
@@ -1,9 +1,9 @@
 {
-  "Id": "ActionTemplates-101",
+  "Id": "73f89638-51d1-4fbb-b68f-b71ba9e86720",
   "Name": "SQL - Execute Script",
   "Description": "Execute a SQL script",
   "ActionType": "Octopus.Script",
-  "Version": 0,
+  "Version": 5,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.ScriptBody": "$connection = New-Object System.Data.SqlClient.SqlConnection\n$connection.ConnectionString = $OctopusParameters['ConnectionString']\n$continueOnError = $($($OctopusParameters['ContinueOnError']).ToLower() -eq 'true')\nRegister-ObjectEvent -inputobject $connection -eventname InfoMessage -action {\n    write-host $event.SourceEventArgs\n} | Out-Null\n\nfunction Execute-SqlQuery($query) {\n    $queries = [System.Text.RegularExpressions.Regex]::Split($query, \"^\\s*GO\\s*`$\", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Multiline)\n\n    $queries | ForEach-Object {\n        $q = $_\n        if ((-not [String]::IsNullOrWhiteSpace($q)) -and ($q.Trim().ToLowerInvariant() -ne \"go\")) {            \n            $command = $connection.CreateCommand()\n            $command.CommandText = $q\n            $command.CommandTimeout = $OctopusParameters['CommandTimeout']\n            $command.ExecuteNonQuery() | Out-Null\n        }\n    }\n\n}\n\n$handler = [System.Data.SqlClient.SqlInfoMessageEventHandler] {param($sender, $event) Write-Verbose $event.Message }\n\ntry {\n\t\n    Write-Host \"Attach InfoMessage event handler\"\n\t$connection.add_InfoMessage($handler)\n    \n\tWrite-Host \"Connecting\"\n    $connection.Open()\n\n    Write-Host \"Executing script\"\n    Execute-SqlQuery -query $OctopusParameters['SqlScript']\n}\ncatch {\n\tif ($continueOnError) {\n\t\tWrite-Host $_.Exception.Message\n\t}\n\telse {\n\t\tthrow\n\t}\n}\nfinally {\n\t\n    Write-Host \"Detach InfoMessage event handler\"\n\t$connection.remove_InfoMessage($handler)\n    Write-Host \"Closing connection\"\n    $connection.Dispose()\n}",
@@ -56,9 +56,12 @@
       "Links": {}
     }
   ],
+  "LastModifiedOn": "2017-12-12T10:43:07+00:00",
+  "LastModifiedBy": "prebenh",
   "$Meta": {
     "ExportedAt": "2017-12-13T10:43:07.699Z",
     "OctopusVersion": "4.1.1",
     "Type": "ActionTemplate"
-  }
+  },
+  "Category": "sql"
 }


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
