### PR TITLE
Add SSIS Deploy of SQL Agent Job

### DIFF
--- a/step-templates/ssis-deploy-sqlagentjob.json
+++ b/step-templates/ssis-deploy-sqlagentjob.json
@@ -1,7 +1,7 @@
 {
   "Id": "67cfc200-9523-45a9-8d80-372f52c3e030",
   "Name": "SSIS - Deploy SQL Agent Job",
-  "Description": "Deploy a SQL Agent Job for SSIS Ispac Deployment. Requires SMO to be installed on the machine where this step will be run ",
+  "Description": "Deploy a SQL Agent Job for SSIS Ispac Deployment. Requires SMO to be installed on the machine where this step will be run. ",
   "ActionType": "Octopus.Script",
   "Version": 9,
   "CommunityActionTemplateId": null,

--- a/step-templates/ssis-deploy-sqlagentjob.json
+++ b/step-templates/ssis-deploy-sqlagentjob.json
@@ -1,0 +1,182 @@
+{
+  "Id": "67cfc200-9523-45a9-8d80-372f52c3e030",
+  "Name": "SSIS - Deploy SQL Agent Job",
+  "Description": "Deploy a SQL Agent Job for SSIS Ispac Deployment. Requires SMO to be installed on the machine where this step will be run ",
+  "ActionType": "Octopus.Script",
+  "Version": 9,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false",
+    "Octopus.Action.Script.ScriptBody": "Function Format-OctopusArgument\r\n{\r\n\r\n    <#\r\n    .SYNOPSIS\r\n    Converts boolean values to boolean types\r\n\r\n    .DESCRIPTION\r\n    Converts boolean values to boolean types\r\n\r\n    .PARAMETER Value\r\n    The value to convert\r\n\r\n    .EXAMPLE\r\n    Format-OctopusArgument \"true\"\r\n    #>\r\n    Param(\r\n        [string]$Value\r\n    )\r\n\r\n    $Value = $Value.Trim()\r\n\r\n    # There must be a better way to do this\r\n    Switch -Wildcard ($Value)\r\n    {\r\n\r\n        \"True\"\r\n        { Return $True\r\n        }\r\n        \"False\"\r\n        { Return $False\r\n        }\r\n        \"#{*}\"\r\n        { Return $null\r\n        }\r\n        Default\r\n        { Return $Value\r\n        }\r\n    }\r\n}\r\n\r\n\r\nFunction Get-SSISCommand\r\n{\r\n\r\n    <#\r\n    .SYNOPSIS\r\n    Format the SSIS Command that execute the package.\r\n    Only valid for now for Project Deployment ($typecommand = '/ISSERVER \"\\')\r\n\r\n    .DESCRIPTION\r\n    Return a string with the correct format to execute a Project Package Deploy (Step).\r\n    The SSIS Command can be built by paramaters (ServerName, CatalogName, ProjectName, FolderName, Package and Environment)\r\n    @TO-DO:\r\n    But most of the cases need an ending string that could be the same for most of the deployments.\r\n    I will keep this as a Octopus Parameter by now.\r\n\r\n\r\n    #>\r\n\r\n    Param($ServerName, $CatalogName, $FolderName, $ProjectName, $PackageName, $EnvironmentName)\r\n    process {\r\n        $environmentid = Get-EnvironmentId -ServerName $ServerName -EnvironmentName $EnvironmentName\r\n        write-host \"The Environmemnt Id found for $EnvironmentName is $environmentid\"\r\n        $slash = '\\'\r\n        $quotes = '\"'\r\n        $typecommand = '/ISSERVER \"\\'\r\n        $environmentCommand = '\\\"\" /ENVREFERENCE ' + $environmentid.ToString()\r\n        $packagep = $slash + $CatalogName + $slash + $FolderName + $slash + $ProjectName + $slash + $PackageName + '.dtsx' + $slash\r\n        $servertype = '\" /SERVER \"\\\"'\r\n        $commandoptions = ' /Par \"\\\"$ServerOption::LOGGING_LEVEL(Int16)\\\"\";1 /Par \"\\\"$ServerOption::SYNCHRONIZED(Boolean)\\\"\";True /CALLERINFO SQLAGENT /REPORTING E'\r\n    }\r\n    end {\r\n        return $typecommand + $quotes + $packagep + $quotes + $servertype + $ServerName + $environmentCommand + $commandoptions\r\n    }\r\n\r\n}\r\n\r\nFunction Get-EnvironmentId\r\n{\r\n    <#\r\n    .SYNOPSIS\r\n    Get the ID of the Environment by Name of Environment\r\n\r\n    .DESCRIPTION\r\n    ProjectDeploy Packages use Enviroments for variables previously deployed for the package.\r\n    To be able to format the SSIS Command, we will need the Environment ID\r\n\r\n    .PARAMETER ServerName\r\n    .PARAMETER CatalogName\r\n    .PARAMETER FolderName\r\n    .PARAMETER ProjectName\r\n    .PARAMETER PackageName\r\n    .PARAMETER EnvironmentName\r\n    #>\r\n\r\n    Param($ServerName, $EnvironmentName)\r\n    $query = \"select environment_id from [SSISDB].[internal].[environments] where environment_name = '$EnvironmentName'\"\r\n    $EnvironmentId = Invoke-Sqlcmd  -Query $query -ServerInstance $ServerName -Verbose\r\n    return $EnvironmentId.environment_id\r\n}\r\n\r\nFunction Add-Job\r\n{\r\n    <#\r\n    .SYNOPSIS\r\n    Add a new type of Job in SQL Agent Job\r\n\r\n    .DESCRIPTION\r\n    The function will remove an existing Job with same name (SQL SMO Job doesnt contains update function)\r\n    and it will return as GlobalVariable the JOb Object.\r\n\r\n    .PARAMETER JobName\r\n    .PARAMETER ServerName\r\n    .PARAMETER EnvironmentName\r\n    .PARAMETER JobStepName\r\n    .PARAMETER JobStepCommand\r\n    #>\r\n\r\n    param($JobName, $ServerName, $EnvironmentName, $JobsStepName, $JobStepCommand, $JobCategory )\r\n    try\r\n    {\r\n        $server = New-Object Microsoft.SqlServer.Management.Smo.Server($ServerName)\r\n        $server.JobServer.HostLoginName\r\n        $existingjob = $server.Jobserver.Jobs|where-object {$_.Name -like $JobName}\r\n        if ($existingjob)\r\n        {\r\n            Write-Host \"|- Dropping Job [$JobName]...\" -NoNewline\r\n            $existingjob.drop()\r\n            Write-Host \"|- Done\" -ForegroundColor Green\r\n        }\r\n\r\n        $job = New-Object Microsoft.SqlServer.Management.SMO.Agent.Job($server.JobServer, $jobName)\r\n        #$job.DropIfExists() only for sqlserver 2016\r\n        $job.Create()\r\n        $job.OwnerLoginName = \"sa\"\r\n        $job.Category = $JobCategory\r\n        $job.ApplyToTargetServer($server.Name)\r\n\r\n\r\n    }\r\n    catch\r\n    {\r\n        write-host \"####### Error Adding a job\" -ForegroundColor Red\r\n        write-host $_.Exception.Message\r\n    }\r\n    #Instead of creating a class and return a Job, lets settup a global variable. Return statament doenst return all script output\r\n    $Global:newjob = $job\r\n\r\n}\r\n\r\nFunction Add-JobStep\r\n{\r\n    <#\r\n    .SYNOPSIS\r\n    Add a job step to a Job\r\n\r\n    .DESCRIPTION\r\n    The function will remove an existing Job with same name (SQL SMO Job doesnt contains update function)\r\n    and it will return as GlobalVariable t\r\n     he JOb Object.\r\n    .PARAMETER Job\r\n    .PARAMETER JobStepName\r\n    .PARAMETER JobStepCommand\r\n    #>\r\n    param($job, $JobStepName, $CommandJob )\r\n    try\r\n    {\r\n        $jobStep = New-Object Microsoft.SqlServer.Management.Smo.Agent.JobStep($job, 'Step Number 1')\r\n        $jobStep.Subsystem = [Microsoft.SqlServer.Management.Smo.Agent.AgentSubSystem]::SSIS\r\n        $jobStep.Command = $CommandJob\r\n        $jobStep.Create()\r\n    }\r\n    catch\r\n    {\r\n        write-host \"#########   Error adding a job step\" -ForegroundColor Red\r\n        write-host $_.Exception.Message\r\n    }\r\n\r\n\r\n}\r\n\r\nFunction Add-JobSchedule\r\n{\r\n    param($job, $JobScheduleName, $FrecuencyInterval, $startHour, $startMinutes)\r\n    try\r\n    {\r\n        $name = $job.Name\r\n        $SQLJobSchedule = New-Object -TypeName Microsoft.SqlServer.Management.SMO.Agent.JobSchedule($job, \"lala\")\r\n        $SQLJobSchedule.FrequencyTypes =  [Microsoft.SqlServer.Management.SMO.Agent.FrequencyTypes]::Daily\r\n        # Setup Frequency Interval\r\n        $SQLJobSchedule.FrequencyInterval = $FrecuencyInterval\r\n        # Job Start\r\n        $timeofday = New-TimeSpan -hours $startHour -minutes $startMinutes\r\n        $SQLJobSchedule.ActiveStartTimeOfDay = $timeofday\r\n        #Activate the Job\r\n        $SQLJobSchedule.ActiveStartDate = Get-Date\r\n        $SQLJobSchedule.Create()\r\n    }\r\n    catch\r\n    {\r\n        Write-Host \"Error\" -ForegroundColor Red\r\n        write-host \"Exception Type: $($_.Exception.GetType().FullName)\" -ForegroundColor Red\r\n        write-host \"Exception Message: $($_.Exception.Message)\" -ForegroundColor Red\r\n        $error[0]|format-list -force\r\n\r\n    }\r\n\r\n}\r\n\r\nFunction Set-SQLJob\r\n{\r\n    #Get-Octopus Variables\r\n    Write-Host \"Collecting Octopus Variables\"\r\n\r\n    $ServerName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_ServerName\"]\r\n    $FolderName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_FolderName\"]\r\n    $ProjectName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_ProjectName\"]\r\n    $CatalogName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_CatalogName\"]\r\n    $EnvironmentName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_EnvironmentName\"]\r\n    $PackageName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_PackageName\"]\r\n    $JobName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobName\"]\r\n    $JobCategory =  Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobCategory\"]\r\n    $JobStepName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobStepName\"]\r\n    $JobScheduleName = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobScheduleName\"]\r\n    $JobExecutionFrequency = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobExecutionFrequency\"]\r\n    $JobFrequencyInterval = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobFrequencyInterval\"]\r\n    $JobExecutionTimeHour = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobExecutionTimeHour\"]\r\n    $JobExecutionTimeMinute = Format-OctopusArgument -Value $OctopusParameters[\"SSIS_JobExecutionTimeMinute\"]\r\n\r\n\r\n   # FrecuencyType is hardcoded\r\n\r\n    #Getting Module\r\n    $Module = Get-Module |where-object {$_.Name -like \"sqlserver\"} | Select-object Name\r\n    If ($Module -ne \"sqlserver\")\r\n    {\r\n        Import-Module sqlserver -DisableNameChecking\r\n    }\r\n\r\n    #First step is to generate the command execution for Job Step.\r\n    $JobStepCommand = Get-SSISCommand -ServerName $ServerName -CatalogName $CatalogName -FolderName $FolderName -ProjectName $ProjectName -PackageName $PackageName -EnvironmentName $EnvironmentName -Verbose\r\n\r\n    write-Host \"Command found to deploy Step is \"\r\n    write-Host $JobStepCommand\r\n    write-Host \"STARTING DEPLOYMENT \"\r\n    write-Host \"|- Start Adding the Job $JobName\"\r\n    Add-Job -JobName $JobName -ServerName $ServerName -EnvironmentName $EnvironmentName -JobsStepName $JobStepName -JobStepCommand $JobStepCommandmand\r\n    write-Host \"|- $JobName Added to $ServerName\"\r\n\r\n    write-Host \"|--- Start Adding the JobStep $JobStepName to Job $JobName\"\r\n    Add-JobStep -JobStepName $JobStepName -CommandJob $JobStepCommand -Job $Global:newjob\r\n    write-Host \"|--- $JobStepName added to Job $JobName\"\r\n\r\n    write-Host \"|----  Start Adding JobShedule  $JobScheduleName JobStep $JobName\"\r\n    Add-JobSchedule -job $Global:newjob  -JobScheduleName $JobScheduleName -FrecuencyInterval $JobFrequencyInterval -startHour $JobExecutionTimeHour -startMinutes $JobExecutionTimeMinute\r\n    write-Host \"|---- $JobStepName added to Job $JobName\"\r\n}\r\n\r\nWrite-Host \"Starting deployment of SQL Job\"\r\n\r\n\r\nSet-SQLJob\r\n\r\n\r\nWrite-Host \"Finishing Install\"\r\n",
+    "Octopus.Action.Script.ScriptFileName": null,
+    "Octopus.Action.Package.FeedId": null,
+    "Octopus.Action.Package.PackageId": null
+  },
+  "Parameters": [
+    {
+      "Id": "44a2fa3c-3117-450b-8004-ebdbfd2362e9",
+      "Name": "SSIS_ServerName",
+      "Label": "Server Name",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "ae040e98-f686-4f44-ad80-8939fbd902e4",
+      "Name": "SSIS_FolderName",
+      "Label": "Folder Name",
+      "HelpText": "Folder Name of the deployed package",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "3e755e91-afb5-46c3-ad61-47bf80ac88b8",
+      "Name": "SSIS_ProjectName",
+      "Label": "Project Name",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "21dc0b13-7db0-4c99-b512-53dbfad55893",
+      "Name": "SSIS_CatalogName",
+      "Label": "Catalog Name",
+      "HelpText": "By default SSISDB",
+      "DefaultValue": "SSISDB",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "eb197ae7-99e1-41a2-aee4-5b379fdb349c",
+      "Name": "SSIS_EnvironmentName",
+      "Label": "Environment Name",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "94f97e01-d04c-4696-ad0a-e170a21ecd87",
+      "Name": "SSIS_PackageName",
+      "Label": "Package Name",
+      "HelpText": "Complete name of the package to execute, without dtsx extension",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "cb138aa6-2f51-4ebd-b744-9b0d17535ea1",
+      "Name": "SSIS_JobName",
+      "Label": "Job Name",
+      "HelpText": "Name of the SQL Job",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "458225af-7d11-4f98-b984-2fe02e66996e",
+      "Name": "SSIS_JobStepName",
+      "Label": "Job Step Name",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "07d85895-e548-4f54-a403-25cc53fa1a88",
+      "Name": "SSIS_JobSheduleName",
+      "Label": "Job Schedule Name",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "023f21b1-7757-42f2-8b69-e9a95deb7bae",
+      "Name": "SSIS_JobExecutionFrequency",
+      "Label": "Job Execution Frequency",
+      "HelpText": "Frequency of execution",
+      "DefaultValue": "Daily",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "AutoStart\nDaily\nMonthly\nMonthlyRelative\nOneTime\nOnidle\nUnknow\nWeekly"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "25efa439-5490-4ed4-a70f-7b514bd18446",
+      "Name": "SSIS_JobFrequencyInterval",
+      "Label": "Job Frequency Interval",
+      "HelpText": "Depends of Job Execution Frequency.\nExample:\n1 -> Recurs every 1 Day\n2 -> Recurs every 2 Weeks",
+      "DefaultValue": "1",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "50b3ab13-8635-4631-a247-092792364902",
+      "Name": "SSIS_JobExecutionTimeHour",
+      "Label": "Job Execution Time Hour",
+      "HelpText": "Hour of the day to execute the job",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "4d57dc4e-8717-4f05-bdad-0f16cc9b566d",
+      "Name": "SSIS_JobExecutionTimeMinute",
+      "Label": "Job Execution Time Minute",
+      "HelpText": "Minutes of the day to execute the job",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "7a4c18db-51c3-48e7-ab04-b4f084dde3de",
+      "Name": "SSIS_JobCategory",
+      "Label": "Job Category",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    }
+  ],
+  "LastModifiedOn": "2018-04-04T10:59:08.819Z",
+  "LastModifiedBy": "andrescolodrero",
+  "$Meta": {
+    "ExportedAt": "2018-04-04T10:59:08.819Z",
+    "OctopusVersion": "3.14.15",
+    "Type": "ActionTemplate"
+  },
+  "Category": "sql"
+}

