### PR TITLE
Lock event-stream to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "del": "^3.0.0",
     "envify": "^4.1.0",
     "eslint-plugin-react": "^7.4.0",
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "glob": "^7.0.3",
     "gulp": "^3.9.1",
     "gulp-babel": "^7.0.0",


### PR DESCRIPTION
To fix security alert:

GHSA-mh6f-8j2x-4483 - critical severity
Vulnerable versions: > 3.3.4
Patched version: No fix
The NPM package flatmap-stream is considered malicious. A malicious actor added this package as a dependency to the NPM event-stream package in versions 3.3.6 and later. Users of event-stream are encouraged to downgrade to the last non-malicious version, 3.3.4.

Note: there was no vulnerable code referenced - this just prevents an issue if we run `npm update`.
