### PR TITLE
Fix missing encoding when posting to MS Teams webhook

### DIFF
--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -3,7 +3,7 @@
   "Name": "Microsoft Teams - Post a message",
   "Description": "Posts a message to Microsoft Teams using a general webhook.",
   "ActionType": "Octopus.Script",
-  "Version": 13,
+  "Version": 14,
   "Properties": {
     "Octopus.Action.Script.ScriptBody": "[int]$timeoutSec = $null\nif(-not [int]::TryParse($OctopusParameters['Timeout'], [ref]$timeoutSec)) { $timeoutSec = 60 }\n\n$payload = @{\n    title = $OctopusParameters['Title']\n    text = $OctopusParameters['Body'];\n    themeColor = $OctopusParameters['Color'];\n}\n\nInvoke-RestMethod -Method POST -Uri $OctopusParameters['HookUrl'] -Body ($payload | ConvertTo-Json -Depth 4) -ContentType 'application/json; charset=utf-8' -TimeoutSec $timeoutSec",
     "Octopus.Action.Script.Syntax": "PowerShell",

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -5,7 +5,7 @@
   "ActionType": "Octopus.Script",
   "Version": 13,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[int]$timeoutSec = $null\nif(-not [int]::TryParse($OctopusParameters['Timeout'], [ref]$timeoutSec)) { $timeoutSec = 60 }\n\n$payload = @{\n    title = $OctopusParameters['Title']\n    text = $OctopusParameters['Body'];\n    themeColor = $OctopusParameters['Color'];\n}\n\nInvoke-RestMethod -Method POST -Uri $OctopusParameters['HookUrl'] -Body ($payload | ConvertTo-Json -Depth 4) -ContentType 'application/json' -TimeoutSec $timeoutSec",
+    "Octopus.Action.Script.ScriptBody": "[int]$timeoutSec = $null\nif(-not [int]::TryParse($OctopusParameters['Timeout'], [ref]$timeoutSec)) { $timeoutSec = 60 }\n\n$payload = @{\n    title = $OctopusParameters['Title']\n    text = $OctopusParameters['Body'];\n    themeColor = $OctopusParameters['Color'];\n}\n\nInvoke-RestMethod -Method POST -Uri $OctopusParameters['HookUrl'] -Body ($payload | ConvertTo-Json -Depth 4) -ContentType 'application/json; charset=utf-8' -TimeoutSec $timeoutSec",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -70,7 +70,7 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy": "ekrapfl",
+  "LastModifiedBy": "tbolon",
   "$Meta": {
     "ExportedAt": "2017-04-10T19:26:28.092Z",
     "OctopusVersion": "3.12.1",


### PR DESCRIPTION
This PR only changes the `-ContentType` powershell parameter to include the encoding.

Without it, the inferred encoding by the webhook is ANSI, which does not work.

I have tested the fix manually by sending requests using powershell directly:

```powershell
$payload = @{ title = 'Test'
text = 'Message avec accents : éèû'
}
Invoke-RestMethod -Method POST -Uri https://outlook.office365.com/webhook/xxx/IncomingWebhook/xxx -Body ($payload | ConvertTo-Json -Depth 4) -ContentType 'application/json; charset=utf-8'
```