### PR TITLE
Update SQL Change Automation step templates

### DIFF
--- a/step-templates/redgate-create-database-release.json
+++ b/step-templates/redgate-create-database-release.json
@@ -1,139 +1,141 @@
 {
-  "Id": "c20b70dc-69aa-42a1-85db-6d37341b63e3",
-  "Name": "Redgate - Create Database Release",
-  "Description": "Creates the resources (including the SQL update script) to deploy database changes using Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage), and exports them as Octopus artifacts so you can review the changes before deploying.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 3rd July, 2018*",
-  "ActionType": "Octopus.Script",
-  "Version": 14,
-  "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn't installed at all or $requiredVersion is specified but that version of SCA isn't installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We've got a version of SCA installed, but $requiredVersion isn't specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we're done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can't just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn't have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there's no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don't have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue('Release') -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]'1.6') {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we're actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n# Version date: 10th July 2018\r\n$ErrorActionPreference = 'Stop'\r\n$VerbosePreference = 'Continue'\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\nif ($SpecificModuleVersion -eq '') {\r\n    $SpecificModuleVersion = $null\r\n}\r\n\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] '3.0.3'\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationDatabaseName)) { throw \"You must enter a value for 'Target database name'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationDatabaseServer)) { throw \"You must enter a value for 'Target SQL Server instance'.\" } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationNuGetDbPackageDownloadStepName)) { throw \"You must enter a value for 'Database package step'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationFilterPath)) { $DLMAutomationFilterPath = $null } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationCompareOptions)) { $DLMAutomationCompareOptions = $null } \r\n\r\n# Get the NuGet package installation directory path.\r\n$packagePath = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Output.Package.InstallationDirectoryPath\"]\r\nif($packagePath -eq $null) {\r\n    throw \"The 'Database package download step' is not a 'Deploy a NuGet package' step: '$DLMAutomationNuGetDbPackageDownloadStepName'\"\r\n}\r\n\r\n# Constructing the unique export path.\r\n$projectId = $OctopusParameters[\"Octopus.Project.Id\"]\r\n$releaseNumber = $OctopusParameters[\"Octopus.Release.Number\"]\r\n$nugetPackageId = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Package.NuGetPackageId\"]\r\n$exportPath = Join-Path (Join-Path (Join-Path $DLMAutomationDeploymentResourcesPath $projectId) $releaseNumber) $nugetPackageId\r\n\r\n# Make sure the directory we're about to create doesn't already exist, and delete any files if requested.\r\nif ((Test-Path $exportPath) -AND ((Get-ChildItem $exportPath | Measure-Object).Count -ne 0)) {\r\n    if ($DLMAutomationDeleteExistingFiles -eq 'True') {\r\n        Write-Host \"Deleting all files in $exportPath\"\r\n        rmdir $exportPath -Recurse -Force\r\n    } else {\r\n        throw \"The export path is not empty: $exportPath.  Select the 'Delete files in export folder' option to overwrite the existing folder contents.\"\r\n    }\r\n}\r\n\r\n# Determine whether or not to include identical objects in the report.\r\n$DLMAutomationIncludeIdenticalsInReport = $DLMAutomationIncludeIdenticalsInReport -eq \"True\"\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationDatabaseServer -Database $DLMAutomationDatabaseName -Username $DLMAutomationDatabaseUsername -Password $DLMAutomationDatabasePassword | Test-DatabaseConnection\r\n$ignoreStaticData = $DLMAutomationIgnoreStaticData -eq \"True\"\r\n\r\n$importedBuildArtifact = Import-DatabaseBuildArtifact -Path $packagePath\r\n\r\n# Only allow sqlcmd variables that don't have special characters like spaces, colon or dashes\r\n$regex = '^[a-zA-Z_][a-zA-Z0-9_]+$'\r\n$sqlCmdVariables = @{}\r\n$OctopusParameters.Keys | Where { $_ -match $regex } | ForEach {\r\n\t$sqlCmdVariables[$_] = $OctopusParameters[$_]\r\n}\r\n\r\n# Create the deployment resources from the database to the NuGet package\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                       -Source $importedBuildArtifact `\r\n                                       -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                       -IgnoreStaticData:$ignoreStaticData `\r\n                                       -FilterPath $DLMAutomationFilterPath `\r\n                                       -SQLCompareOptions $DLMAutomationCompareOptions `\r\n                                       -IncludeIdenticalsInReport:$DLMAutomationIncludeIdenticalsInReport `\r\n                                       -SqlCmdVariables $sqlCmdVariables\r\n\r\n# Export the deployment resources to disk\r\n$release | Export-DatabaseReleaseArtifact -Path $exportPath\r\n        \r\n# Import the changes summary, deployment warnings, and update script as Octopus artifacts, so you can review them.\r\nfunction UploadIfExists() {\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$artifactPath\r\n    ) \r\n    if (Test-Path $artifactPath) {\r\n        New-OctopusArtifact $artifactPath\r\n    }\r\n}\r\n    \r\nUploadIfExists(\"$exportPath\\Reports\\Changes.html\")\r\nUploadIfExists(\"$exportPath\\Reports\\Drift.html\")\r\nUploadIfExists(\"$exportPath\\Reports\\Warnings.xml\")\r\nUploadIfExists(\"$exportPath\\Update.sql\")\r\nUploadIfExists(\"$exportPath\\TargetedDeploymentScript.sql\")\r\n"
-  },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
-      "Name": "DLMAutomationDeploymentResourcesPath",
-      "Label": "Export path",
-      "HelpText": "The path that the database deployment resources will be exported to.\n\nThis path is used in the \"Redgate - Deploy from Database Release\" step, and must be accessible to all tentacles used in database deployment steps.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDeleteExistingFiles",
-      "Label": "Delete files in export folder",
-      "HelpText": "If the folder that the deployment resources are exported to isn't empty, this step will fail. Select this option to delete any files in the folder.",
-      "DefaultValue": "True",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
-      "Name": "DLMAutomationNuGetDbPackageDownloadStepName",
-      "Label": "Database package step",
-      "HelpText": "Select the step in this project which downloads the database package.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "StepName"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseServer",
-      "Label": "Target SQL Server instance",
-      "HelpText": "The fully qualified SQL Server instance name for the target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseName",
-      "Label": "Target database name",
-      "HelpText": "The name of the database that the source schema (the database package) will be compared with to generate the deployment resources. This must be an existing database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseUsername",
-      "Label": "Username (optional)",
-      "HelpText": "The SQL Server username used to connect to the database. If you leave this field and 'Password' blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabasePassword",
-      "Label": "Password (optional)",
-      "HelpText": "You must enter a password if you entered a username.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    },
-    {
-      "Name": "DLMAutomationFilterPath",
-      "Label": "Filter path (optional)",
-      "HelpText": "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationCompareOptions",
-      "Label": "SQL Compare options (optional)",
-      "HelpText": "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTransactionIsolationLevel",
-      "Label": "Transaction isolation level (optional)",
-      "HelpText": "Select the transaction isolation level to be used in deployment scripts.",
-      "DefaultValue": "Serializable",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
-      }
-    },
-    {
-      "Name": "DLMAutomationIgnoreStaticData",
-      "Label": "Ignore static data",
-      "HelpText": "Exclude changes to static data when generating the deployment resources.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
-      "Name": "DLMAutomationIncludeIdenticalsInReport",
-      "Label": "Include identical objects in the change report",
-      "HelpText": "By default, the change report only includes added, modified and removed objects. Choose this option to also include identical objects.",
-      "DefaultValue": "False",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
-      "Name": "SpecificModuleVersion",
-      "Label": "SQL Change Automation version (optional)",
-      "HelpText": "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    }
-  ],
-  "LastModifiedOn": "2018-09-14T14:34Z",
-  "LastModifiedBy": "markgould",
-  "$Meta": {
-    "ExportedAt": "2015-07-17T11:04:21.348Z",
-    "OctopusVersion": "2.6.5.1010",
-    "Type": "ActionTemplate"
-  },
-  "Category": "redgate"
+    "Id":  "c20b70dc-69aa-42a1-85db-6d37341b63e3",
+    "Name":  "Redgate - Create Database Release",
+    "Description":  "Creates the resources (including the SQL update script) to deploy database changes using Redgate\u0027s [SQL Change Automation](http://www.red-gate.com/sca/productpage), and exports them as Octopus artifacts so you can review the changes before deploying.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 2018-10-18*",
+    "ActionType":  "Octopus.Script",
+    "Version":  15,
+    "Properties":  {
+                       "Octopus.Action.Script.ScriptBody":  "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn\u0027t installed at all or $requiredVersion is specified but that version of SCA isn\u0027t installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We\u0027ve got a version of SCA installed, but $requiredVersion isn\u0027t specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we\u0027re done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can\u0027t just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn\u0027t have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there\u0027s no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don\u0027t have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue(\u0027Release\u0027) -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]\u00271.6\u0027) {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we\u0027re actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n\r\n$ErrorActionPreference = \u0027Stop\u0027\r\n$VerbosePreference = \u0027Continue\u0027\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\n#Helper functions for paramter handling\r\nfunction Required() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { throw \"You must enter a value for \u0027$Name\u0027\" }\r\n}\r\nfunction Optional() {\r\n    #Default is untyped here - if we specify [string] powershell will convert nulls into empty string\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $false)]$Default\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { \r\n        $Default\r\n    } else { \r\n        $Parameter\r\n    }\r\n}\r\nfunction RequirePositiveNumber() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    $Result = 0\r\n    if (![int32]::TryParse($Parameter , [ref]$Result )) { throw \"\u0027$Name\u0027 must be a numerical value.\" }\r\n    if ($Result -lt 0) { throw \"\u0027$Name\u0027 must be \u003e= 0.\" }\r\n    $Result\r\n}\r\n\r\n$SpecificModuleVersion = Optional -Parameter $SpecificModuleVersion\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] \u00273.0.3\u0027\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nRequired -Parameter $DLMAutomationDeploymentResourcesPath -Name \u0027Export Path\u0027\r\nRequired -Parameter $DLMAutomationDeleteExistingFiles -Name \u0027Delete files in export folder\u0027\r\nRequired -Parameter $DLMAutomationNuGetDbPackageDownloadStepName -Name \u0027Database package step\u0027\r\nRequired -Parameter $DLMAutomationDatabaseServer -Name \u0027Target SQL Server instance\u0027\r\nRequired -Parameter $DLMAutomationDatabaseName -Name \u0027Target database name\u0027\r\n$DLMAutomationDatabaseUsername = Optional -Parameter $DLMAutomationDatabaseUsername\r\n$DLMAutomationDatabasePassword = Optional -Parameter $DLMAutomationDatabasePassword\r\n$DLMAutomationFilterPath = Optional -Parameter $DLMAutomationFilterPath\r\n$DLMAutomationCompareOptions = Optional -Parameter $DLMAutomationCompareOptions\r\n$DLMAutomationTransactionIsolationLevel = Optional -Parameter $DLMAutomationTransactionIsolationLevel -Default \u0027Serializable\u0027\r\n$DLMAutomationIgnoreStaticData = Optional -Parameter $DLMAutomationIgnoreStaticData -Default \u0027False\u0027\r\n$DLMAutomationIncludeIdenticalsInReport = Optional -Parameter $DLMAutomationIncludeIdenticalsInReport -Default \u0027False\u0027\r\n\r\n# Get the NuGet package installation directory path.\r\n$packagePath = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Output.Package.InstallationDirectoryPath\"]\r\nif($packagePath -eq $null) {\r\n    throw \"The \u0027Database package download step\u0027 is not a \u0027Deploy a NuGet package\u0027 step: \u0027$DLMAutomationNuGetDbPackageDownloadStepName\u0027\"\r\n}\r\n\r\n# Constructing the unique export path.\r\n$projectId = $OctopusParameters[\"Octopus.Project.Id\"]\r\n$releaseNumber = $OctopusParameters[\"Octopus.Release.Number\"]\r\n$nugetPackageId = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Package.NuGetPackageId\"]\r\n$exportPath = Join-Path (Join-Path (Join-Path $DLMAutomationDeploymentResourcesPath $projectId) $releaseNumber) $nugetPackageId\r\n\r\n# Make sure the directory we\u0027re about to create doesn\u0027t already exist, and delete any files if requested.\r\nif ((Test-Path $exportPath) -AND ((Get-ChildItem $exportPath | Measure-Object).Count -ne 0)) {\r\n    if ($DLMAutomationDeleteExistingFiles -eq \u0027True\u0027) {\r\n        Write-Host \"Deleting all files in $exportPath\"\r\n        rmdir $exportPath -Recurse -Force\r\n    } else {\r\n        throw \"The export path is not empty: $exportPath.  Select the \u0027Delete files in export folder\u0027 option to overwrite the existing folder contents.\"\r\n    }\r\n}\r\n\r\n# Determine whether or not to include identical objects in the report.\r\n$DLMAutomationIncludeIdenticalsInReport = $DLMAutomationIncludeIdenticalsInReport -eq \"True\"\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationDatabaseServer -Database $DLMAutomationDatabaseName -Username $DLMAutomationDatabaseUsername -Password $DLMAutomationDatabasePassword | Test-DatabaseConnection\r\n$ignoreStaticData = $DLMAutomationIgnoreStaticData -eq \"True\"\r\n\r\n$importedBuildArtifact = Import-DatabaseBuildArtifact -Path $packagePath\r\n\r\n# Only allow sqlcmd variables that don\u0027t have special characters like spaces, colon or dashes\r\n$regex = \u0027^[a-zA-Z_][a-zA-Z0-9_]+$\u0027\r\n$sqlCmdVariables = @{}\r\n$OctopusParameters.Keys | Where { $_ -match $regex } | ForEach {\r\n\t$sqlCmdVariables[$_] = $OctopusParameters[$_]\r\n}\r\n\r\n# Create the deployment resources from the database to the NuGet package\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                       -Source $importedBuildArtifact `\r\n                                       -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                       -IgnoreStaticData:$ignoreStaticData `\r\n                                       -FilterPath $DLMAutomationFilterPath `\r\n                                       -SQLCompareOptions $DLMAutomationCompareOptions `\r\n                                       -IncludeIdenticalsInReport:$DLMAutomationIncludeIdenticalsInReport `\r\n                                       -SqlCmdVariables $sqlCmdVariables\r\n\r\n# Export the deployment resources to disk\r\n$release | Export-DatabaseReleaseArtifact -Path $exportPath\r\n        \r\n# Import the changes summary, deployment warnings, and update script as Octopus artifacts, so you can review them.\r\nfunction UploadIfExists() {\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$artifactPath\r\n    ) \r\n    if (Test-Path $artifactPath) {\r\n        New-OctopusArtifact $artifactPath\r\n    }\r\n}\r\n    \r\nUploadIfExists(\"$exportPath\\Reports\\Changes.html\")\r\nUploadIfExists(\"$exportPath\\Reports\\Drift.html\")\r\nUploadIfExists(\"$exportPath\\Reports\\Warnings.xml\")\r\nUploadIfExists(\"$exportPath\\Update.sql\")\r\nUploadIfExists(\"$exportPath\\TargetedDeploymentScript.sql\")\r\nUploadIfExists(\"$exportPath\\DriftRevertScript.sql\")\r\n"
+                   },
+    "SensitiveProperties":  {
+
+                            },
+    "Parameters":  [
+                       {
+                           "Name":  "DLMAutomationDeploymentResourcesPath",
+                           "Label":  "Export path",
+                           "HelpText":  "The path that the database deployment resources will be exported to.\n\nThis path is used in the \"Redgate - Deploy from Database Release\" step, and must be accessible to all tentacles used in database deployment steps.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDeleteExistingFiles",
+                           "Label":  "Delete files in export folder",
+                           "HelpText":  "If the folder that the deployment resources are exported to isn\u0027t empty, this step will fail. Select this option to delete any files in the folder.",
+                           "DefaultValue":  "True",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Checkbox"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationNuGetDbPackageDownloadStepName",
+                           "Label":  "Database package step",
+                           "HelpText":  "Select the step in this project which downloads the database package.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "StepName"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseServer",
+                           "Label":  "Target SQL Server instance",
+                           "HelpText":  "The fully qualified SQL Server instance name for the target database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseName",
+                           "Label":  "Target database name",
+                           "HelpText":  "The name of the database that the source schema (the database package) will be compared with to generate the deployment resources. This must be an existing database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseUsername",
+                           "Label":  "Username (optional)",
+                           "HelpText":  "The SQL Server username used to connect to the database. If you leave this field and \u0027Password\u0027 blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabasePassword",
+                           "Label":  "Password (optional)",
+                           "HelpText":  "You must enter a password if you entered a username.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Sensitive"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationFilterPath",
+                           "Label":  "Filter path (optional)",
+                           "HelpText":  "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationCompareOptions",
+                           "Label":  "SQL Compare options (optional)",
+                           "HelpText":  "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTransactionIsolationLevel",
+                           "Label":  "Transaction isolation level (optional)",
+                           "HelpText":  "Select the transaction isolation level to be used in deployment scripts.",
+                           "DefaultValue":  "Serializable",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Select",
+                                                   "Octopus.SelectOptions":  "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationIgnoreStaticData",
+                           "Label":  "Ignore static data",
+                           "HelpText":  "Exclude changes to static data when generating the deployment resources.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Checkbox"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationIncludeIdenticalsInReport",
+                           "Label":  "Include identical objects in the change report",
+                           "HelpText":  "By default, the change report only includes added, modified and removed objects. Choose this option to also include identical objects.",
+                           "DefaultValue":  "False",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Checkbox"
+                                               }
+                       },
+                       {
+                           "Name":  "SpecificModuleVersion",
+                           "Label":  "SQL Change Automation version (optional)",
+                           "HelpText":  "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       }
+                   ],
+    "LastModifiedOn":  "2018-10-18T14:54:56.366+01:00",
+    "LastModifiedBy":  "support@red-gate.com",
+    "$Meta":  {
+                  "ExportedAt":  "2015-07-17T11:04:21.348Z",
+                  "OctopusVersion":  "2.6.5.1010",
+                  "Type":  "ActionTemplate"
+              },
+    "Category":  "redgate"
 }