--- a/step-templates/tests/scripts/ssis-deploy-sqlagentjob.Tests.ps1
+++ b/step-templates/tests/scripts/ssis-deploy-sqlagentjob.Tests.ps1
@@ -1,0 +1,71 @@
+Import-Module Pester
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$dirName = Split-Path -Leaf $here
+write-host $here
+$toTest = (Join-Path $here "..\..\step-template\ssis-deploy-sqlagentjob.ps1")
+
+# Initialize OctopusParameters
+$OctopusParameters = @{}
+$OctopusParameters.Add("SSIS_ServerName", "localhost")
+$OctopusParameters.Add("SSIS_FolderName", "Hekla")
+$OctopusParameters.Add("SSIS_ProjectName", "Dummy.MA.Postings.ispac")
+$OctopusParameters.Add("SSIS_PackageName", "Package")
+$OctopusParameters.Add("SSIS_JobName", "1 Job Name Testing")
+$OctopusParameters.Add("SSIS_CatalogName", "SSISDB")
+$OctopusParameters.Add("SSIS_EnvironmentName", "Test")
+$OctopusParameters.Add("SSIS_JobStepName", "Job Step Name Test 1")
+$OctopusParameters.Add("SSIS_JobScheduleName", "Job Schedule Name")
+$OctopusParameters.Add("SSIS_JobExecutionFrequency", "Daily")
+$OctopusParameters.Add("SSIS_JobFrequencyInterval", "1")
+$OctopusParameters.Add("SSIS_JobExecutionTimeHour", "12")
+$OctopusParameters.Add("SSIS_JobExecutionTimeMinute", "00")
+
+
+#arrange: We need to deploy first a project
+$expectedProjectName = $OctopusParameters["SSIS_ProjectName"]
+$isPester = $True #Indicate to script this is test
+. "$toTest"
+
+
+
+Describe "Validate Scripts and Powershell " {
+    # Add Tests
+    write-host "Executing...."
+    write-host $toTest
+        Context 'Step Template Setup' {
+        It "Arion-deploy-sqljob.ps1 is correct ps1" {
+            $toTest | Should Exist
+        }
+
+        It "File Contains valid ps1" {
+            $psFile = Get-Content -Path $toTest -ErrorAction Stop
+            $errors = $null
+            $null = [System.Management.Automation.PSParser]::Tokenize($psFile, [ref]$errors)
+            $errors.Count | Should Be 0
+         }
+
+    } #end of context
+
+}
+
+Describe "Check Project Exists " {
+    # Add Tests
+    write-host "returning $Catalog"
+    Write-Host "Get project $Project"
+    Write-Host "Project time $Project.LastDeployedTime"
+    write-host $toTest
+        Context 'Step Template Setup' {
+        It "Project Name exists" {
+            $Project.Name | Should Be $expectedProjectName
+        }
+
+        It "Deployment Date is Today" {
+            $deploymentDate = $Project.LastDeployedTime
+            $deploymentDate.Date | Should -Be (Get-Date).Date
+         }
+
+    } #end of context
+
+}
+


### PR DESCRIPTION
This is a new Step to complete the deploy of SSIS Packages, ispac type.

The script add SQL Agent Jobs to an Integration Services Server:

Add a Job: Job name, Category and Owner ("sa" hardcoded by now).
Add 1 Job Step: Type: SSIS Package, Package Source: Catalog (Project Deployment) , Server name and Environment name.
Add a Job Shedule: Type (Daily for now, hardcoded), recurring time and time to start.
@to-do:
This current script satisfy my requirements to add a job,. I didnt want to end with way too many parameters. However, it will be necesary to add more features based on the documenation if needed:
https://msdn.microsoft.com/en-us/library/microsoft.sqlserver.management.smo.agent.aspx

Pester Test:
https://gist.github.com/andrescolodrero/98593c2fe51ee73e38a5b9d0babd44bf