### PR TITLE
Change task not found behavior to throw error

### DIFF
--- a/step-templates/windows-scheduled-task-disable.json
+++ b/step-templates/windows-scheduled-task-disable.json
@@ -3,9 +3,9 @@
   "Name": "Windows Scheduled Task - Disable",
   "Description": "Disables a Windows Scheduled Task for both 2008 and 2012.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$taskName = $OctopusParameters['TaskName']\n$maximumWaitTime = $OctopusParameters['MaximumWaitTime']\n\n#Check if the PowerShell cmdlets are available\n$cmdletSupported = [bool](Get-Command -Name Get-ScheduledTask -ErrorAction SilentlyContinue)\n\ntry {\n\tif($cmdletSupported) {\n\t\t$taskExists = Get-ScheduledTask | Where-Object { $_.TaskName -eq $taskName }\n\t}\n\telse {\n\t\t$taskService = New-Object -ComObject \"Schedule.Service\"\n\t\t$taskService.Connect()\n\t\t$taskFolder = $taskService.GetFolder('\\')\n\t\t$taskExists = $taskFolder.GetTasks(0) | Select-Object Name, State | Where-Object { $_.Name -eq $taskName }\n\t}\n\n\tif(-not $taskExists) {\n\t\tWrite-Output \"Scheduled task '$taskName' does not exist\"\n\t\treturn\n\t}\n\n\tWrite-Output \"Disabling $taskName...\"\n\t$waited = 0\n\tif($cmdletSupported) {\n\t\t$task = Disable-ScheduledTask $taskName\n\t\tWrite-Output \"Waiting until $taskName is disabled...\"\n\t\twhile(($task.State -ne [Microsoft.PowerShell.Cmdletization.GeneratedTypes.ScheduledTask.StateEnum]::Disabled) -and (($maximumWaitTime -eq 0) -or ($waited -lt $maximumWaitTime))) \n\t\t{\n\t\t\tStart-Sleep -Milliseconds 200\n\t\t\t$waited += 200\n\t\t\t$task = Get-ScheduledTask $taskName\n\t\t}\n\t\t\n\t\tif($task.State -ne [Microsoft.PowerShell.Cmdletization.GeneratedTypes.ScheduledTask.StateEnum]::Disabled) {\n\t\t\tthrow \"The scheduled task $taskName could not be disabled within the specified wait time\"\n\t\t}\n\t}\n\telse {\n\t\tschtasks /Change /Disable /TN \"$taskName\"\n\t\t#The State property can hold the following values:\n\t\t# 0: Unknown\n\t\t# 1: Disabled\n\t\t# 2: Queued\n\t\t# 3: Ready\n\t\t# 4: Running\n\t\twhile(($taskFolder.GetTask($taskName).State -ne 1) -and (($maximumWaitTime -eq 0) -or ($waited -lt $maximumWaitTime))) {\n\t\t\tStart-Sleep -Milliseconds 200\n\t\t\t$waited += 200\n\t\t}\n\t\t\n\t\tif($taskFolder.GetTask($taskName).State -ne 1) {\n\t\t    throw \"The scheduled task '$taskName' could not be disabled within the specified wait time\"\n\t\t}\n\t}\n}\nfinally {\n    if($taskFolder -ne $NULL) {\n\t    [System.Runtime.Interopservices.Marshal]::ReleaseComObject($taskFolder)   \n\t}\n\t\n\tif($taskService -ne $NULL) {\n\t    [System.Runtime.Interopservices.Marshal]::ReleaseComObject($taskService)   \n\t}\n}",
