### PR TITLE
Fixes for "Windows Service - Set Recovery on Failure Actions" step template

### DIFF
--- a/step-templates/windows-service-set-recovery-on-failure-actions.json
+++ b/step-templates/windows-service-set-recovery-on-failure-actions.json
@@ -3,13 +3,13 @@
   "Name": "Windows Service - Set Recovery on Failure Actions",
   "Description": "Set the recovery on failure actions for a particular service.",
   "ActionType": "Octopus.Script",
-  "Version": 11,
+  "Version": 12,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "cls\n#ignore above\n\nfunction main\n{\n    $serviceName = Get-OctoParameter -parameterName \"ServiceName\" -parameterDescription \"Service Name\"\n    $firstFailureAction = Get-OctoParameter -parameterName \"FirstFailureAction\" -parameterDescription \"First Failure Action\" -default \"restart\"\n    $secondFailureAction = Get-OctoParameter -parameterName \"SecondFailureAction\" -parameterDescription \"Second Failure Action\" -default \"restart\"\n    $thirdFailureAction = Get-OctoParameter -parameterName \"ThirdFailureAction\" -parameterDescription \"Third Failure Action\" -default \"restart\"\n    $firstFailureDelay = Get-OctoParameter -parameterName \"FirstFailureDelay\" -parameterDescription \"First Failure Delay\" -default 180000\n    $secondFailureDelay = Get-OctoParameter -parameterName \"SecondFailureDelay\" -parameterDescription \"Second Failure Delay\" -default 180000\n    $thirdFailureDelay = Get-OctoParameter -parameterName \"ThirdFailureDelay\" -parameterDescription \"Third Failure Delay\" -default 180000\n    $reset = Get-OctoParameter -parameterName \"Reset\" -parameterDescription \"Reset\" -default 86400\n\n    $service = Get-Service $serviceName -ErrorAction SilentlyContinue\n\n    if (!$service)\n    {\n        Write-Host \"Windows Service '$serviceName' not found, skipping.\"\n        return\n    }\n\n    echo \"Updating the '$serviceName' service with recovery options...\"\n    echo \"    On first failure '$firstFailureAction' after '$firstFailureDelay' milliseconds.\"\n    echo \"    On second failure '$secondFailureAction' after '$secondFailureDelay' milliseconds.\"\n    echo \"    On third failure '$thirdFailureAction' after '$thirdFailureDelay' milliseconds.\"\n    echo \"    Reset after '$reset' minutes.\"\n\n    sc.exe failure $service.Name actions= $firstFailureAction/$firstFailureDelay/$secondFailureAction/$secondFailureDelay/$thirdFailureAction/$thridFailureDelay reset= $reset\n\n    echo \"Done\"\n}\n\nfunction Get-OctoParameter() \n{\n    Param\n    (\n        [Parameter(Mandatory=$true)]$parameterName,\n        [Parameter(Mandatory=$true)]$parameterDescription,\n        [Parameter(Mandatory=$false)]$default\n    )\n\n    $ErrorActionPreference = \"SilentlyContinue\" \n    $value = $OctopusParameters[$parameterName] \n    $ErrorActionPreference = \"Stop\" \n    \n    if (! $value) \n    {\n        if(! $default) \n        {\n            throw \"'$parameterDescription' cannot be empty, please specify a value.\"\n        }\n\n        return $default\n    }\n    \n    return $value\n}\n\nmain",
+    "Octopus.Action.Script.ScriptBody": "cls\n#ignore above\n\nfunction main\n{\n    $serviceName = Get-OctoParameter -parameterName \"ServiceName\" -parameterDescription \"Service Name\"\n    $firstFailureAction = Get-OctoParameter -parameterName \"FirstFailureAction\" -parameterDescription \"First Failure Action\" -default \"restart\"\n    $secondFailureAction = Get-OctoParameter -parameterName \"SecondFailureAction\" -parameterDescription \"Second Failure Action\" -default \"restart\"\n    $thirdFailureAction = Get-OctoParameter -parameterName \"ThirdFailureAction\" -parameterDescription \"Third Failure Action\" -default \"restart\"\n    $firstFailureDelay = Get-OctoParameter -parameterName \"FirstFailureDelay\" -parameterDescription \"First Failure Delay\" -default 180000\n    $secondFailureDelay = Get-OctoParameter -parameterName \"SecondFailureDelay\" -parameterDescription \"Second Failure Delay\" -default 180000\n    $thirdFailureDelay = Get-OctoParameter -parameterName \"ThirdFailureDelay\" -parameterDescription \"Third Failure Delay\" -default 180000\n    $reset = Get-OctoParameter -parameterName \"Reset\" -parameterDescription \"Reset\" -default 86400\n\n    $service = Get-Service $serviceName -ErrorAction SilentlyContinue\n\n    if (!$service)\n    {\n        Write-Host \"Windows Service '$serviceName' not found, skipping.\"\n        return\n    }\n\n    echo \"Updating the '$serviceName' service with recovery options...\"\n    echo \"    On first failure '$firstFailureAction' after '$firstFailureDelay' milliseconds.\"\n    echo \"    On second failure '$secondFailureAction' after '$secondFailureDelay' milliseconds.\"\n    echo \"    On third failure '$thirdFailureAction' after '$thirdFailureDelay' milliseconds.\"\n    echo \"    Reset after '$reset' minutes.\"\n\n    sc.exe failure $service.Name actions= $firstFailureAction/$firstFailureDelay/$secondFailureAction/$secondFailureDelay/$thirdFailureAction/$thirdFailureDelay reset= $reset\n\n    echo \"Done\"\n}\n\nfunction Get-OctoParameter() \n{\n    Param\n    (\n        [Parameter(Mandatory=$true)]$parameterName,\n        [Parameter(Mandatory=$true)]$parameterDescription,\n        [Parameter(Mandatory=$false)]$default\n    )\n\n    $ErrorActionPreference = \"SilentlyContinue\" \n    $value = $OctopusParameters[$parameterName] \n    $ErrorActionPreference = \"Stop\" \n    \n    if (! $value) \n    {\n        if(! $default) \n        {\n            throw \"'$parameterDescription' cannot be empty, please specify a value.\"\n        }\n\n        return $default\n    }\n    \n    return $value\n}\n\nmain",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null
@@ -36,7 +36,7 @@
       "DefaultValue": "restart",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
+        "Octopus.SelectOptions": "\"\"|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
       },
       "Links": {}
     },
@@ -61,7 +61,7 @@
       "DefaultValue": "restart",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
+        "Octopus.SelectOptions": "\"\"|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
       },
       "Links": {}
     },
@@ -86,7 +86,7 @@
       "DefaultValue": "restart",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
+        "Octopus.SelectOptions": "\"\"|Take No Action\nrestart|Restart Service\nreboot|Reboot Computer"
       },
       "Links": {}
     },
@@ -115,11 +115,11 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy":"DavidDeSloovere",
+  "LastModifiedBy": "samcook",
   "$Meta": {
     "ExportedAt": "2017-04-11T16:38:17.527Z",
     "OctopusVersion": "3.12.4",
     "Type": "ActionTemplate"
   },
-  "Category":"Windows"
+  "Category": "Windows"
 }


### PR DESCRIPTION
Fix for typo in `$thirdFailureDelay` variable name.
Use `""` instead of empty string for "Take no action" to avoid it being replaced with the default `restart`.

---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
