### PR TITLE
Make Slack notification message field MultiLineText

### DIFF
--- a/step-templates/slack-send-simple-notification.json
+++ b/step-templates/slack-send-simple-notification.json
@@ -3,7 +3,7 @@
   "Name": "Slack - Send Simple Notification",
   "Description": "Send a basic message notification to Slack.",
   "ActionType": "Octopus.Script",
-  "Version": 7,
+  "Version": 8,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
@@ -77,7 +77,7 @@
       "HelpText": "The body of the notification in Slack.\n\nSupported formatting includes: ` ```pre``` `, `_italic_`, `*bold*`, and even `~strike~`.",
       "DefaultValue": "",
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+        "Octopus.ControlType": "MultiLineText"
       },
       "Links": {}
     },


### PR DESCRIPTION
Makes the 'Message' field for Slack notifications into a multiline text area.

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