+    "Octopus.Action.Script.ScriptBody": "$taskName = $OctopusParameters['TaskName']\n$maximumWaitTime = $OctopusParameters['MaximumWaitTime']\n$succeedOnTaskNotFound = $OctopusParameters['SucceedOnTaskNotFound']\n\n#Check if the PowerShell cmdlets are available\n$cmdletSupported = [bool](Get-Command -Name Get-ScheduledTask -ErrorAction SilentlyContinue)\n\ntry {\n\tif($cmdletSupported) {\n\t\t$taskExists = Get-ScheduledTask | Where-Object { $_.TaskName -eq $taskName }\n\t}\n\telse {\n\t\t$taskService = New-Object -ComObject \"Schedule.Service\"\n\t\t$taskService.Connect()\n\t\t$taskFolder = $taskService.GetFolder('\\')\n\t\t$taskExists = $taskFolder.GetTasks(0) | Select-Object Name, State | Where-Object { $_.Name -eq $taskName }\n\t}\n\n\tif(-not $taskExists) {\n        if( $succeedOnTaskNotFound){\n            Write-Output \"Scheduled task '$taskName' does not exist\"\n            }\n        else {\n\t\t    throw \"Scheduled task '$taskName' does not exist\"\n        }\n\t\treturn\n\t}\n\n\tWrite-Output \"Disabling $taskName...\"\n\t$waited = 0\n\tif($cmdletSupported) {\n\t\t$task = Disable-ScheduledTask $taskName\n\t\tWrite-Output \"Waiting until $taskName is disabled...\"\n\t\twhile(($task.State -ne [Microsoft.PowerShell.Cmdletization.GeneratedTypes.ScheduledTask.StateEnum]::Disabled) -and (($maximumWaitTime -eq 0) -or ($waited -lt $maximumWaitTime))) \n\t\t{\n\t\t\tStart-Sleep -Milliseconds 200\n\t\t\t$waited += 200\n\t\t\t$task = Get-ScheduledTask $taskName\n\t\t}\n\t\t\n\t\tif($task.State -ne [Microsoft.PowerShell.Cmdletization.GeneratedTypes.ScheduledTask.StateEnum]::Disabled) {\n\t\t\tthrow \"The scheduled task $taskName could not be disabled within the specified wait time\"\n\t\t}\n\t}\n\telse {\n\t\tschtasks /Change /Disable /TN \"$taskName\"\n\t\t#The State property can hold the following values:\n\t\t# 0: Unknown\n\t\t# 1: Disabled\n\t\t# 2: Queued\n\t\t# 3: Ready\n\t\t# 4: Running\n\t\twhile(($taskFolder.GetTask($taskName).State -ne 1) -and (($maximumWaitTime -eq 0) -or ($waited -lt $maximumWaitTime))) {\n\t\t\tStart-Sleep -Milliseconds 200\n\t\t\t$waited += 200\n\t\t}\n\t\t\n\t\tif($taskFolder.GetTask($taskName).State -ne 1) {\n\t\t    throw \"The scheduled task '$taskName' could not be disabled within the specified wait time\"\n\t\t}\n\t}\n}\nfinally {\n    if($taskFolder -ne $NULL) {\n\t    [System.Runtime.Interopservices.Marshal]::ReleaseComObject($taskFolder)   \n\t}\n\t\n\tif($taskService -ne $NULL) {\n\t    [System.Runtime.Interopservices.Marshal]::ReleaseComObject($taskService)   \n\t}\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -21,6 +21,16 @@
       "Label": "Maximum Wait Time",
       "HelpText": "Maximum time the script must wait before aborting. Use '0' to wait indefinitely.",
       "DefaultValue": 0
+    },
+    {
+      "Name": "SucceedOnTaskNotFound",
+      "Label": "Succeed On Task Not Found",
+      "HelpText": "This setting prevents the script from throwing an error if the task is not found.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
     }
   ],
   "LastModifiedBy": "HumanPrinter",


### PR DESCRIPTION
When a task wasn't found the step was succeeding in Octopus. An error should be raised if the task wasn't found.

This could potentially break deployments that were relying on this behavior. So I also added a toggle to prevent the error and maintain backwards compatibility

---

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