--- a/step-templates/redgate-deploy-from-database-release.json
+++ b/step-templates/redgate-deploy-from-database-release.json
@@ -1,93 +1,95 @@
 {
-  "Id": "7d18aeb8-5e69-4c91-aca4-0d71022944e8",
-  "Name": "Redgate - Deploy from Database Release",
-  "Description": "Uses the deployment resources from the 'Redgate - Create Database Release' step to deploy the database changes using Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage).\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 3rd July, 2018*",
-  "ActionType": "Octopus.Script",
-  "Version": 9,
-  "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn't installed at all or $requiredVersion is specified but that version of SCA isn't installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We've got a version of SCA installed, but $requiredVersion isn't specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we're done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can't just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn't have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there's no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don't have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue('Release') -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]'1.6') {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we're actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n# Version date: 10th July 2018\r\n$ErrorActionPreference = 'Stop'\r\n$VerbosePreference = 'Continue'\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\nif ($SpecificModuleVersion -eq '') {\r\n    $SpecificModuleVersion = $null\r\n}\r\n\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] '3.0.3'\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationDeploymentResourcesPath)) { throw \"You must enter a value for 'Export path'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationDatabaseName)) { throw \"You must enter a value for 'Target database name'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationDatabaseServer)) { throw \"You must enter a value for 'Target SQL Server instance'.\" } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationNuGetDbPackageDownloadStepName)) { throw \"You must enter a value for 'Database package step'.\" } \r\n\r\n$queryBatchTimeout = 30\r\nif (![string]::IsNullOrWhiteSpace($DLMAutomationQueryBatchTimeout)) {\r\n    if (![int32]::TryParse($DLMAutomationQueryBatchTimeout , [ref]$queryBatchTimeout )) {\r\n        throw 'The query batch timeout must be a numerical value (in seconds).'\r\n    }\r\n    if ($queryBatchTimeout -lt 0) {\r\n        throw \"The query batch timeout can't be negative.\"\r\n    }\r\n}\r\n\r\n# Check whether database deployment resources export path exists and is a valid directory path \r\nif((Test-Path $DLMAutomationDeploymentResourcesPath) -eq $true) {\r\n    if((Get-Item $DLMAutomationDeploymentResourcesPath) -isnot [System.IO.DirectoryInfo]) {\r\n        throw \"The export path is not a valid folder: $DLMAutomationDeploymentResourcesPath\"\r\n    }\r\n} else {\r\n    throw \"The export path folder doesn't exist, or the current Windows account can't access it: $DLMAutomationDeploymentResourcesPath\"\r\n}\r\n\r\n# Get the NuGet package ID and validate the step name.\r\n$nugetPackageId = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Package.NuGetPackageId\"]\r\nif ($nugetPackageId -eq $null) { \r\n    throw \"The 'Database package download step' is not a 'Deploy a NuGet package' step: '$DLMAutomationNuGetDbPackageDownloadStepName'\"\r\n}\r\n\r\n# Constructing the unique export path.\r\n$projectId = $OctopusParameters['Octopus.Project.Id']\r\n$releaseNumber = $OctopusParameters['Octopus.Release.Number']\r\n$exportPath = Join-Path (Join-Path (Join-Path $DLMAutomationDeploymentResourcesPath $projectId) $releaseNumber) $nugetPackageId\r\n\r\n# Create and test connection to the database.\r\n$databaseConnection = New-DatabaseConnection -ServerInstance $DLMAutomationDatabaseServer `\r\n                                                -Database $DLMAutomationDatabaseName `\r\n                                                -Username $DLMAutomationDatabaseUsername `\r\n                                                -Password $DLMAutomationDatabasePassword | Test-DatabaseConnection\r\n\r\n$releaseUrl = $OctopusParameters['Octopus.Web.BaseUrl'] + $OctopusParameters['Octopus.Web.DeploymentLink']; \r\n# Import and deploy the release.\r\nImport-DatabaseReleaseArtifact $exportPath | Use-DatabaseReleaseArtifact -DeployTo $databaseConnection -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n"
-  },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
-      "Name": "DLMAutomationDeploymentResourcesPath",
-      "Label": "Export path",
-      "HelpText": "The path the database deployment resources were exported to.\n\nThis should be the same path specified in the \"Redgate - Create Database Release\" step, and must be accessible to all tentacles used in database deployment steps.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationNuGetDbPackageDownloadStepName",
-      "Label": "Database package step",
-      "HelpText": "Select the step in this project which downloads the database package.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "StepName"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseServer",
-      "Label": "Target SQL Server instance",
-      "HelpText": "The fully qualified SQL Server instance name for the target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseName",
-      "Label": "Target database name",
-      "HelpText": "The name of the database to deploy changes to. This must be an existing database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabaseUsername",
-      "Label": "Username (optional)",
-      "HelpText": "The SQL Server username used to connect to the database. If you leave this field and 'Password' blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationDatabasePassword",
-      "Label": "Password (optional)",
-      "HelpText": "You must enter a password if you entered a username.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    },
-    {
-      "Name": "DLMAutomationQueryBatchTimeout",
-      "Label": "Query batch timeout (in seconds)",
-      "HelpText": "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
-      "DefaultValue": "30",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "SpecificModuleVersion",
-      "Label": "SQL Change Automation version (optional)",
-      "HelpText": "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    }
-  ],
-  "LastModifiedOn": "2018-09-14T14:34Z",
-  "LastModifiedBy": "markgould",
-  "$Meta": {
-    "ExportedAt": "2015-07-15T16:29:37.447Z",
-    "OctopusVersion": "2.5.5.318",
-    "Type": "ActionTemplate"
-  },
-  "Category": "redgate"
+    "Id":  "7d18aeb8-5e69-4c91-aca4-0d71022944e8",
+    "Name":  "Redgate - Deploy from Database Release",
+    "Description":  "Uses the deployment resources from the \u0027Redgate - Create Database Release\u0027 step to deploy the database changes using Redgate\u0027s [SQL Change Automation](http://www.red-gate.com/sca/productpage).\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 2018-10-18*",
+    "ActionType":  "Octopus.Script",
+    "Version":  10,
+    "Properties":  {
+                       "Octopus.Action.Script.ScriptBody":  "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn\u0027t installed at all or $requiredVersion is specified but that version of SCA isn\u0027t installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We\u0027ve got a version of SCA installed, but $requiredVersion isn\u0027t specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we\u0027re done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can\u0027t just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn\u0027t have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there\u0027s no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don\u0027t have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue(\u0027Release\u0027) -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]\u00271.6\u0027) {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we\u0027re actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n\r\n$ErrorActionPreference = \u0027Stop\u0027\r\n$VerbosePreference = \u0027Continue\u0027\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\n#Helper functions for paramter handling\r\nfunction Required() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { throw \"You must enter a value for \u0027$Name\u0027\" }\r\n}\r\nfunction Optional() {\r\n    #Default is untyped here - if we specify [string] powershell will convert nulls into empty string\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $false)]$Default\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { \r\n        $Default\r\n    } else { \r\n        $Parameter\r\n    }\r\n}\r\nfunction RequirePositiveNumber() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    $Result = 0\r\n    if (![int32]::TryParse($Parameter , [ref]$Result )) { throw \"\u0027$Name\u0027 must be a numerical value.\" }\r\n    if ($Result -lt 0) { throw \"\u0027$Name\u0027 must be \u003e= 0.\" }\r\n    $Result\r\n}\r\n\r\n$SpecificModuleVersion = Optional -Parameter $SpecificModuleVersion\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] \u00273.0.3\u0027\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nRequired -Parameter $DLMAutomationDeploymentResourcesPath -Name \u0027Export path\u0027\r\nRequired -Parameter $DLMAutomationNuGetDbPackageDownloadStepName -Name \u0027Database package step\u0027 \r\nRequired -Parameter $DLMAutomationDatabaseServer -Name  \u0027Target SQL Server instance\u0027\r\nRequired -Parameter $DLMAutomationDatabaseName -Name  \u0027Target database name\u0027\r\n$DLMAutomationDatabaseUsername = Optional -Parameter $DLMAutomationDatabaseUsername\r\n$DLMAutomationDatabasePassword = Optional -Parameter $DLMAutomationDatabasePassword\r\n$DLMAutomationQueryBatchTimeout = Optional -Parameter $DLMAutomationQueryBatchTimeout -Default \u002730\u0027\r\n\r\n$queryBatchTimeout = RequirePositiveNumber -Parameter $DLMAutomationQueryBatchTimeout -Name \u0027Query Batch Timeout\u0027\r\n\r\n# Check whether database deployment resources export path exists and is a valid directory path \r\nif((Test-Path $DLMAutomationDeploymentResourcesPath) -eq $true) {\r\n    if((Get-Item $DLMAutomationDeploymentResourcesPath) -isnot [System.IO.DirectoryInfo]) {\r\n        throw \"The export path is not a valid folder: $DLMAutomationDeploymentResourcesPath\"\r\n    }\r\n} else {\r\n    throw \"The export path folder doesn\u0027t exist, or the current Windows account can\u0027t access it: $DLMAutomationDeploymentResourcesPath\"\r\n}\r\n\r\n# Get the NuGet package ID and validate the step name.\r\n$nugetPackageId = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Package.NuGetPackageId\"]\r\nif ($nugetPackageId -eq $null) { \r\n    throw \"The \u0027Database package download step\u0027 is not a \u0027Deploy a NuGet package\u0027 step: \u0027$DLMAutomationNuGetDbPackageDownloadStepName\u0027\"\r\n}\r\n\r\n# Constructing the unique export path.\r\n$projectId = $OctopusParameters[\u0027Octopus.Project.Id\u0027]\r\n$releaseNumber = $OctopusParameters[\u0027Octopus.Release.Number\u0027]\r\n$exportPath = Join-Path (Join-Path (Join-Path $DLMAutomationDeploymentResourcesPath $projectId) $releaseNumber) $nugetPackageId\r\n\r\n# Create and test connection to the database.\r\n$databaseConnection = New-DatabaseConnection -ServerInstance $DLMAutomationDatabaseServer `\r\n                                                -Database $DLMAutomationDatabaseName `\r\n                                                -Username $DLMAutomationDatabaseUsername `\r\n                                                -Password $DLMAutomationDatabasePassword | Test-DatabaseConnection\r\n\r\n$releaseUrl = $OctopusParameters[\u0027Octopus.Web.BaseUrl\u0027] + $OctopusParameters[\u0027Octopus.Web.DeploymentLink\u0027]; \r\n# Import and deploy the release.\r\nImport-DatabaseReleaseArtifact $exportPath | Use-DatabaseReleaseArtifact -DeployTo $databaseConnection -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n"
+                   },
+    "SensitiveProperties":  {
+
+                            },
+    "Parameters":  [
+                       {
+                           "Name":  "DLMAutomationDeploymentResourcesPath",
+                           "Label":  "Export path",
+                           "HelpText":  "The path the database deployment resources were exported to.\n\nThis should be the same path specified in the \"Redgate - Create Database Release\" step, and must be accessible to all tentacles used in database deployment steps.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationNuGetDbPackageDownloadStepName",
+                           "Label":  "Database package step",
+                           "HelpText":  "Select the step in this project which downloads the database package.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "StepName"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseServer",
+                           "Label":  "Target SQL Server instance",
+                           "HelpText":  "The fully qualified SQL Server instance name for the target database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseName",
+                           "Label":  "Target database name",
+                           "HelpText":  "The name of the database to deploy changes to. This must be an existing database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabaseUsername",
+                           "Label":  "Username (optional)",
+                           "HelpText":  "The SQL Server username used to connect to the database. If you leave this field and \u0027Password\u0027 blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationDatabasePassword",
+                           "Label":  "Password (optional)",
+                           "HelpText":  "You must enter a password if you entered a username.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Sensitive"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationQueryBatchTimeout",
+                           "Label":  "Query batch timeout (in seconds)",
+                           "HelpText":  "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
+                           "DefaultValue":  "30",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "SpecificModuleVersion",
+                           "Label":  "SQL Change Automation version (optional)",
+                           "HelpText":  "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       }
+                   ],
+    "LastModifiedOn":  "2018-10-18T14:54:56.508+01:00",
+    "LastModifiedBy":  "support@red-gate.com",
+    "$Meta":  {
+                  "ExportedAt":  "2015-07-15T16:29:37.447Z",
+                  "OctopusVersion":  "2.5.5.318",
+                  "Type":  "ActionTemplate"
+              },
+    "Category":  "redgate"
 }

