### PR TITLE
Added parameter to support uploading files with s3 prefix 

### DIFF
--- a/step-templates/amazon-s3-upload.json
+++ b/step-templates/amazon-s3-upload.json
@@ -3,9 +3,9 @@
   "Name": "Amazon S3 Upload",
   "Description": "Upload files and folders to an S3 bucket from a specified location.\n\nEither specify a single file or a folder containing the files and folders to be uploaded.\n\n**Important!** _For this plugin to function, you must install [AWS Tools for Windows PowerShell](http://aws.amazon.com/powershell/) on your tentacle server and you must restart your tentacle service._",
   "ActionType": "Octopus.Script",
-  "Version": 10,
+  "Version": 11,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "\r\n$recurse = [boolean]::Parse($Recursive)\r\n\r\n$params = @{}\r\n\r\n#Sets the Permissions to public if the selection is true\r\nif ($MakePublic -eq $True) {\r\n    $params.add(\"CannedACLName\", \"public-read\")\r\n}\r\n\r\n#Initialises the S3 Credentials based on the Access Key and Secret Key provided, so that we can invoke the APIs further down\r\nSet-AWSCredentials -AccessKey $S3AccessKey -SecretKey $S3SecretKey -StoreAs S3Creds\r\n\r\n#Initialises the Default AWS Region based on the region provided\r\nSet-DefaultAWSRegion -Region $S3Region\r\n\r\n#Gets all relevant files and uploads them\r\nfunction Upload($item) \r\n{\r\n    #Gets all files and child folders within the given directory\r\n    foreach ($i in Get-ChildItem $item) {\r\n\r\n        #Checks if the item is a folder\r\n        if($i -is [System.IO.DirectoryInfo]) {\r\n\r\n            #Inserts all files within a folder to AWS           \r\n            Write-S3Object -ProfileName S3Creds -BucketName $S3Bucket -KeyPrefix $i.Name -Folder $i.FullName -Recurse:$recurse @params\r\n\r\n        } else {\r\n\r\n            #Inserts file to AWS\r\n            Write-S3Object -ProfileName S3Creds -BucketName $S3Bucket -Key $i.Name -File $i.FullName @params\r\n\r\n        }\r\n    }\r\n}\r\n\r\nUpload($SourceFolderLocation)\r\n",
+    "Octopus.Action.Script.ScriptBody": "\r\n$recurse = [boolean]::Parse($Recursive)\r\n\r\n$params = @{}\r\n\r\n#Sets the Permissions to public if the selection is true\r\nif ($MakePublic -eq $True) {\r\n    $params.add(\"CannedACLName\", \"public-read\")\r\n}\r\n\r\n#Initialises the S3 Credentials based on the Access Key and Secret Key provided, so that we can invoke the APIs further down\r\nSet-AWSCredentials -AccessKey $S3AccessKey -SecretKey $S3SecretKey -StoreAs S3Creds\r\n\r\n#Initialises the Default AWS Region based on the region provided\r\nSet-DefaultAWSRegion -Region $S3Region\r\n\r\n#Gets all relevant files and uploads them\r\nfunction Upload($item) \r\n{\r\n    #Gets all files and child folders within the given directory\r\n    foreach ($i in Get-ChildItem $item) {\r\n\r\n        #Checks if the item is a folder\r\n        if($i -is [System.IO.DirectoryInfo]) {\r\n\r\n            #Inserts all files within a folder to AWS           \r\n            Write-S3Object -ProfileName S3Creds -BucketName $S3Bucket -KeyPrefix $S3Prefix$($i.Name) -Folder $i.FullName -Recurse:$recurse @params\r\n\r\n        } else {\r\n\r\n            #Inserts file to AWS\r\n            Write-S3Object -ProfileName S3Creds -BucketName $S3Bucket -Key $S3Prefix$($i.Name) -File $i.FullName @params\r\n\r\n        }\r\n    }\r\n}\r\n\r\nUpload($SourceFolderLocation)\r\n",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -24,6 +24,15 @@
       "Name": "S3Bucket",
       "Label": "Bucket Name",
       "HelpText": "This is the name of the bucket on S3 to which you'd like your files and folders uploaded.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "S3Prefix",
+      "Label": "Prefix",
+      "HelpText": "This is the prefix for the path you want the folder to be uploaded to if they differ from the source structure.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -75,10 +84,10 @@
       }
     }
   ],
-  "LastModifiedBy": "paulwitt",
+  "LastModifiedBy": "Phillip Haydon",
   "$Meta": {
-    "ExportedAt": "2016-09-16T13:01:48.230+00:00",
-    "OctopusVersion": "3.3.10",
+    "ExportedAt": "2018-04-10T11:05:46.352Z",
+    "OctopusVersion": "2018.2.7",
     "Type": "ActionTemplate"
   },
   "Category": "aws"


### PR DESCRIPTION
This update adds a new parameter to the S3 Upload function allowing a user to add a Prefix.

I needed this so we could version off our assets into S3 by prefixing with the deployment environment and version.

i.e

`#{Environment}/#{Octopus.Release.Number}/`

Then all the files from the source will be in the sub-directory of:

`/staging/8.232.0/`



----

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
