### PR TITLE
Added template for tagging ECR images with deployment imagetags

### DIFF
--- a/step-templates/aws-add-imagetag-to-all-used-ecr-packages.json
+++ b/step-templates/aws-add-imagetag-to-all-used-ecr-packages.json
@@ -13,14 +13,14 @@
     "Octopus.Action.AwsAccount.UseInstanceRole": "False",
     "Octopus.Action.AwsAccount.Variable": "#{AwsAccount}",
     "Octopus.Action.Aws.Region": "#{AwsRegion}",
-    "Octopus.Action.Script.ScriptBody": "$DeployTag = $DeployPrefix + $OctopusParameters[\"Octopus.Environment.Name\"]\n\n#{each action in Octopus.Action}\n    #{each package in action.Package}\n        Write-Output \"Package #{package.PackageId} at version #{package.PackageVersion}\"\n\n        $Image = Get-ECRImageBatch -ImageId @{ imageTag=\"#{package.PackageVersion}\" } -RepositoryName \"#{package.PackageId}\"\n        $ImageDeploy = Get-ECRImageBatch -ImageId @{ imageTag=$DeployTag } -RepositoryName \"#{package.PackageId}\"\n\n        if($Image.Images[0].ImageId.ImageDigest -ne $ImageDeploy.Images[0].ImageId.ImageDigest) {\n            Write-Output \"Setting tag $DeployTag on image $($Image.Images[0].ImageId.ImageDigest)\"\n            $Manifest = $Image.Images[0].ImageManifest\n            Write-ECRImage -RepositoryName \"#{package.PackageId}\" -ImageManifest $Manifest -ImageTag $DeployTag\n        }\n\t#{/each}\n#{/each}\n"
+    "Octopus.Action.Script.ScriptBody": "$DeployTag = $AwsDeployPrefix + $OctopusParameters[\"Octopus.Environment.Name\"]\n\n#{each action in Octopus.Action}\n    #{each package in action.Package}\n        Write-Output \"Package #{package.PackageId} at version #{package.PackageVersion}\"\n\n        $Image = Get-ECRImageBatch -ImageId @{ imageTag=\"#{package.PackageVersion}\" } -RepositoryName \"#{package.PackageId}\"\n        $ImageDeploy = Get-ECRImageBatch -ImageId @{ imageTag=$DeployTag } -RepositoryName \"#{package.PackageId}\"\n\n        if($Image.Images[0].ImageId.ImageDigest -ne $ImageDeploy.Images[0].ImageId.ImageDigest) {\n            Write-Output \"Setting tag $DeployTag on image $($Image.Images[0].ImageId.ImageDigest)\"\n            $Manifest = $Image.Images[0].ImageManifest\n            Write-ECRImage -RepositoryName \"#{package.PackageId}\" -ImageManifest $Manifest -ImageTag $DeployTag\n        }\n\t#{/each}\n#{/each}\n"
   },
   "Parameters": [
     {
       "Id": "3bed9fa6-9d8e-452e-957a-25af1bb6fa58",
       "Name": "AwsAccount",
       "Label": "Account",
-      "HelpText": null,
+      "HelpText": "AWS Account to connect using",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "AmazonWebServicesAccount"
@@ -30,7 +30,7 @@
       "Id": "2c64b94b-deb7-4e4b-b977-ec24f3b86951",
       "Name": "AwsRegion",
       "Label": "Region",
-      "HelpText": null,
+      "HelpText": "AWS Region that is used",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -38,9 +38,9 @@
     },
     {
       "Id": "fa47f4c7-b67a-4ee7-8c8f-a890acae795a",
-      "Name": "DeployPrefix",
+      "Name": "AwsDeployPrefix",
       "Label": "Deployment Prefix",
-      "HelpText": null,
+      "HelpText": "Prefix for the image tags. The Octopus environment is then appended to this.",
       "DefaultValue": "deploy-",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"

--- a/step-templates/aws-add-imagetag-to-all-used-ecr-packages.json
+++ b/step-templates/aws-add-imagetag-to-all-used-ecr-packages.json
@@ -1,0 +1,57 @@
+{
+  "Id": "9894aeda-bf06-4be2-8789-b570c9050d34",
+  "Name": "Tag all used ECR images",
+  "Description": "This will apply a tag to all AWS Elastic Container Registry images/packages from the ECR feed that are used in the deployment. That way the lifecycle policies in ECR can be configured to not delete images that are in-use by deployments in various environments.",
+  "ActionType": "Octopus.AwsRunScript",
+  "Version": 12,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.AwsAccount.Variable": "#{AwsAccount}",
+    "Octopus.Action.Aws.Region": "#{AwsRegion}",
+    "Octopus.Action.Script.ScriptBody": "$DeployTag = $DeployPrefix + $OctopusParameters[\"Octopus.Environment.Name\"]\n\n#{each action in Octopus.Action}\n    #{each package in action.Package}\n        Write-Output \"Package #{package.PackageId} at version #{package.PackageVersion}\"\n\n        $Image = Get-ECRImageBatch -ImageId @{ imageTag=\"#{package.PackageVersion}\" } -RepositoryName \"#{package.PackageId}\"\n        $ImageDeploy = Get-ECRImageBatch -ImageId @{ imageTag=$DeployTag } -RepositoryName \"#{package.PackageId}\"\n\n        if($Image.Images[0].ImageId.ImageDigest -ne $ImageDeploy.Images[0].ImageId.ImageDigest) {\n            Write-Output \"Setting tag $DeployTag on image $($Image.Images[0].ImageId.ImageDigest)\"\n            $Manifest = $Image.Images[0].ImageManifest\n            Write-ECRImage -RepositoryName \"#{package.PackageId}\" -ImageManifest $Manifest -ImageTag $DeployTag\n        }\n\t#{/each}\n#{/each}\n"
+  },
+  "Parameters": [
+    {
+      "Id": "3bed9fa6-9d8e-452e-957a-25af1bb6fa58",
+      "Name": "AwsAccount",
+      "Label": "Account",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    },
+    {
+      "Id": "2c64b94b-deb7-4e4b-b977-ec24f3b86951",
+      "Name": "AwsRegion",
+      "Label": "Region",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "fa47f4c7-b67a-4ee7-8c8f-a890acae795a",
+      "Name": "DeployPrefix",
+      "Label": "Deployment Prefix",
+      "HelpText": null,
+      "DefaultValue": "deploy-",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedBy": "hakanl",
+  "$Meta": {
+    "ExportedAt": "2019-02-06T15:41:19.708Z",
+    "OctopusVersion": "2018.11.2",
+    "Type": "ActionTemplate"
+  },
+  "Category": "aws"
+}


### PR DESCRIPTION
### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
