### PR TITLE
New step: Windows service - Change binary path

### DIFF
--- a/step-templates/windows-service-change-binary-path.json
+++ b/step-templates/windows-service-change-binary-path.json
@@ -1,0 +1,46 @@
+{
+  "Id": "b6860fcf-9dee-48a0-afac-85e2098df692",
+  "Name": "Windows Service - Change binary path",
+  "Description": "Change binary path of existing windows service",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "$TheService = Get-Service $ServiceName -ErrorAction SilentlyContinue\nif ($TheService)\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" found, changing path.\"\n    if ($TheService.Status -eq \"Running\")\n    {\n        Write-Host \"Stopping $ServiceName ...\"\n        $TheService.Stop()\n    }\n    sc.exe config $TheService binPath= $BinaryPath\n    Write-Host \"Service \"\"$ServiceName\"\" path changed to \"\"$BinaryPath\"\".\"\n}\nelse\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" not found.\"\n}\n",
+    "Octopus.Action.Package.DownloadOnTentacle": "False"
+  },
+  "Parameters": [
+    {
+      "Id": "b6cfb2c2-7bfd-4d28-ab91-f9f114c2c0dd",
+      "Name": "ServiceName",
+      "Label": "Service name.",
+      "HelpText": "Name of the service to remove. Example: OctopusService",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "d2e685d0-e244-450f-82eb-c435462cdb0f",
+      "Name": "BinaryPath",
+      "Label": "Binary path",
+      "HelpText": "Path to the new service binary. Example: c:\\services\\octopus.exe",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    }
+  ],
+  "LastModifiedOn": "2018-04-10T11:16:06.014Z",
+  "LastModifiedBy": "sphinxy",
+  "$Meta": {
+    "ExportedAt": "2018-04-10T11:16:06.014Z",
+    "OctopusVersion": "4.0.10",
+    "Type": "ActionTemplate"
+  },
+  "Category": "windows"
+}

--- a/step-templates/windows-service-change-binary-path.json
+++ b/step-templates/windows-service-change-binary-path.json
@@ -1,22 +1,22 @@
 {
   "Id": "b6860fcf-9dee-48a0-afac-85e2098df692",
   "Name": "Windows Service - Change binary path",
-  "Description": "Change binary path of existing windows service",
+  "Description": "Change binary path of existing windows service (changes will be effective after service start/stop)",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "$TheService = Get-Service $ServiceName -ErrorAction SilentlyContinue\nif ($TheService)\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" found, changing path.\"\n    if ($TheService.Status -eq \"Running\")\n    {\n        Write-Host \"Stopping $ServiceName ...\"\n        $TheService.Stop()\n    }\n    sc.exe config $TheService binPath= $BinaryPath\n    Write-Host \"Service \"\"$ServiceName\"\" path changed to \"\"$BinaryPath\"\".\"\n}\nelse\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" not found.\"\n}\n",
+    "Octopus.Action.Script.ScriptBody": "$TheService = Get-Service $ServiceName -ErrorAction SilentlyContinue\nif ($TheService)\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" found, changing path.\"\n    sc.exe config $TheService binPath= $BinaryPath\n    Write-Host \"Service \"\"$ServiceName\"\" path changed to \"\"$BinaryPath\"\", restart service to use new path.\"\n}\nelse\n{\n    Write-Host \"Windows Service \"\"$ServiceName\"\" not found.\"\n}\n",
     "Octopus.Action.Package.DownloadOnTentacle": "False"
   },
   "Parameters": [
     {
       "Id": "b6cfb2c2-7bfd-4d28-ab91-f9f114c2c0dd",
       "Name": "ServiceName",
-      "Label": "Service name.",
-      "HelpText": "Name of the service to remove. Example: OctopusService",
+      "Label": "Service name to change binary path.",
+      "HelpText": "Name of the service to change. Example: OctopusService",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -35,10 +35,10 @@
       "Links": {}
     }
   ],
-  "LastModifiedOn": "2018-04-10T11:16:06.014Z",
+  "LastModifiedOn": "2018-05-04T08:38:54.450Z",
   "LastModifiedBy": "sphinxy",
   "$Meta": {
-    "ExportedAt": "2018-04-10T11:16:06.014Z",
+    "ExportedAt": "2018-05-04T08:38:54.450Z",
     "OctopusVersion": "4.0.10",
     "Type": "ActionTemplate"
   },


### PR DESCRIPTION
### Step template checklist

- [x ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x ] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author