### PR TITLE
Update hipchat-notify template

### DIFF
--- a/step-templates/hipchat-notify.json
+++ b/step-templates/hipchat-notify.json
@@ -3,9 +3,9 @@
   "Name": "HipChat - Notify",
   "Description": "Notifies a HipChat room of a deployment outcome.",
   "ActionType": "Octopus.Script",
-  "Version": 0,
+  "Version": 1,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "#--------- Notify-Hipchat\r\n$apitoken = $OctopusParameters['AuthToken']\r\n$roomid = $OctopusParameters['RoomId']\r\n$messageText = \"(successful)\"\r\n$color = 'green'\r\n\r\nif ($OctopusParameters['Octopus.Deployment.Error']) {\r\n    $messageText = \"(failed)\"\r\n    $color = 'red'\r\n}\r\n\r\n$messageValue = \"$messageText $($OctopusParameters['Octopus.Project.Name']) [v$($OctopusParameters['Octopus.Release.Number'])] deployed to $($OctopusParameters['Octopus.Environment.Name'])    on $($OctopusParameters['Octopus.Machine.Name'])\"\r\n\r\nif ($OctopusParameters['NotificationText']) {\r\n    $messageValue = $OctopusParameters['NotificationText']\r\n    $color = $OctopusParameters['NotificationColor']\r\n}\r\n\r\n$message = New-Object PSObject \r\n$message | Add-Member -MemberType NoteProperty -Name color -Value $color\r\n$message | Add-Member -MemberType NoteProperty -Name message -Value $messageValue\r\n$message | Add-Member -MemberType NoteProperty -Name notify -Value $false\r\n$message | Add-Member -MemberType NoteProperty -Name message_format -Value text\r\n\r\n#Do the HTTP POST to HipChat\r\n$uri = \"https://api.hipchat.com/v2/room/$roomid/notification?auth_token=$apitoken\"\r\n$postBody = ConvertTo-Json -InputObject $message\r\n$postStr = [System.Text.Encoding]::UTF8.GetBytes($postBody)\r\n\r\n$webRequest = [System.Net.WebRequest]::Create($uri)\r\n$webRequest.ContentType = \"application/json\"\r\n$webrequest.ContentLength = $postStr.Length\r\n$webRequest.Method = \"POST\"\r\n\r\n$requestStream = $webRequest.GetRequestStream()\r\n$requestStream.Write($postStr, 0,$postStr.length)\r\n$requestStream.Close()\r\n\r\n[System.Net.WebResponse] $resp = $webRequest.GetResponse()\r\n$rs = $resp.GetResponseStream()\r\n\r\n[System.IO.StreamReader] $sr = New-Object System.IO.StreamReader -argumentList $rs\r\n$sr.ReadToEnd()",
+    "Octopus.Action.Script.ScriptBody": "#--------- Notify-Hipchat\r\n$apitoken = $OctopusParameters['AuthToken']\r\n$roomid = $OctopusParameters['RoomId']\r\n$messageText = \"(successful)\"\r\n$color = 'green'\r\n$notify = \"false\"\r\n\r\nif ($OctopusParameters['Octopus.Deployment.Error']) {\r\n    $messageText = \"(failed)\"\r\n    $color = 'red'\r\n}\r\n\r\n$messageValue = \"$messageText $($OctopusParameters['Octopus.Project.Name']) [v$($OctopusParameters['Octopus.Release.Number'])] deployed to $($OctopusParameters['Octopus.Environment.Name']) on $($OctopusParameters['Octopus.Machine.Name'])\"\r\n\r\nif ($OctopusParameters['NotificationText']) {\r\n    $messageValue = $OctopusParameters['NotificationText']\r\n}\r\n\r\nif ($OctopusParameters['NotificationColor']) {\r\n    $color = $OctopusParameters['NotificationColor']\r\n}\r\n\r\nif ($OctopusParameters['NotificationNotify']) {\r\n    $color = $OctopusParameters['NotificationNotify']\r\n}\r\n\r\n$message = New-Object PSObject \r\n$message | Add-Member -MemberType NoteProperty -Name color -Value $color\r\n$message | Add-Member -MemberType NoteProperty -Name message -Value $messageValue\r\n$message | Add-Member -MemberType NoteProperty -Name notify -Value $notify\r\n$message | Add-Member -MemberType NoteProperty -Name message_format -Value text\r\n\r\n#Do the HTTP POST to HipChat\r\n$uri = \"https://api.hipchat.com/v2/room/$roomid/notification?auth_token=$apitoken\"\r\n$postBody = ConvertTo-Json -InputObject $message\r\n$postStr = [System.Text.Encoding]::UTF8.GetBytes($postBody)\r\n\r\n$webRequest = [System.Net.WebRequest]::Create($uri)\r\n$webRequest.ContentType = \"application/json\"\r\n$webrequest.ContentLength = $postStr.Length\r\n$webRequest.Method = \"POST\"\r\n\r\n$requestStream = $webRequest.GetRequestStream()\r\n$requestStream.Write($postStr, 0,$postStr.length)\r\n$requestStream.Close()\r\n\r\n[System.Net.WebResponse] $resp = $webRequest.GetResponse()\r\n$rs = $resp.GetResponseStream()\r\n\r\n[System.IO.StreamReader] $sr = New-Object System.IO.StreamReader -argumentList $rs\r\n$sr.ReadToEnd()",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -41,6 +41,15 @@
       "Name": "NotificationColor",
       "Label": "Notification Color",
       "HelpText": "The color for the notification for the room. Default messages will receive green success, and red failure.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Name": "NotificationNotify",
+      "Label": "Notification Notify",
+      "HelpText": "Whether this message should trigger a user notification. Default is false.",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] If a new `Category` has been created:
   - [X] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [X] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Updated the hipchat-notify with the following fixes:
- Removed excess spacing in default message
- Correctly update variables on being set in Octopus
- Added parameter to send notifications to trigger an user notification
