### PR TITLE
Updated json merge step template to fix issue where some symbols from json files where read incorrectly

### DIFF
--- a/step-templates/json-merge.json
+++ b/step-templates/json-merge.json
@@ -1,5 +1,5 @@
 {
-  "Id": "823A64D2-073D-4E9E-8CBD-C7543A57665F",
+  "Id": "6bb1fb50-de38-4380-a5ef-7f21ac3a3e6f",
   "Name": "JSON - Merge Files",
   "Description": "Merge JSON files",
   "ActionType": "Octopus.Script",
@@ -16,7 +16,7 @@
   },
   "Parameters": [
     {
-      "Id": "89daafc7-46c9-481b-8eef-f18d5bd659ba",
+      "Id": "ff6ebb11-b388-460b-835e-5cf98ae394ed",
       "Name": "jmf_SourceFile",
       "Label": "Source file",
       "HelpText": "Path to the source file",
@@ -27,7 +27,7 @@
       "Links": {}
     },
     {
-      "Id": "85aa3ecc-1238-4318-b8e6-3004e0774e34",
+      "Id": "f4695bf4-817a-4029-92b8-3e0c9f7da324",
       "Name": "jmf_TransformFile",
       "Label": "Transform file",
       "HelpText": "Path to the file with the changes",
@@ -38,7 +38,7 @@
       "Links": {}
     },
     {
-      "Id": "584faceb-d76a-4498-a76c-3bfabb983915",
+      "Id": "8b5e7f58-a167-46c9-9260-6c49f4945943",
       "Name": "jmf_FailIfTransformFileMissing",
       "Label": "Fail if transform file missing",
       "HelpText": "Should the script fail if the transformation file is missing?",
@@ -49,7 +49,7 @@
       "Links": {}
     },
     {
-      "Id": "04f05a72-cd14-46aa-81f9-5119dcd93294",
+      "Id": "16e43e45-5bc7-4e13-a0d1-4c699cadd259",
       "Name": "jmf_OutputFile",
       "Label": "Output file",
       "HelpText": "Path to the output file",

--- a/step-templates/json-merge.json
+++ b/step-templates/json-merge.json
@@ -1,22 +1,22 @@
 {
-  "Id": "6bb1fb50-de38-4380-a5ef-7f21ac3a3e6f",
+  "Id": "823A64D2-073D-4E9E-8CBD-C7543A57665F",
   "Name": "JSON - Merge Files",
   "Description": "Merge JSON files",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "function Get-RequiredParam($Name) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue    \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n\t\tthrow \"Missing parameter value $Name\"\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction Merge-Objects($file1, $file2) {\r\n    $propertyNames = $($file2 | Get-Member -MemberType *Property).Name\r\n    foreach ($propertyName in $propertyNames) {\r\n\t\t# Check if property already exists\r\n        if ($file1.PSObject.Properties.Match($propertyName).Count) {\r\n            if ($file1.$propertyName.GetType().Name -eq 'PSCustomObject') {\r\n\t\t\t\t# Recursively merge subproperties\r\n                $file1.$propertyName = Merge-Objects $file1.$propertyName $file2.$propertyName\r\n            } else {\r\n\t\t\t\t# Overwrite Property\r\n                $file1.$propertyName = $file2.$propertyName\r\n            }\r\n        } else {\r\n\t\t\t# Add property\r\n            $file1 | Add-Member -MemberType NoteProperty -Name $propertyName -Value $file2.$propertyName\r\n        }\r\n    }\r\n    return $file1\r\n}\r\n\r\nfunction Merge-Json($sourcePath, $transformPath, $failIfTransformMissing, $outputPath) {\r\n\tif(!(Test-Path $sourcePath)) {\r\n\t\tWrite-Host \"Source file $sourcePath does not exist!\"\r\n\t\tExit 1\r\n\t}\r\n\t\r\n\t$sourceObject = (Get-Content $sourcePath) -join \"`n\" | ConvertFrom-Json\r\n\t$mergedObject = $sourceObject\r\n\t\r\n\tif (!(Test-Path $transformPath)) {\r\n\t\tWrite-Host \"Transform file $transformPath does not exist!\"\r\n\t\tif ([System.Convert]::ToBoolean($failIfTransformMissing)) {\r\n\t\t\tExit 1\r\n\t\t}\r\n\t\tWrite-Host 'Source file will be written to output without changes'\r\n\t} else {\r\n\t\tWrite-Host 'Applying transformations'\r\n\t\t$transformObject = (Get-Content $transformPath) -join \"`n\" | ConvertFrom-Json\r\n\t\t$mergedObject = Merge-Objects $sourceObject $transformObject\r\n\t}\r\n\t\r\n\tWrite-Host \"Writing merged JSON to $outputPath...\"\r\n\t$mergedJson = $mergedObject | ConvertTo-Json -Depth 200\r\n\t[System.IO.File]::WriteAllLines($outputPath, $mergedJson)\r\n}\r\n\r\n$ErrorActionPreference = 'Stop'\r\n\r\nif($OctopusParameters -eq $null) {\r\n    Write-Host 'OctopusParameters is null...exiting with 1'\r\n    Exit 1    \r\n}\r\n\r\n$sourceFilePath = Get-RequiredParam 'jmf_SourceFile'\r\n$transformFilePath = Get-RequiredParam 'jmf_TransformFile'\r\n$failIfTransformFileMissing = Get-RequiredParam 'jmf_FailIfTransformFileMissing'\r\n$outputFilePath = Get-RequiredParam 'jmf_OutputFile'\r\n\r\nMerge-Json $sourceFilePath $transformFilePath $failIfTransformFileMissing $outputFilePath",
-    "Octopus.Action.Script.ScriptFileName": null,
-    "Octopus.Action.Package.FeedId": null,
-    "Octopus.Action.Package.PackageId": null
+    "Octopus.Action.Script.ScriptBody": "function Get-RequiredParam($Name) {\r\n    $result = $null\r\n\r\n    if ($OctopusParameters -ne $null) {\r\n        $result = $OctopusParameters[$Name]\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n        $variable = Get-Variable $Name -EA SilentlyContinue    \r\n        if ($variable -ne $null) {\r\n            $result = $variable.Value\r\n        }\r\n    }\r\n\r\n    if ($result -eq $null) {\r\n\t\tthrow \"Missing parameter value $Name\"\r\n    }\r\n\r\n    return $result\r\n}\r\n\r\nfunction Merge-Objects($file1, $file2) {\r\n    $propertyNames = $($file2 | Get-Member -MemberType *Property).Name\r\n    foreach ($propertyName in $propertyNames) {\r\n\t\t# Check if property already exists\r\n        if ($file1.PSObject.Properties.Match($propertyName).Count) {\r\n            if ($file1.$propertyName.GetType().Name -eq 'PSCustomObject') {\r\n\t\t\t\t# Recursively merge subproperties\r\n                $file1.$propertyName = Merge-Objects $file1.$propertyName $file2.$propertyName\r\n            } else {\r\n\t\t\t\t# Overwrite Property\r\n                $file1.$propertyName = $file2.$propertyName\r\n            }\r\n        } else {\r\n\t\t\t# Add property\r\n            $file1 | Add-Member -MemberType NoteProperty -Name $propertyName -Value $file2.$propertyName\r\n        }\r\n    }\r\n    return $file1\r\n}\r\n\r\nfunction Merge-Json($sourcePath, $transformPath, $failIfTransformMissing, $outputPath) {\r\n\tif(!(Test-Path $sourcePath)) {\r\n\t\tWrite-Host \"Source file $sourcePath does not exist!\"\r\n\t\tExit 1\r\n\t}\r\n\t\r\n\t$sourceObject = (Get-Content -Path $sourcePath -Encoding UTF8) -join \"`n\" | ConvertFrom-Json\r\n\t$mergedObject = $sourceObject\r\n\t\r\n\tif (!(Test-Path $transformPath)) {\r\n\t\tWrite-Host \"Transform file $transformPath does not exist!\"\r\n\t\tif ([System.Convert]::ToBoolean($failIfTransformMissing)) {\r\n\t\t\tExit 1\r\n\t\t}\r\n\t\tWrite-Host 'Source file will be written to output without changes'\r\n\t} else {\r\n\t\tWrite-Host 'Applying transformations'\r\n\t\t$transformObject = (Get-Content -Path $transformPath -Encoding UTF8) -join \"`n\" | ConvertFrom-Json\r\n\t\t$mergedObject = Merge-Objects $sourceObject $transformObject\r\n\t}\r\n\t\r\n\tWrite-Host \"Writing merged JSON to $outputPath...\"\r\n\t$mergedJson = $mergedObject | ConvertTo-Json -Depth 200\r\n\t[System.IO.File]::WriteAllLines($outputPath, $mergedJson)\r\n}\r\n\r\n$ErrorActionPreference = 'Stop'\r\n\r\nif($OctopusParameters -eq $null) {\r\n    Write-Host 'OctopusParameters is null...exiting with 1'\r\n    Exit 1    \r\n}\r\n\r\n$sourceFilePath = Get-RequiredParam 'jmf_SourceFile'\r\n$transformFilePath = Get-RequiredParam 'jmf_TransformFile'\r\n$failIfTransformFileMissing = Get-RequiredParam 'jmf_FailIfTransformFileMissing'\r\n$outputFilePath = Get-RequiredParam 'jmf_OutputFile'\r\n\r\nMerge-Json $sourceFilePath $transformFilePath $failIfTransformFileMissing $outputFilePath"
+												 
+										  
+											
   },
   "Parameters": [
     {
-      "Id": "ff6ebb11-b388-460b-835e-5cf98ae394ed",
+      "Id": "89daafc7-46c9-481b-8eef-f18d5bd659ba",
       "Name": "jmf_SourceFile",
       "Label": "Source file",
       "HelpText": "Path to the source file",
@@ -27,7 +27,7 @@
       "Links": {}
     },
     {
-      "Id": "f4695bf4-817a-4029-92b8-3e0c9f7da324",
+      "Id": "85aa3ecc-1238-4318-b8e6-3004e0774e34",
       "Name": "jmf_TransformFile",
       "Label": "Transform file",
       "HelpText": "Path to the file with the changes",
@@ -38,7 +38,7 @@
       "Links": {}
     },
     {
-      "Id": "8b5e7f58-a167-46c9-9260-6c49f4945943",
+      "Id": "584faceb-d76a-4498-a76c-3bfabb983915",
       "Name": "jmf_FailIfTransformFileMissing",
       "Label": "Fail if transform file missing",
       "HelpText": "Should the script fail if the transformation file is missing?",
@@ -49,7 +49,7 @@
       "Links": {}
     },
     {
-      "Id": "16e43e45-5bc7-4e13-a0d1-4c699cadd259",
+      "Id": "04f05a72-cd14-46aa-81f9-5119dcd93294",
       "Name": "jmf_OutputFile",
       "Label": "Output file",
       "HelpText": "Path to the output file",
@@ -60,10 +60,10 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy": "CommonGuy",
+  "LastModifiedBy": "jonasjanusauskas",
   "$Meta": {
-    "ExportedAt": "2017-08-14T12:32:58.511Z",
-    "OctopusVersion": "3.7.4",
+    "ExportedAt": "2019-01-31T13:01:36.386Z",
+    "OctopusVersion": "2018.2.3",
     "Type": "ActionTemplate"
   },
   "Category": "json"


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
