### PR TITLE
[iis-app-update-property] Changed how the item property is read

### DIFF
--- a/step-templates/iis-app-update-property.json
+++ b/step-templates/iis-app-update-property.json
@@ -3,55 +3,59 @@
   "Name": "IIS App - Update Property",
   "Description": "Updates property for specified application",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\r\nparam(\r\n    [string]$webSiteName,\r\n    [string]$applicationName,\r\n    [string]$propertyName,\r\n    [object]$propertyValue,\r\n    [switch]$whatIf\r\n) \r\n\r\n$ErrorActionPreference = \"Stop\" \r\n\r\nfunction Get-Param($Name, [switch]$Required, $Default) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue   \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null -or $result -eq \"\") {\r\n        if ($Required) {\r\n            throw \"Missing parameter value $Name\"\r\n        } else {\r\n            $result = $Default\r\n        }\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\n& {\r\n    param(\r\n        [string]$webSiteName,\r\n        [string]$applicationName,\r\n        [string]$propertyName,\r\n        [object]$propertyValue\r\n    ) \r\n\r\n    Write-Host \"Setting $webSiteName\\$applicationName property $propertyName to $propertyValue\"\r\n\r\n    try {\r\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\r\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\r\n         \r\n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName | Select-Object -ExpandProperty \"Value\"\r\n         $oldValueString = \"\"\r\n\r\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\r\n         {\r\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\");\r\n         }\r\n         else \r\n         {\r\n             $oldValueString = $oldValue\r\n         }\r\n\r\n         Write-Host \"Old value $oldValueString\"\r\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName -Value $propertyValue\r\n         Write-Host \"New value $propertyValue\"\r\n         Write-Host \"Done\"\r\n    } catch {\r\n        Write-Host $_.Exception|format-list -force\r\n        Write-Host \"There was a problem setting property\"    \r\n    }\r\n\r\n } `\r\n (Get-Param 'webSiteName' -Required) (Get-Param 'applicationName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\r\n",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\nparam(\n    [string]$webSiteName,\n    [string]$applicationName,\n    [string]$propertyName,\n    [object]$propertyValue,\n    [switch]$whatIf\n) \n\n$ErrorActionPreference = \"Stop\" \n\nfunction Get-Param($Name, [switch]$Required, $Default) {\n    $result = $null\n\n    if ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n    }\n\n    if ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue   \n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    if ($result -eq $null -or $result -eq \"\") {\n        if ($Required) {\n            throw \"Missing parameter value $Name\"\n        } else {\n            $result = $Default\n        }\n    }\n\n    return $result\n}\n\n& {\n    param(\n        [string]$webSiteName,\n        [string]$applicationName,\n        [string]$propertyName,\n        [object]$propertyValue\n    ) \n\n    Write-Host \"Setting $webSiteName\\$applicationName property $propertyName to $propertyValue\"\n\n    try {\n         Add-PSSnapin WebAdministration -ErrorAction SilentlyContinue\n         Import-Module WebAdministration -ErrorAction SilentlyContinue\n         \n         $oldValue = Get-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName\n         $oldValueString = \"\"\n\n         if ($oldValue.GetType() -eq [Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute])\n         {\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty \"Value\")\n         }\n         elseif ($oldValue.GetType() -eq [System.String])\n         {\n             $oldValueString = $oldValue\n         }\n         elseif ($oldValue.GetType() -eq [System.Management.Automation.PSCustomObject])\n         {\n             $oldValueString = ($oldValue | Select-Object -ExpandProperty $propertyName)\n         }\n\n         Write-Host \"Old value $oldValueString\"\n         Set-ItemProperty \"IIS:\\Sites\\$webSiteName\\$applicationName\" -Name $propertyName -Value $propertyValue\n         Write-Host \"New value $propertyValue\"\n         Write-Host \"Done\"\n    } catch {\n        Write-Host $_.Exception|format-list -force\n        Write-Host \"There was a problem setting property\"    \n    }\n\n } `\n (Get-Param 'webSiteName' -Required) (Get-Param 'applicationName' -Required) (Get-Param 'propertyName' -Required) (Get-Param 'propertyValue' -Required)\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline"
   },
-  "SensitiveProperties": {},
   "Parameters": [
     {
+      "Id": "41b1663e-f84a-4e8a-981a-fb86ec4176b9",
       "Name": "webSiteName",
       "Label": "Web site name",
       "HelpText": null,
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     },
     {
+      "Id": "1d7a25f9-0900-4c5c-b76b-5afbb427249b",
       "Name": "applicationName",
       "Label": "Aplication name",
       "HelpText": null,
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     },
     {
+      "Id": "b074c934-c903-45e3-a96b-6c5282840d60",
       "Name": "propertyName",
       "Label": "Name of the property to set",
       "HelpText": null,
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     },
     {
+      "Id": "cdc37d1e-8a16-44bd-b80b-5c83c9d3022f",
       "Name": "propertyValue",
       "Label": "Value of the property to set",
       "HelpText": null,
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     }
   ],
-  "LastModifiedOn": "2015-10-23T00:59:31.908+00:00",
-  "LastModifiedBy": "jmalczak",
+  "LastModifiedOn": "2018-12-03T17:04:14.758Z",
+  "LastModifiedBy": "micdenny",
   "$Meta": {
-    "ExportedAt": "2015-10-23T02:13:55.226+00:00",
-    "OctopusVersion": "2.6.5.1010",
+    "ExportedAt": "2018-12-03T17:04:14.758Z",
+    "OctopusVersion": "2018.9.12",
     "Type": "ActionTemplate"
   },
   "Category": "iis"


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
I've left the parameter as it was, because this is an upgrade, if we want this we can do another version with this breaking change
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