--- a/step-templates/redgate-deploy-from-database.json
+++ b/step-templates/redgate-deploy-from-database.json
@@ -1,139 +1,141 @@
 {
-  "Id": "548a661f-0c77-479d-acbd-da1e0875df1d",
-  "Name": "Redgate - Deploy from Database",
-  "Description": "Uses Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage) to deploy a source schema to a SQL Server database without a review step.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 3rd July, 2018*",
-  "ActionType": "Octopus.Script",
-  "Version": 28,
-  "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn't installed at all or $requiredVersion is specified but that version of SCA isn't installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We've got a version of SCA installed, but $requiredVersion isn't specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we're done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can't just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn't have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there's no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don't have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue('Release') -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]'1.6') {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we're actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n# Version date: 10th July 2018\r\n$ErrorActionPreference = 'Stop'\r\n$VerbosePreference = 'Continue'\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\nif ($SpecificModuleVersion -eq '') {\r\n    $SpecificModuleVersion = $null\r\n}\r\n\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] '3.0.3'\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationSourceDatabaseName)) { throw \"You must enter a value for 'Source database name'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationSourceDatabaseServer)) { throw \"You must enter a value for 'Source SQL Server instance'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationTargetDatabaseName)) { throw \"You must enter a value for 'Target database name'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationTargetDatabaseServer)) { throw \"You must enter a value for 'Target SQL Server instance'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationFilterPath)) { $DLMAutomationFilterPath = $null } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationCompareOptions)) { $DLMAutomationCompareOptions = $null }\r\n\r\n$queryBatchTimeout = 30\r\nif (![string]::IsNullOrWhiteSpace($DLMAutomationQueryBatchTimeout)) {\r\n    if (![int32]::TryParse($DLMAutomationQueryBatchTimeout , [ref]$queryBatchTimeout )) {\r\n        throw 'The query batch timeout must be a numerical value (in seconds).'\r\n    }\r\n    if ($queryBatchTimeout -lt 0) {\r\n        throw \"The query batch timeout can't be negative.\"\r\n    }\r\n}\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationTargetDatabaseServer -Database $DLMAutomationTargetDatabaseName -Username $DLMAutomationTargetUsername -Password $DLMAutomationTargetPassword | Test-DatabaseConnection\r\n$sourceDB = New-DatabaseConnection -ServerInstance $DLMAutomationSourceDatabaseServer -Database $DLMAutomationSourceDatabaseName -Username $DLMAutomationSourceUsername -Password $DLMAutomationSourcePassword | Test-DatabaseConnection\r\n\r\n# Create the deployment resources, only adding the arguments that are not null or empty.\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                      -Source $sourceDB `\r\n                                      -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                      -FilterPath $DLMAutomationFilterPath `\r\n                                      -SQLCompareOptions $DLMAutomationCompareOptions\r\n\r\n$releaseUrl = $OctopusParameters['Octopus.Web.BaseUrl'] + $OctopusParameters['Octopus.Web.DeploymentLink']; \r\n# Deploy the source schema to the target database.\r\n$release | Use-DatabaseReleaseArtifact -DeployTo $targetDB -SkipPreUpdateSchemaCheck -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n"
-  },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
-      "Name": "DLMAutomationSourceDatabaseServer",
-      "Label": "Source SQL Server instance",
-      "HelpText": "The fully qualified instance name of the SQL Server that hosts the source database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationSourceDatabaseName",
-      "Label": "Source database name",
-      "HelpText": "The name of the database with the source schema (the schema that will be deployed).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationSourceUsername",
-      "Label": "Username (optional)",
-      "HelpText": "The SQL Server username used to connect to the source database. If you leave this field and 'Password' blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationSourcePassword",
-      "Label": "Password (optional)",
-      "HelpText": "You must enter a password if you entered a username for source database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetDatabaseServer",
-      "Label": "Target SQL Server instance",
-      "HelpText": "The fully qualified SQL Server instance name for the target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetDatabaseName",
-      "Label": "Target database name",
-      "HelpText": "The name of the database to deploy changes to. This must be an existing database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetUsername",
-      "Label": "Username (optional)",
-      "HelpText": "The SQL Server username used to connect to the target database. If you leave this field and 'Password' blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetPassword",
-      "Label": "Password (optional)",
-      "HelpText": "You must enter a password if you entered a username for target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    },
-    {
-      "Name": "DLMAutomationFilterPath",
-      "Label": "Filter path (optional)",
-      "HelpText": "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationCompareOptions",
-      "Label": "SQL Compare options (optional)",
-      "HelpText": "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTransactionIsolationLevel",
-      "Label": "Transaction isolation level (optional)",
-      "HelpText": "Select the transaction isolation level to be used in deployment scripts.",
-      "DefaultValue": "Serializable",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
-      }
-    },
-    {
-      "Name": "DLMAutomationQueryBatchTimeout",
-      "Label": "Query batch timeout (in seconds)",
-      "HelpText": "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
-      "DefaultValue": "30",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "SpecificModuleVersion",
-      "Label": "SQL Change Automation version (optional)",
-      "HelpText": "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    }
-  ],
-  "LastModifiedOn": "2018-09-14T14:34Z",
-  "LastModifiedBy": "markgould",
-  "$Meta": {
-    "ExportedAt": "2015-07-15T16:23:30.409Z",
-    "OctopusVersion": "2.5.5.318",
-    "Type": "ActionTemplate"
-  },
-  "Category": "redgate"
+    "Id":  "548a661f-0c77-479d-acbd-da1e0875df1d",
+    "Name":  "Redgate - Deploy from Database",
+    "Description":  "Uses Redgate\u0027s [SQL Change Automation](http://www.red-gate.com/sca/productpage) to deploy a source schema to a SQL Server database without a review step.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 2018-10-18*",
+    "ActionType":  "Octopus.Script",
+    "Version":  29,
+    "Properties":  {
+                       "Octopus.Action.Script.ScriptBody":  "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn\u0027t installed at all or $requiredVersion is specified but that version of SCA isn\u0027t installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We\u0027ve got a version of SCA installed, but $requiredVersion isn\u0027t specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we\u0027re done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can\u0027t just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn\u0027t have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there\u0027s no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don\u0027t have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue(\u0027Release\u0027) -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]\u00271.6\u0027) {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we\u0027re actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n\r\n$ErrorActionPreference = \u0027Stop\u0027\r\n$VerbosePreference = \u0027Continue\u0027\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\n#Helper functions for paramter handling\r\nfunction Required() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { throw \"You must enter a value for \u0027$Name\u0027\" }\r\n}\r\nfunction Optional() {\r\n    #Default is untyped here - if we specify [string] powershell will convert nulls into empty string\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $false)]$Default\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { \r\n        $Default\r\n    } else { \r\n        $Parameter\r\n    }\r\n}\r\nfunction RequirePositiveNumber() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    $Result = 0\r\n    if (![int32]::TryParse($Parameter , [ref]$Result )) { throw \"\u0027$Name\u0027 must be a numerical value.\" }\r\n    if ($Result -lt 0) { throw \"\u0027$Name\u0027 must be \u003e= 0.\" }\r\n    $Result\r\n}\r\n\r\n$SpecificModuleVersion = Optional -Parameter $SpecificModuleVersion\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] \u00273.0.3\u0027\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nRequired -Parameter $DLMAutomationSourceDatabaseServer -Name \u0027Source SQL Server instance\u0027\r\nRequired -Parameter $DLMAutomationSourceDatabaseName -Name \u0027Source database name\u0027\r\n$DLMAutomationSourceUsername = Optional -Parameter $DLMAutomationSourceUsername\r\n$DLMAutomationSourcePassword = Optional -Parameter $DLMAutomationSourcePassword\r\nRequired -Parameter $DLMAutomationTargetDatabaseServer -Name \u0027Target SQL Server instance\u0027\r\nRequired -Parameter $DLMAutomationTargetDatabaseName -Name \u0027Target database name\u0027\r\n$DLMAutomationTargetUsername = Optional -Parameter $DLMAutomationTargetUsername\r\n$DLMAutomationTargetPassword = Optional -Parameter $DLMAutomationTargetPassword\r\n$DLMAutomationFilterPath = Optional -Parameter $DLMAutomationFilterPath\r\n$DLMAutomationCompareOptions = Optional -Parameter $DLMAutomationCompareOptions\r\n$DLMAutomationTransactionIsolationLevel = Optional -Parameter $DLMAutomationTransactionIsolationLevel -Default \u0027Serializable\u0027\r\n$DLMAutomationQueryBatchTimeout = Optional -Parameter $DLMAutomationQueryBatchTimeout -Default \u002730\u0027\r\n\r\n$queryBatchTimeout = RequirePositiveNumber -Parameter $DLMAutomationQueryBatchTimeout -Name \u0027Query Batch Timeout\u0027\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationTargetDatabaseServer -Database $DLMAutomationTargetDatabaseName -Username $DLMAutomationTargetUsername -Password $DLMAutomationTargetPassword | Test-DatabaseConnection\r\n$sourceDB = New-DatabaseConnection -ServerInstance $DLMAutomationSourceDatabaseServer -Database $DLMAutomationSourceDatabaseName -Username $DLMAutomationSourceUsername -Password $DLMAutomationSourcePassword | Test-DatabaseConnection\r\n\r\n# Create the deployment resources, only adding the arguments that are not null or empty.\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                      -Source $sourceDB `\r\n                                      -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                      -FilterPath $DLMAutomationFilterPath `\r\n                                      -SQLCompareOptions $DLMAutomationCompareOptions\r\n\r\n$releaseUrl = $OctopusParameters[\u0027Octopus.Web.BaseUrl\u0027] + $OctopusParameters[\u0027Octopus.Web.DeploymentLink\u0027]; \r\n# Deploy the source schema to the target database.\r\n$release | Use-DatabaseReleaseArtifact -DeployTo $targetDB -SkipPreUpdateSchemaCheck -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n"
+                   },
+    "SensitiveProperties":  {
+
+                            },
+    "Parameters":  [
+                       {
+                           "Name":  "DLMAutomationSourceDatabaseServer",
+                           "Label":  "Source SQL Server instance",
+                           "HelpText":  "The fully qualified instance name of the SQL Server that hosts the source database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationSourceDatabaseName",
+                           "Label":  "Source database name",
+                           "HelpText":  "The name of the database with the source schema (the schema that will be deployed).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationSourceUsername",
+                           "Label":  "Username (optional)",
+                           "HelpText":  "The SQL Server username used to connect to the source database. If you leave this field and \u0027Password\u0027 blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationSourcePassword",
+                           "Label":  "Password (optional)",
+                           "HelpText":  "You must enter a password if you entered a username for source database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Sensitive"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetDatabaseServer",
+                           "Label":  "Target SQL Server instance",
+                           "HelpText":  "The fully qualified SQL Server instance name for the target database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetDatabaseName",
+                           "Label":  "Target database name",
+                           "HelpText":  "The name of the database to deploy changes to. This must be an existing database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetUsername",
+                           "Label":  "Username (optional)",
+                           "HelpText":  "The SQL Server username used to connect to the target database. If you leave this field and \u0027Password\u0027 blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetPassword",
+                           "Label":  "Password (optional)",
+                           "HelpText":  "You must enter a password if you entered a username for target database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Sensitive"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationFilterPath",
+                           "Label":  "Filter path (optional)",
+                           "HelpText":  "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationCompareOptions",
+                           "Label":  "SQL Compare options (optional)",
+                           "HelpText":  "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTransactionIsolationLevel",
+                           "Label":  "Transaction isolation level (optional)",
+                           "HelpText":  "Select the transaction isolation level to be used in deployment scripts.",
+                           "DefaultValue":  "Serializable",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Select",
+                                                   "Octopus.SelectOptions":  "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationQueryBatchTimeout",
+                           "Label":  "Query batch timeout (in seconds)",
+                           "HelpText":  "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
+                           "DefaultValue":  "30",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "SpecificModuleVersion",
+                           "Label":  "SQL Change Automation version (optional)",
+                           "HelpText":  "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       }
+                   ],
+    "LastModifiedOn":  "2018-10-18T14:54:56.514+01:00",
+    "LastModifiedBy":  "support@red-gate.com",
+    "$Meta":  {
+                  "ExportedAt":  "2015-07-15T16:23:30.409Z",
+                  "OctopusVersion":  "2.5.5.318",
+                  "Type":  "ActionTemplate"
+              },
+    "Category":  "redgate"
 }

