### PR TITLE
Add step templates for .NET and .NET Core runtime version check

### DIFF
--- a/step-templates/bash-check-net-core-framework-version.json
+++ b/step-templates/bash-check-net-core-framework-version.json
@@ -1,0 +1,44 @@
+{
+  "Id": "ac73fb02-8107-4747-bedf-7e39effa31d4",
+  "Name": ".NET Core - Check .NET Core Framework Version (Bash)",
+  "Description": "Check if given .NET Core framework version (or greater) is installed.",
+  "ActionType": "Octopus.Script",
+  "Version": 43,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "targetVersion=$(get_octopusvariable \"TargetVersion\")\nexact=$(get_octopusvariable \"Exact\")\n\n# required arguments checking\nif [[ ! $targetVersion ]] || [[ ! $exact ]] \nthen\n    echo \"[ERROR]: Missing required argument. Exit!\"\n    exit 1;\nfi\n\ndotNetCorePath=/usr/share/dotnet/shared/Microsoft.NETCore.App\ndotNetCoreVersions=()\nif [ -d \"$dotNetCorePath\" ]; then\n\tcd $dotNetCorePath\n    dotNetCoreVersions=(*/)\nfi\n\nmatchedVersions=()\nfor i in ${dotNetCoreVersions[@]}; do\n\tif [ $exact = true ] || [ $exact = True ]\n    then\n    \tif [[ $i = $targetVersion/ ]]\n        then\n        \tmatchedVersions+=(${i%/})\n        fi\n    else\n    \tif [[ ! $i < $targetVersion/ ]]\n        then\n        \tmatchedVersions+=(${i%/})\n        fi\n    fi\ndone\n\nif [ ${#matchedVersions[@]} -eq 0 ]; then\n    echo \"Can't find .NET Core Runtime $targetVersion installed in the machine.\"\n    exit 1\nelse\n    for i in ${matchedVersions[@]}; do\n    \techo \"Found .NET Core Runtime $i installed in the machine.\"\n\tdone\nfi"
+  },
+  "Parameters": [
+    {
+      "Id": "694207ec-0e0b-42a1-841b-81aa4ee5cb7d",
+      "Name": "TargetVersion",
+      "Label": "Target .NET Core framework version",
+      "HelpText": "The target .NET Core framework version you expect to be installed in the machine. For example, 2.0.5.",
+      "DefaultValue": "2.0.5",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "b570ac4a-44a8-42ef-90c4-822530ff6d52",
+      "Name": "Exact",
+      "Label": "Exact",
+      "HelpText": "If you check \"Exact\", it means the installed .NET Core framework version MUST match target version.\n\nOtherwise, as long as the installed .NET Coreframework version is greater than or equal to target version, the check will pass.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2018-03-30T10:07:36.152Z",
+    "OctopusVersion": "2018.3.4",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "cjuroz",
+  "Category": "bash"
+}

--- a/step-templates/windows-check-net-core-framework-version.json
+++ b/step-templates/windows-check-net-core-framework-version.json
@@ -1,0 +1,48 @@
+{
+  "Id": "929ff903-29de-4217-b6a9-83fbfd477e11",
+  "Name": ".NET Core - Check .NET Core Framework Version",
+  "Description": "Check if given .NET Core framework version (or greater) is installed.",
+  "ActionType": "Octopus.Script",
+  "Version": 2,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "$ErrorActionPreference = \"Stop\" \r\nfunction Get-Parameter($Name, $Default, [switch]$Required) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction Get-DotNetCoreFrameworkVersions() {\r\n    $dotNetCoreVersions = @()\r\n    if(Test-Path \"$env:programfiles/dotnet/shared/Microsoft.NETCore.App\") {\r\n        $dotNetCoreVersions = (ls \"$env:programfiles/dotnet/shared/Microsoft.NETCore.App\").Name\r\n    }\r\n    return $dotNetCoreVersions\r\n}\r\n\r\n$targetVersion = (Get-Parameter \"TargetVersion\" -Required).Trim()\r\n$exact = [boolean]::Parse((Get-Parameter \"Exact\" -Required))\r\n\r\n$matchedVersions = Get-DotNetCoreFrameworkVersions | Where-Object { if ($exact) { $_ -eq $targetVersion } else { $_ -ge $targetVersion }  }\r\nif (!$matchedVersions) { \r\n    throw \"Can't find .NET Core Runtime $targetVersion installed in the machine.\"\r\n}\r\n$matchedVersions | foreach { Write-Host \"Found .NET Core Runtime $_ installed in the machine.\" }",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "694207ec-0e0b-42a1-841b-81aa4ee5cb7d",
+      "Name": "TargetVersion",
+      "Label": "Target .NET Core framework version",
+      "HelpText": "The target .NET Core framework version you expect to be installed in the machine. For example, 2.0.5.",
+      "DefaultValue": "2.0.5",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "b570ac4a-44a8-42ef-90c4-822530ff6d52",
+      "Name": "Exact",
+      "Label": "Exact",
+      "HelpText": "If you check \"Exact\", it means the installed .NET Core framework version MUST match target version.\n\nOtherwise, as long as the installed .NET Coreframework version is greater than or equal to target version, the check will pass.",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2018-03-29T10:34:36.483Z",
+    "OctopusVersion": "3.17.12",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "cjuroz",
+  "Category": "dotnetcore"
+}

--- a/step-templates/windows-check-net-framework-version.json
+++ b/step-templates/windows-check-net-framework-version.json
@@ -1,0 +1,48 @@
+{
+  "Id": "b15c6b3d-20a1-4059-b0e4-75bef1ff41d5",
+  "Name": ".NET - Check .NET Framework Version",
+  "Description": null,
+  "ActionType": "Octopus.Script",
+  "Version": 5,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.ScriptBody": "# This script is based on MSDN: https://msdn.microsoft.com/en-us/library/hh925568\n\n$releaseVersionMapping = @{\n\t378389 = '4.5'     # 4.5\n\t378675 = '4.5.1'   # 4.5.1 installed with Windows 8.1\n\t378758 = '4.5.1'   # 4.5.1 installed on Windows 8, Windows 7 SP1, or Windows Vista SP2\n\t379893 = '4.5.2'   # 4.5.2\n\t393295 = '4.6'     # 4.6 installed with Windows 10\n\t393297 = '4.6'     # 4.6 installed on all other Windows OS versions\n    394254 = '4.6.1'   # 4.6.1 installed on Windows 10\n    394271 = '4.6.1'   # 4.6.1 installed on all other Windows OS versions\n    394802 = '4.6.2'   # 4.6.2 installed on Windows 10\n    394806 = '4.6.2'   # 4.6.2 installed on all other Windows OS versions\n    460798 = '4.7'     # 4.7 installed on Windows 10\n    460805 = '4.7'     # 4.7 installed on all other Windows OS versions\n    461308 = '4.7.1'   # 4.7.1 installed on Windows 10\n    461310 = '4.7.1'   # 4.7.1 installed on all other Windows OS versions\n}\n\nfunction Get-DotNetFrameworkVersions()\n{\n    $dotNetVersions = @()\n    if($baseKey = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', '')) \n    {\n        # To find .NET Framework versions (.NET Framework 1-4)$dotNetVersions\n        if ($ndpKey = $baseKey.OpenSubKey('SOFTWARE\\Microsoft\\NET Framework Setup\\NDP'))\n        {\n\t        foreach ($versionKeyName in $ndpKey.GetSubKeyNames()) \n            {\n\t\t        if ($versionKeyName -match 'v[2|3]') \n                {\n\t\t\t        $versionKey = $ndpKey.OpenSubKey($versionKeyName)\n\t\t\t\t\tif ($versionKey.GetValue('Version', '') -ne '')\n\t\t\t\t\t{\n\t\t\t\t\t\t$version = [version] ($versionKey.GetValue('Version'))\n\t\t\t\t\t\t$dotNetVersions += \"$($version.Major).$($version.Minor)\"\n\t\t\t\t\t}\n\t\t        }\n\t        }\n        \n            # for .NET 4.0\n            if ($ndp40Key = $ndpKey.OpenSubKey(\"v4.0\"))\n            {\n                foreach ($subKeyName in $ndp40Key.GetSubKeyNames())\n                {\n                    $versionKey = $ndp40Key.OpenSubKey($subKeyName)\n\t\t\t        $version = [version]($versionKey.GetValue('Version', ''))\n                    $dotNetVersions += \"$($version.Major).$($version.Minor)\"\n                }\n            }\n        }\n\n        # To find .NET Framework versions (.NET Framework 4.5 and later)\n\t    if ($ndp4Key = $baseKey.OpenSubKey('SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full')) {\n            $releaseKey = $ndp4Key.GetValue('Release')\n            $dotNetVersions += $releaseVersionMapping[$releaseKey]\n\t    }\n    }\n    return $dotNetVersions\n}\n\n$targetVersion = $OctopusParameters['TargetVersion'].Trim()\n$exact = [boolean]::Parse($OctopusParameters['Exact'])\n\n$matchedVersions = Get-DotNetFrameworkVersions | Where-Object { if ($exact) { $_ -eq $targetVersion } else { $_ -ge $targetVersion }  }\nif (!$matchedVersions)\n{ \n    throw \"Can't find .NET $targetVersion installed in the machine.\"\n}\n$matchedVersions | foreach { Write-Host \"Found .NET $_ installed in the machine.\" }",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "e902b08b-2fc3-4f62-aec0-5225533cace8",
+      "Name": "TargetVersion",
+      "Label": "Target .NET framework version",
+      "HelpText": "The target .NET framework version you expect to be installed in the machine. For example, 4.5.2.",
+      "DefaultValue": "4.5.2",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "205e297b-c72c-4d9b-a6fe-9a20ab62d5b0",
+      "Name": "Exact",
+      "Label": "Exact",
+      "HelpText": "If you check \"Exact\", it means the installed .NET framework version MUST match target version.\n\nOtherwise, as long as the installed .NET framework version is greater than or equal to target version, the check will pass.",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2018-01-23T06:29:38.188Z",
+    "OctopusVersion": "3.17.12",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "cjuroz",
+  "Category": "aspnet"
+}


### PR DESCRIPTION
For .NET Core templates powershell and bash versions are provided.