### PR TITLE
Explicit `$OctopusParameters` parsing. Renamed invalid `$MSMQQueues` …

### DIFF
--- a/step-templates/msmq-create-transactional-queue.json
+++ b/step-templates/msmq-create-transactional-queue.json
@@ -3,9 +3,9 @@
   "Name": "MSMQ - Create Transactional Queue",
   "Description": "Create one or more MSMQ transactional queues and configure permissions.",
   "ActionType": "Octopus.Script",
-  "Version": 8,
+  "Version": 9,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Label \"private$\\$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n        \n        if($ResetPermissions -eq \"True\")\n        {\n            foreach($domain in $ResetDomains.split(\";\"))\n            {\n                # reset permissions\n                $QueuePermissions = $thisQueue | Get-MsmqQueueACL\n                foreach ($AccessItem in $QueuePermissions)\n                {\n                    $userName = [Environment]::UserName\n                    if($AccessItem.AccountName -NotLike \"*$userName\") # not current user\n                    {\n                        $domain = \"$($domain)*\" #append * to end of domain\n                        if ($AccessItem.AccountName -Like \"$($domain)*\")\n                        {\n                            Write-Output \"Removing Permissions $($AccessItem.Right) for $($AccessItem.AccountName)\"\n                            Try\n                            {\n                                $thisQueue | Set-MsmqQueueACL -UserName $AccessItem.AccountName -Remove $AccessItem.Right | Out-Null\n                            }\n                            Catch\n                            {\n                                Write-Output \"Could not set permissions item $_.Exception.Message\"\n                                Break\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
+    "Octopus.Action.Script.ScriptBody": "$MSMQQueues = $OctopusParameters['MSMQQueues']\n$ResetPermissions = $OctopusParameters['ResetPermissions']\n$ResetDomains = $OctopusParameters['ResetDomains']\n$QueuePermissions = $OctopusParameters['QueuePermissions']\n\n$MSMQUsers = $OctopusParameters['MSMQUsers']\n$MSMQPermAllow = $OctopusParameters['MSMQPermAllow']\n$MSMQPermDeny = $OctopusParameters['MSMQPermDeny']\n\n$MSMQAdminUsers = $OctopusParameters['MSMQAdminUsers']\n$MSMQPermAdminAllow = $OctopusParameters['MSMQPermAdminAllow']\n$MSMQPermAdminDeny = $OctopusParameters['MSMQPermAdminDeny']\n\nWrite-Verbose \"`$MSMQQueues = $MSMQQueues\"\nWrite-Verbose \"`$ResetPermissions = $ResetPermissions\"\nWrite-Verbose \"`$ResetDomains = $ResetDomains\"\nWrite-Verbose \"`$QueuePermissions = $QueuePermissions\"\nWrite-Verbose \"`$MSMQUsers = $MSMQUsers\"\nWrite-Verbose \"`$MSMQPermAllow = $MSMQPermAllow\"\nWrite-Verbose \"`$MSMQPermDeny = $MSMQPermDeny\"\nWrite-Verbose \"`$MSMQAdminUsers = $MSMQAdminUsers\"\nWrite-Verbose \"`$MSMQPermAdminAllow = $MSMQPermAdminAllow\"\nWrite-Verbose \"`$MSMQPermAdminDeny = $MSMQPermAdminDeny\"\n\n#Split the Queues into an array\n$arrQueues = $MSMQQueues.split(\";\")\nforeach ($Queue in $arrQueues) \n{\n    #Does Queue Exists Already?\n    $thisQueue = Get-MSMQQueue $Queue\n    if (!$thisQueue)\n    {\n        #not found, create\n        Write-Output \"Creating Queue: \" $Queue\n        New-MsmqQueue -Name \"$Queue\" -Label \"private$\\$Queue\" -Transactional | Out-Null\n        $thisQueue = Get-MSMQQueue $Queue    \n    }\n    else\n    {\n        Write-Output \"Queue Exists: \" $thisQueue.QueueName\n        \n        if($ResetPermissions -eq \"True\")\n        {\n            foreach($domain in $ResetDomains.split(\";\"))\n            {\n                # reset permissions\n                $QueuePermissions = $thisQueue | Get-MsmqQueueACL\n                foreach ($AccessItem in $QueuePermissions)\n                {\n                    $userName = [Environment]::UserName\n                    if($AccessItem.AccountName -NotLike \"*$userName\") # not current user\n                    {\n                        $domain = \"$($domain)*\" #append * to end of domain\n                        if ($AccessItem.AccountName -Like \"$($domain)*\")\n                        {\n                            Write-Output \"Removing Permissions $($AccessItem.Right) for $($AccessItem.AccountName)\"\n                            Try\n                            {\n                                $thisQueue | Set-MsmqQueueACL -UserName $AccessItem.AccountName -Remove $AccessItem.Right | Out-Null\n                            }\n                            Catch\n                            {\n                                Write-Output \"Could not set permissions item $_.Exception.Message\"\n                                Break\n                            }\n                        }\n                    }\n                }\n            }\n        }\n    }\n\n    #set acl for users\n    $arrUsers = $MSMQUsers.split(\";\")\n    foreach ($User in $arrUsers)     \n    {    \n        if ($User)\n        {    \n            Write-Output \"Adding ACL for User: \" $User        \n            \n            #allows\n            if ($MSMQPermAllow)\n            {\n                $arrPermissions = $MSMQPermAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermDeny)\n            {\n                $arrPermissions = $MSMQPermDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny set: $Permission\"\n                }\n            }\n        }\n    }   \n    \n    \n    $arrAdminUsers = $MSMQAdminUsers.split(\";\") \n    foreach ($User in $arrAdminUsers)     \n    {    \n        if ($User)\n        { \n            Write-Output \"Adding ACL for Admin User: \" $User        \n            \n            #allows\n            if ($MSMQPermAdminAllow)\n            {\n                $arrPermissions = $MSMQPermAdminAllow.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Allow $Permission | Out-Null                \n                    Write-Output \"ACL Allow admin set: $Permission\"\n                }\n            }\n                \n            #denies\n            if ($MSMQPermAdminDeny)\n            {\n                $arrPermissions = $MSMQPermAdminDeny.split(\";\")\n                foreach ($Permission in $arrPermissions)     \n                {\n                    $thisQueue | Set-MsmqQueueAcl -UserName $User -Deny $Permission | Out-Null\n                    Write-Output \"ACL Deny admin set: $Permission\"\n                }\n            }\n        }\n    }\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
@@ -16,20 +16,24 @@
   "Parameters": [
     {
       "Id": "35154cac-d005-4a7b-85c9-8eab276e726b",
-      "Name": "$MSMQQueues",
+      "Name": "MSMQQueues",
       "Label": "Queue names",
       "HelpText": "Queue names, separated by semicolons. Example: _Queue1;Queue2;Queue3_",
       "DefaultValue": "",
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
       "Id": "6f3a90b7-df04-4884-9cd1-f04ad7a1f97b",
-      "Name": "$MSMQUsers",
+      "Name": "MSMQUsers",
       "Label": "Queue users",
       "HelpText": "Users with access to the queue separated by semicolons. Example: _DOMAIN\\User1;DOMAIN\\User2_",
       "DefaultValue": "",
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
@@ -38,7 +42,9 @@
       "Label": "Allowed permissions",
       "HelpText": "Permissions granted to the queue users, separated by semicolons. Example: _DeleteMessage;PeekMessage;ReceiveMessage_",
       "DefaultValue": "DeleteMessage;PeekMessage;ReceiveMessage;WriteMessage",
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
@@ -47,7 +53,9 @@
       "Label": "Denied permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
       "DefaultValue": "TakeQueueOwnership",
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
@@ -56,7 +64,9 @@
       "Label": "Admin queue users",
       "HelpText": "Users with access to the queue separated by semicolons. Example: _DOMAIN\\User1;DOMAIN\\User2_",
       "DefaultValue": null,
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
@@ -74,7 +84,9 @@
       "Label": "Denied admin permissions",
       "HelpText": "Denied permissions, separated by semicolons: _TakeQueueOwnership_",
       "DefaultValue": null,
-      "DisplaySettings": {},
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
       "Links": {}
     },
     {
@@ -100,11 +112,11 @@
       "Links": {}
     }
   ],
-  "LastModifiedOn": "2016-12-15T09:41:00.000Z",
-  "LastModifiedBy": "fireydude",
+  "LastModifiedOn": "2018-03-26T10:22:08.629Z",
+  "LastModifiedBy": "WolfyUK",
   "$Meta": {
-    "ExportedAt": "2016-12-15T09:39:26.862Z",
-    "OctopusVersion": "3.5.7",
+    "ExportedAt": "2018-03-26T10:22:08.629Z",
+    "OctopusVersion": "2018.2.8",
     "Type": "ActionTemplate"
   },
   "Category": "windows"

--- a/step-templates/msmq-create-transactional-queue.json
+++ b/step-templates/msmq-create-transactional-queue.json
@@ -112,7 +112,7 @@
       "Links": {}
     }
   ],
-  "LastModifiedOn": "2018-03-26T10:22:08.629Z",
+  "LastModifiedOn": "2018-03-26T10:41:01.455Z",
   "LastModifiedBy": "WolfyUK",
   "$Meta": {
     "ExportedAt": "2018-03-26T10:22:08.629Z",


### PR DESCRIPTION
…and `$MSMQUsers` parameters. Added missing control types to parameters.

### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