--- a/step-templates/redgate-deploy-from-package.json
+++ b/step-templates/redgate-deploy-from-package.json
@@ -1,121 +1,123 @@
 {
-  "Id": "19f750fb-2ce8-4361-859e-2dfcdf08a952",
-  "Name": "Redgate - Deploy from Package",
-  "Description": "Uses Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage) to deploy a package containing a database schema to a SQL Server database, without a review step.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 3rd July, 2018*",
-  "ActionType": "Octopus.Script",
-  "Version": 9,
-  "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn't installed at all or $requiredVersion is specified but that version of SCA isn't installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We've got a version of SCA installed, but $requiredVersion isn't specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we're done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can't just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn't have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there's no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don't have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue('Release') -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]'1.6') {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we're actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n# Version date: 10th July 2018\r\n$ErrorActionPreference = 'Stop'\r\n$VerbosePreference = 'Continue'\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\nif ($SpecificModuleVersion -eq '') {\r\n    $SpecificModuleVersion = $null\r\n}\r\n\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] '3.0.3'\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationTargetDatabaseName)) { throw \"You must enter a value for 'Target database name'.\" }\r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationTargetDatabaseServer)) { throw \"You must enter a value for 'Target SQL Server instance'.\" } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationNuGetDbPackageDownloadStepName)) { throw \"You must enter a value for 'Database package step'.\" } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationFilterPath)) { $DLMAutomationFilterPath = $null } \r\nif ([string]::IsNullOrWhiteSpace($DLMAutomationCompareOptions)) { $DLMAutomationCompareOptions = $null } \r\n\r\n$queryBatchTimeout = 30\r\nif (![string]::IsNullOrWhiteSpace($DLMAutomationQueryBatchTimeout)) {\r\n    if (![int32]::TryParse($DLMAutomationQueryBatchTimeout , [ref]$queryBatchTimeout )) {\r\n        throw 'The query batch timeout must be a numerical value (in seconds).'\r\n    }\r\n    if ($queryBatchTimeout -lt 0) {\r\n        throw \"The query batch timeout can't be negative.\"\r\n    }\r\n}\r\n\r\n# Get the NuGet package installation directory path.\r\n$packageExtractPath = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Output.Package.InstallationDirectoryPath\"]\r\nif($packageExtractPath -eq $null) {\r\n    throw \"The 'Database package download step' is not a 'Deploy a NuGet package' step: '$DLMAutomationNuGetDbPackageDownloadStepName'\"\r\n}\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationTargetDatabaseServer -Database $DLMAutomationTargetDatabaseName -Username $DLMAutomationTargetUsername -Password $DLMAutomationTargetPassword | Test-DatabaseConnection\r\n$ignoreStaticData = $DLMAutomationIgnoreStaticData -eq \"True\"\r\n\r\n$importedBuildArtifact = Import-DatabaseBuildArtifact -Path $packageExtractPath\r\n\r\n# Only allow sqlcmd variables that don't have special characters like spaces, colon or dashes\r\n$regex = '^[a-zA-Z_][a-zA-Z0-9_]+$'\r\n$sqlCmdVariables = @{}\r\n$OctopusParameters.Keys | Where { $_ -match $regex } | ForEach {\r\n\t$sqlCmdVariables[$_] = $OctopusParameters[$_]\r\n}\r\n\r\n# Create database deployment resources from the NuGet package to the database\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                       -Source $importedBuildArtifact `\r\n                                       -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                       -IgnoreStaticData:$ignoreStaticData `\r\n                                       -FilterPath $DLMAutomationFilterPath `\r\n                                       -SQLCompareOptions $DLMAutomationCompareOptions `\r\n                                       -SqlCmdVariables $sqlCmdVariables\r\n\r\n# Deploy the source schema to the target database.\r\nWrite-Host \"Timeout = $queryBatchTimeout\"\r\n$releaseUrl = $OctopusParameters['Octopus.Web.BaseUrl'] + $OctopusParameters['Octopus.Web.DeploymentLink']; \r\n$release | Use-DatabaseReleaseArtifact -DeployTo $targetDB -SkipPreUpdateSchemaCheck -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n\r\n"
-  },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
-      "Name": "DLMAutomationNuGetDbPackageDownloadStepName",
-      "Label": "Database package step",
-      "HelpText": "Select the step in this project which downloads the database package.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "StepName"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetDatabaseServer",
-      "Label": "Target SQL Server instance",
-      "HelpText": "The fully qualified SQL Server instance name for the target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetDatabaseName",
-      "Label": "Target database name",
-      "HelpText": "The name of the database to deploy changes to. This must be an existing database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetUsername",
-      "Label": "Username (optional)",
-      "HelpText": "The SQL Server username used to connect to the database. If you leave this field and 'Password' blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTargetPassword",
-      "Label": "Password (optional)",
-      "HelpText": "You must enter a password if you entered a username.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    },
-    {
-      "Name": "DLMAutomationFilterPath",
-      "Label": "Filter path (optional)",
-      "HelpText": "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationCompareOptions",
-      "Label": "SQL Compare options (optional)",
-      "HelpText": "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DLMAutomationTransactionIsolationLevel",
-      "Label": "Transaction isolation level (optional)",
-      "HelpText": "Select the transaction isolation level to be used in deployment scripts.",
-      "DefaultValue": "Serializable",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
-      }
-    },
-    {
-      "Name": "DLMAutomationIgnoreStaticData",
-      "Label": "Ignore static data",
-      "HelpText": "Exclude changes to static data when generating the deployment resources.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
-      "Name": "DLMAutomationQueryBatchTimeout",
-      "Label": "Query batch timeout (in seconds)",
-      "HelpText": "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
-      "DefaultValue": "30",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "SpecificModuleVersion",
-      "Label": "SQL Change Automation version (optional)",
-      "HelpText": "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    }
-  ],
-  "LastModifiedOn": "2018-09-14T14:34Z",
-  "LastModifiedBy": "markgould",
-  "$Meta": {
-    "ExportedAt": "2015-07-17T11:10:11.871Z",
-    "OctopusVersion": "2.6.5.1010",
-    "Type": "ActionTemplate"
-  },
-  "Category": "redgate"
+    "Id":  "19f750fb-2ce8-4361-859e-2dfcdf08a952",
+    "Name":  "Redgate - Deploy from Package",
+    "Description":  "Uses Redgate\u0027s [SQL Change Automation](http://www.red-gate.com/sca/productpage) to deploy a package containing a database schema to a SQL Server database, without a review step.\r\n\r\nRequires SQL Change Automation version 3.0.2 or later.\r\n\r\n*Version date: 2018-10-18*",
+    "ActionType":  "Octopus.Script",
+    "Version":  10,
+    "Properties":  {
+                       "Octopus.Action.Script.ScriptBody":  "$DlmAutomationModuleName = \"DLMAutomation\"\r\n$SqlChangeAutomationModuleName = \"SqlChangeAutomation\"\r\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\r\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\r\n\r\nfunction IsScaAvailable\r\n{\r\n    if ((Get-Module $SqlChangeAutomationModuleName) -ne $null) {\r\n        return $true\r\n    }\r\n\r\n    return $false\r\n}\r\n\r\nfunction InstallCorrectSqlChangeAutomation\r\n{\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$requiredVersion\r\n    )\r\n\r\n    CheckRequiredDotNetVersionIsInstalled\r\n\r\n    $moduleName = $SqlChangeAutomationModuleName\r\n\r\n    # this will be null if $requiredVersion is not specified - which is exactly what we want\r\n    $maximumVersion = $requiredVersion\r\n\r\n    if ($requiredVersion) {\r\n        if ($requiredVersion.Revision -eq -1) {\r\n            #If provided with a 3 part version number (the 4th part, revision, == -1), we should allow any value for the revision\r\n            $maximumVersion = [Version]\"$requiredVersion.$([System.Int32]::MaxValue)\"\r\n        }\r\n\r\n        if ($requiredVersion.Major -lt 3) {\r\n            # If the specified version is below V3 then the user is requesting a version of DLMA. We should look for that module name instead\r\n            $moduleName = $DlmAutomationModuleName\r\n        }\r\n    }\r\n\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule) {\r\n        #Either SCA isn\u0027t installed at all or $requiredVersion is specified but that version of SCA isn\u0027t installed\r\n        Write-Verbose \"$moduleName $requiredVersion not available - attempting to download from gallery\"\r\n        InstallLocalModule -moduleName $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n    }\r\n    elseif (!$requiredVersion) {\r\n        #We\u0027ve got a version of SCA installed, but $requiredVersion isn\u0027t specified so we might be able to upgrade\r\n        $newest = GetHighestInstallableModule $moduleName\r\n        if ($newest -and ($installedModule.Version -lt $newest.Version)) {\r\n            Write-Verbose \"Updating $moduleName to version $($newest.Version)\"\r\n            InstallLocalModule -moduleName $moduleName -minimumVersion $newest.Version\r\n        }\r\n    }\r\n\r\n    # Now we\u0027re done with install/upgrade, try to import the highest available module that matches our version requirements\r\n\r\n    # We can\u0027t just use -minimumVersion and -maximumVersion arguments on Import-Module because PowerShell 3 doesn\u0027t have them,\r\n    # so we have to find the precise matching installed version using our code, then import that specifically. Note that\r\n    # $requiredVersion and $maximumVersion might be null when there\u0027s no specific version we need.\r\n    $installedModule = GetHighestInstalledModule $moduleName -minimumVersion $requiredVersion -maximumVersion $maximumVersion\r\n\r\n    if (!$installedModule -and !$requiredVersion) {\r\n        #Did not find SCA, and we don\u0027t have a required version so we might be able to use an installed DLMA instead.\r\n        Write-Verbose \"$moduleName is not installed - trying to fall back to $DlmAutomationModuleName\"\r\n        $installedModule = GetHighestInstalledModule $DlmAutomationModuleName        \r\n    }\r\n    \r\n    if ($installedModule) {\r\n        Write-Verbose \"Importing installed $($installedModule.Name) version $($installedModule.Version)\"\r\n        Import-Module $installedModule -Force\r\n    }\r\n    else {\r\n        throw \"$moduleName $requiredVersion is not installed, and could not be downloaded from the PowerShell gallery\"\r\n    }\r\n}\r\n\r\nfunction CheckRequiredDotNetVersionIsInstalled {\r\n    Write-Debug \"Check .NET version pre-requisite\"\r\n\r\n    # Based on https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#ps_a\r\n    $dotNet461Installed = Get-ChildItem \"HKLM:SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\\" -ErrorAction SilentlyContinue | ? {$_.GetValue(\u0027Release\u0027) -ge 394254} \r\n    \r\n    if (!$dotNet461Installed) {\r\n        throw \"SQL Change Automation requires .NET Framework 4.6.1 or later.\"\r\n    }\r\n}\r\n\r\nfunction InstallPowerShellGet {\r\n    [CmdletBinding()]\r\n    Param()\r\n    $psget = GetHighestInstalledModule PowerShellGet\r\n    if (!$psget)\r\n    {\r\n        Write-Warning @\"\r\nCannot access the PowerShell Gallery because PowerShellGet is not installed.\r\nTo install PowerShellGet, either upgrade to PowerShell 5 or install the PackageManagement MSI.\r\nSee https://docs.microsoft.com/en-us/powershell/gallery/installing-psget for more details.\r\n\"@\r\n        throw \"PowerShellGet is not available\"\r\n    }\r\n\r\n    if ($psget.Version -lt [Version]\u00271.6\u0027) {\r\n        #Bootstrap the NuGet package provider, which updates NuGet without requiring admin rights\r\n        Write-Debug \"Installing NuGet package provider\"\r\n        Get-PackageProvider NuGet -ForceBootstrap | Out-Null\r\n\r\n        #Use the currently-installed version of PowerShellGet\r\n        Import-PackageProvider PowerShellGet \r\n        \r\n        #Download the version of PowerShellGet that we actually need\r\n        Write-Debug \"Installing PowershellGet\"\r\n        Save-Module -Name PowerShellGet -Path $LocalModules -MinimumVersion 1.6 -Force\r\n    }\r\n\r\n    Write-Debug \"Importing PowershellGet\"\r\n    Import-Module PowerShellGet -MinimumVersion 1.6 -Force\r\n    #Make sure we\u0027re actually using the package provider from the imported version of PowerShellGet\r\n    Import-PackageProvider ((Get-Module PowerShellGet).Path) | Out-Null\r\n}\r\n\r\nfunction InstallLocalModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true)]\r\n        [string]$moduleName,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n    try {\r\n        InstallPowerShellGet\r\n\r\n        Write-Debug \"Install $moduleName $requiredVersion\"\r\n        Save-Module -Name $moduleName -Path $LocalModules -Force -AcceptLicense -MinimumVersion $minimumVersion -MaximumVersion $maximumVersion -ErrorAction Stop\r\n    }\r\n    catch {\r\n        Write-Warning \"Could not install $moduleName $requiredVersion from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetHighestInstalledModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName,\r\n\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$minimumVersion,\r\n        [Parameter(Mandatory = $false)]\r\n        [Version]$maximumVersion\r\n    )\r\n\r\n    return Get-Module $moduleName -ListAvailable | \r\n           Where {(!$minimumVersion -or ($_.Version -ge $minimumVersion)) -and (!$maximumVersion -or ($_.Version -le $maximumVersion))} | \r\n           Sort -Property Version -Descending |\r\n           Select -First 1\r\n}\r\n\r\nfunction GetHighestInstallableModule {\r\n    [CmdletBinding()]\r\n    Param(\r\n        [Parameter(Mandatory = $true, Position = 0)]\r\n        [string] $moduleName\r\n    )\r\n\r\n    try {\r\n        InstallPowerShellGet\r\n        Find-Module $moduleName -AllVersions -ErrorAction Stop | Sort -Property Version -Descending | Select -First 1    \r\n    }\r\n    catch {\r\n        Write-Warning \"Could not find any suitable versions of $moduleName from any registered PSRepository\"\r\n    }\r\n}\r\n\r\nfunction GetInstalledSqlChangeAutomationVersion {\r\n    $scaModule = (Get-Module $SqlChangeAutomationModuleName)\r\n\r\n    if ($scaModule -ne $null) {\r\n        return $scaModule.Version\r\n    }\r\n\r\n    $dlmaModule = (Get-Module $DlmAutomationModuleName)\r\n\r\n    if ($dlmaModule -ne $null) {\r\n        return $dlmaModule.Version\r\n    }\r\n\r\n    return $null\r\n}\r\n\r\n$ErrorActionPreference = \u0027Stop\u0027\r\n$VerbosePreference = \u0027Continue\u0027\r\n\r\n# Set process level FUR environment\r\n$env:REDGATE_FUR_ENVIRONMENT = \"Octopus Step Templates\"\r\n\r\n#Helper functions for paramter handling\r\nfunction Required() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { throw \"You must enter a value for \u0027$Name\u0027\" }\r\n}\r\nfunction Optional() {\r\n    #Default is untyped here - if we specify [string] powershell will convert nulls into empty string\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $false)]$Default\r\n    )\r\n    if ([string]::IsNullOrWhiteSpace($Parameter)) { \r\n        $Default\r\n    } else { \r\n        $Parameter\r\n    }\r\n}\r\nfunction RequirePositiveNumber() {\r\n    Param(\r\n        [Parameter(Mandatory = $false)][string]$Parameter, \r\n        [Parameter(Mandatory = $true)][string]$Name\r\n    )\r\n    $Result = 0\r\n    if (![int32]::TryParse($Parameter , [ref]$Result )) { throw \"\u0027$Name\u0027 must be a numerical value.\" }\r\n    if ($Result -lt 0) { throw \"\u0027$Name\u0027 must be \u003e= 0.\" }\r\n    $Result\r\n}\r\n\r\n$SpecificModuleVersion = Optional -Parameter $SpecificModuleVersion\r\nInstallCorrectSqlChangeAutomation -requiredVersion $SpecificModuleVersion\r\n\r\n# Check if SQL Change Automation is installed.\t\r\n$powershellModule = Get-Module -Name SqlChangeAutomation\t\r\nif ($powershellModule -eq $null) { \t\r\n    throw \"Cannot find SQL Change Automation on your Octopus Tentacle. If SQL Change Automation is installed, try restarting the Tentacle service for it to be detected.\"\t\r\n}\r\n\r\n$currentVersion = $powershellModule.Version\t\r\n$minimumRequiredVersion = [version] \u00273.0.3\u0027\t\r\nif ($currentVersion -lt $minimumRequiredVersion) { \t\r\n    throw \"This step requires SQL Change Automation version $minimumRequiredVersion or later. The current version is $currentVersion. The latest version can be found at http://www.red-gate.com/sca/productpage\"\t\r\n}\r\n# Check the parameters.\r\nRequired -Parameter $DLMAutomationNuGetDbPackageDownloadStepName -Name \u0027Database package step\u0027 \r\nRequired -Parameter $DLMAutomationTargetDatabaseServer -Name \u0027Target SQL Server instance\u0027\r\nRequired -Parameter $DLMAutomationTargetDatabaseName -Name \u0027Target database name\u0027\r\n$DLMAutomationTargetUsername = Optional -Parameter $DLMAutomationTargetUsername\r\n$DLMAutomationTargetPassword = Optional -Parameter $DLMAutomationTargetPassword\r\n$DLMAutomationFilterPath = Optional -Parameter $DLMAutomationFilterPath\r\n$DLMAutomationCompareOptions = Optional -Parameter $DLMAutomationCompareOptions\r\n$DLMAutomationTransactionIsolationLevel = Optional -Parameter $DLMAutomationTransactionIsolationLevel -Default \"Serializable\"\r\n$DLMAutomationIgnoreStaticData = Optional -Parameter $DLMAutomationIgnoreStaticData -Default \u0027False\u0027\r\n$DLMAutomationQueryBatchTimeout = Optional -Parameter $DLMAutomationQueryBatchTimeout -Default \u002730\u0027\r\n\r\n$queryBatchTimeout = RequirePositiveNumber -Parameter $DLMAutomationQueryBatchTimeout -Name \u0027Query Batch Timeout\u0027\r\n\r\n# Get the NuGet package installation directory path.\r\n$packageExtractPath = $OctopusParameters[\"Octopus.Action[$DLMAutomationNuGetDbPackageDownloadStepName].Output.Package.InstallationDirectoryPath\"]\r\nif($packageExtractPath -eq $null) {\r\n    throw \"The \u0027Database package download step\u0027 is not a \u0027Deploy a NuGet package\u0027 step: \u0027$DLMAutomationNuGetDbPackageDownloadStepName\u0027\"\r\n}\r\n\r\n$targetDB = New-DatabaseConnection -ServerInstance $DLMAutomationTargetDatabaseServer -Database $DLMAutomationTargetDatabaseName -Username $DLMAutomationTargetUsername -Password $DLMAutomationTargetPassword | Test-DatabaseConnection\r\n$ignoreStaticData = $DLMAutomationIgnoreStaticData -eq \"True\"\r\n\r\n$importedBuildArtifact = Import-DatabaseBuildArtifact -Path $packageExtractPath\r\n\r\n# Only allow sqlcmd variables that don\u0027t have special characters like spaces, colon or dashes\r\n$regex = \u0027^[a-zA-Z_][a-zA-Z0-9_]+$\u0027\r\n$sqlCmdVariables = @{}\r\n$OctopusParameters.Keys | Where { $_ -match $regex } | ForEach {\r\n\t$sqlCmdVariables[$_] = $OctopusParameters[$_]\r\n}\r\n\r\n# Create database deployment resources from the NuGet package to the database\r\n$release = New-DatabaseReleaseArtifact -Target $targetDB `\r\n                                       -Source $importedBuildArtifact `\r\n                                       -TransactionIsolationLevel $DLMAutomationTransactionIsolationLevel `\r\n                                       -IgnoreStaticData:$ignoreStaticData `\r\n                                       -FilterPath $DLMAutomationFilterPath `\r\n                                       -SQLCompareOptions $DLMAutomationCompareOptions `\r\n                                       -SqlCmdVariables $sqlCmdVariables\r\n\r\n# Deploy the source schema to the target database.\r\nWrite-Host \"Timeout = $queryBatchTimeout\"\r\n$releaseUrl = $OctopusParameters[\u0027Octopus.Web.BaseUrl\u0027] + $OctopusParameters[\u0027Octopus.Web.DeploymentLink\u0027]; \r\n$release | Use-DatabaseReleaseArtifact -DeployTo $targetDB -SkipPreUpdateSchemaCheck -QueryBatchTimeout $queryBatchTimeout -ReleaseUrl $releaseUrl\r\n\r\n"
+                   },
+    "SensitiveProperties":  {
+
+                            },
+    "Parameters":  [
+                       {
+                           "Name":  "DLMAutomationNuGetDbPackageDownloadStepName",
+                           "Label":  "Database package step",
+                           "HelpText":  "Select the step in this project which downloads the database package.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "StepName"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetDatabaseServer",
+                           "Label":  "Target SQL Server instance",
+                           "HelpText":  "The fully qualified SQL Server instance name for the target database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetDatabaseName",
+                           "Label":  "Target database name",
+                           "HelpText":  "The name of the database to deploy changes to. This must be an existing database.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetUsername",
+                           "Label":  "Username (optional)",
+                           "HelpText":  "The SQL Server username used to connect to the database. If you leave this field and \u0027Password\u0027 blank, Windows authentication will be used to connect instead, using the account that runs the Tentacle service.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTargetPassword",
+                           "Label":  "Password (optional)",
+                           "HelpText":  "You must enter a password if you entered a username.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Sensitive"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationFilterPath",
+                           "Label":  "Filter path (optional)",
+                           "HelpText":  "Specify the location of a SQL Compare filter file (.scpf), which defines objects to include/exclude in the schema comparison. Filter files are generated by SQL Source Control.\n\nFor more help see [Using SQL Compare filters in SQL Change Automation](http://www.red-gate.com/sca/ps/help/filters).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationCompareOptions",
+                           "Label":  "SQL Compare options (optional)",
+                           "HelpText":  "Enter SQL Compare options to apply when generating the update script. Use a comma-separated list to enter multiple values. For more help see [Using SQL Compare options in SQL Change Automation](http://www.red-gate.com/sca/add-ons/compare-options).",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationTransactionIsolationLevel",
+                           "Label":  "Transaction isolation level (optional)",
+                           "HelpText":  "Select the transaction isolation level to be used in deployment scripts.",
+                           "DefaultValue":  "Serializable",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Select",
+                                                   "Octopus.SelectOptions":  "Serializable\nSnapshot\nRepeatableRead\nReadCommitted\nReadUncommitted"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationIgnoreStaticData",
+                           "Label":  "Ignore static data",
+                           "HelpText":  "Exclude changes to static data when generating the deployment resources.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "Checkbox"
+                                               }
+                       },
+                       {
+                           "Name":  "DLMAutomationQueryBatchTimeout",
+                           "Label":  "Query batch timeout (in seconds)",
+                           "HelpText":  "The execution timeout, in seconds, for each batch of queries in the update script. The default value is 30 seconds. A value of zero indicates no execution timeout.",
+                           "DefaultValue":  "30",
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       },
+                       {
+                           "Name":  "SpecificModuleVersion",
+                           "Label":  "SQL Change Automation version (optional)",
+                           "HelpText":  "If you wish to use a specific version of SQL Change Automation rather than the latest, enter the version number here.",
+                           "DefaultValue":  null,
+                           "DisplaySettings":  {
+                                                   "Octopus.ControlType":  "SingleLineText"
+                                               }
+                       }
+                   ],
+    "LastModifiedOn":  "2018-10-18T14:54:56.521+01:00",
+    "LastModifiedBy":  "support@red-gate.com",
+    "$Meta":  {
+                  "ExportedAt":  "2015-07-17T11:10:11.871Z",
+                  "OctopusVersion":  "2.6.5.1010",
+                  "Type":  "ActionTemplate"
+              },
+    "Category":  "redgate"
 }


### PR DESCRIPTION
Updates step templates for SQL Change Automation to improve handling of optional parameters.

### Step template checklist
- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- ~If a new `Category` has been created:~
   - ~An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder~
   - ~The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it~
