### PR TITLE
Update azure-remove-resource-group-deployments.json

### DIFF
--- a/step-templates/azure-remove-resource-group-deployments.json
+++ b/step-templates/azure-remove-resource-group-deployments.json
@@ -1,43 +1,33 @@
 {
   "Id": "7351a3e7-df59-4e0c-863a-dca6f33ad2e1",
   "Name": "Azure - Remove Resource Group Deployments",
-  "Description": "There is a cap in Azure that prevents having more than 800 deployments in the history at any given time: [link to microsoft docs](https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#resource-group-limits.)\n\nThis script helps alleviate this issue by limiting how many deployments are allowed exist, keeps the latest specified number of deployments, and will remove the rest.\n\n**What it does:** *Logs into Azure, selects the resource group of the app. Based on how many deployments it wants to keep, it will keep the latest X deployments and remove the rest. If there are less deployments than X to keep, the script will skip.*\n",
+  "Description": "There is a cap in Azure that prevents having more than 800 deployments in the history at any given time: link to microsoft docs\n\nThis script helps alleviate this issue by limiting how many deployments are allowed exist, keeps the latest specified number of deployments, and will remove the rest.\n\nWhat it does: Logs into Azure, selects the resource group of the app. Based on how many deployments it wants to keep, it will keep the latest X deployments and remove the rest. If there are less deployments than X to keep, the script will skip.",
   "ActionType": "Octopus.AzurePowerShell",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
+  "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Azure.AccountId": "#{AzureSubscriptionAccount}",
-    "Octopus.Action.Script.ScriptBody": "Function Validate-Parameter($parameterValue, [string[]]$validInput, $parameterName) {\n    Write-Host \"${parameterName}: ${parameterValue}\"\n    if (! $parameterValue) {\n        throw \"$parameterName cannot be empty, please specify a value\"\n    }\n}\n\nFunction Remove-AzureRmResourceDeployments {\n\n    [CmdletBinding()]\n    Param(\n        [Parameter(Mandatory = $true)]\n        [string]$resourceGroupName,\n\n        [Parameter(Mandatory = $true)]\n        [string]$appServiceName,\n        \n        [Parameter(Mandatory = $true)]\n        [int]$numberOfDeploymentsToKeep\n    )\n\n    $listOfDeployments = Get-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName\n\n    $azureDeploymentNameAndDate = @()\n    $listOfDeployments | % {$azureDeploymentNameAndDate += [PSCustomObject]@{DeploymentName = $_.DeploymentName; AppName = $_.Parameters.webSiteName.value; Time = $_.Timestamp}}\n    Write-Output \"Found $($azureDeploymentNameAndDate.Count) deployments from the $resourceGroupName resource group\"\n    \n    $totalNumberOfDeployments = $azureDeploymentNameAndDate | where {$_.AppName -match $appServiceName} | sort Time -Descending \n    $itemsToRemove = $azureDeploymentNameAndDate | where {$_.AppName -match $appServiceName} | sort Time -Descending | select-object -skip $numberOfDeploymentsToKeep\n    $numberOfItemsToRemove = $itemsToRemove | measure\n    \n    Write-Output \"There is a total of $($totalNumberOfDeployments.Count) deployments for $appServiceName\"\n\n    if ($numberOfitemsToRemove.Count -eq 0) {\n        Write-Output \"There are $($totalNumberOfDeployments.Count) deployments, max number of deployments set to keep is $numberOfDeploymentsToKeep... skipping\"\n    }\n    else {\n        Write-Output \"Deleting $($numberOfitemsToRemove.Count) deployment(s) from $appServiceName\"\n        $itemsToRemove | % {Write-Output \"Deleting $($_.DeploymentName)\"; Remove-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -name $_.DeploymentName}\n    }\n}\n\n## --------------------------------------------------------------------------------------\n## Input\n## --------------------------------------------------------------------------------------\n\n$resourceGroupName = $OctopusParameters['Azure.RemoveResourceGroupDeployments.ResourceGroupName']\n$appServiceName = $OctopusParameters['Azure.RemoveResourceGroupDeployments.AppServiceName']\n$numberOfDeploymentsToKeep = $OctopusParameters['Azure.RemoveResourceGroupDeployments.NumberOfDeploymentsToKeep']\n\n# Validate that all parameters have values\nWrite-Output \"Validating parameters...\"\nValidate-Parameter $resourceGroupName -parameterName \"resourceGroupName\"\nValidate-Parameter $appServiceName -parameterName \"appServiceName\"\nValidate-Parameter $numberOfDeploymentsToKeep -parameterName \"numberOfDeploymentsToKeep\"\n\nRemove-AzureRmResourceDeployments -resourceGroupName $resourceGroupName -appServiceName $appServiceName -numberOfDeploymentsToKeep $numberOfDeploymentsToKeep -Verbose"
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "function Get-Param($Name, [switch]$Required, $Default) {\n    $result = $null\n\n    if ($null -ne $OctopusParameters) {\n        $result = $OctopusParameters[$Name]\n    }\n\n    if ($null -eq $result) {\n        $variable = Get-Variable $Name -EA SilentlyContinue\n        if ($null -ne $variable) {\n            $result = $variable.Value\n        }\n    }\n\n    if ($null -eq $result) {\n        if ($Required) {\n            throw \"Missing parameter value $Name\"\n        }\n        else {\n            $result = $Default\n        }\n    }\n\n    return $result\n}\n\nFunction Get-Deployments {\n    Param(\n        [Parameter(Mandatory = $true)]\n        [string]$resourceGroupName\n    )\n    $listOfDeployments = Get-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName\n    $azureDeploymentNameAndDate = @()\n    $listOfDeployments | ForEach-Object { $azureDeploymentNameAndDate += [PSCustomObject]@{DeploymentName = $_.DeploymentName; Time = $_.Timestamp } }\n\n    return $azureDeploymentNameAndDate\n}\n\nFunction Remove-AzureRmResourceDeployments {\n\n    [CmdletBinding()]\n    Param(\n        [Parameter(Mandatory = $true)]\n        [string]$resourceGroupName,\n\n        [ValidateRange(0, 800)]\n        [int]$numberOfDeploymentsToKeep,\n\n        [int]$numberOfDaysToKeep\n    )\n\n    if ($null -ne $($numberOfDaysToKeep) -and $($numberOfDaysToKeep) -gt 0) {\n        $azureDeploymentNameAndDate = Get-Deployments $resourceGroupName\n\n        Write-Output \"Found $($azureDeploymentNameAndDate.Count) deployments from the $resourceGroupName resource group\"\n\n        $itemsToRemove = $azureDeploymentNameAndDate | Where-Object { $_.Time -lt ((get-date).AddDays( - $($numberOfDaysToKeep))) }\n        $numberOfItemsToRemove = $itemsToRemove | Measure-Object\n\n        if ($numberOfitemsToRemove.Count -eq 0) {\n            Write-Output \"There are no deployments older than $($numberOfDaysToKeep) days old in $($resourceGroupName)... skipping\"\n        }\n        else {\n            Write-Output \"Deleting $($numberOfitemsToRemove.Count) deployment(s) from $($resourceGroupName) as they are more than $($numberOfDaysToKeep) days old.\"\n            $itemsToRemove | ForEach-Object { Write-Output \"Deleting $($_.DeploymentName)\"; Remove-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -name $_.DeploymentName }\n        }\n    }\n\n    if ($null -ne $($numberOfDeploymentsToKeep) -and $($numberOfDeploymentsToKeep) -gt 0) {\n        $azureDeploymentNameAndDate = Get-Deployments $resourceGroupName\n\n        Write-Output \"Found $($azureDeploymentNameAndDate.Count) deployments from the $resourceGroupName resource group\"\n\n        $itemsToRemove = $azureDeploymentNameAndDate | Sort-Object Time -Descending | select-object -skip $numberOfDeploymentsToKeep\n        $numberOfItemsToRemove = $itemsToRemove | Measure-Object\n\n        if ($numberOfitemsToRemove.Count -eq 0) {\n            Write-Output \"Max number of deployments set to keep is $numberOfDeploymentsToKeep... skipping\"\n        }\n        else {\n            Write-Output \"Maximum number of deployments exceeded. Deleting $($numberOfitemsToRemove.Count) deployment(s) from $($resourceGroupName)\"\n            $itemsToRemove | ForEach-Object { Write-Output \"Deleting $($_.DeploymentName)\"; Remove-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -name $_.DeploymentName }\n        }\n    }\n}\n\n## --------------------------------------------------------------------------------------\n## Input\n## --------------------------------------------------------------------------------------\n\n$resourceGroupName = Get-Param 'Azure.RemoveResourceGroupDeployments.ResourceGroupName' -Required\n$numberOfDeploymentsToKeep = Get-Param 'Azure.RemoveResourceGroupDeployments.NumberOfDeploymentsToKeep' -Default 0\n$numberOfDaysToKeep = Get-Param 'Azure.RemoveResourceGroupDeployments.NumberOfDaysToKeep' -Default 0\n\nRemove-AzureRmResourceDeployments -resourceGroupName $resourceGroupName -numberOfDeploymentsToKeep $numberOfDeploymentsToKeep -numberOfDaysToKeep $numberOfDaysToKeep -Verbose\n"
   },
   "Parameters": [
     {
-      "Id": "0bbab39d-753d-479b-9ff4-b9bca412f980",
+      "Id": "30a798bd-db11-44d3-82bd-28c3b13e77a5",
       "Name": "AzureSubscriptionAccount",
       "Label": "Azure Subscription Account",
       "HelpText": null,
       "DefaultValue": "",
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      },
-      "Links": {}
+        "Octopus.ControlType": "AzureAccount"
+      }
     },
     {
       "Id": "27c68d1f-7fdc-4e10-aa4a-77a0ff55eb29",
       "Name": "Azure.RemoveResourceGroupDeployments.ResourceGroupName",
-      "Label": "ResourceGroupName",
+      "Label": "Resource Group Name",
       "HelpText": "Enter the name of the resource group.",
-      "DefaultValue": "",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      },
-      "Links": {}
-    },
-    {
-      "Id": "8ffc310f-8731-4b96-9237-738b5b59438a",
-      "Name": "Azure.RemoveResourceGroupDeployments.AppServiceName",
-      "Label": "AppServiceName",
-      "HelpText": "Enter the name of your web/api/etc app.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -48,19 +38,29 @@
       "Id": "2adcf1a9-d319-4ed3-80e7-4c533ddbe5cd",
       "Name": "Azure.RemoveResourceGroupDeployments.NumberOfDeploymentsToKeep",
       "Label": "Number Of Deployments To Keep",
-      "HelpText": "Number Of Deployments To Keep.",
+      "HelpText": "Number Of Deployments To Keep. Defaults to empty and will not be used.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
-      },
-      "Links": {}
+      }
+    },
+    {
+      "Id": "c5ce930b-ea04-42b8-8ade-d167a26dab2a",
+      "Name": "Azure.RemoveResourceGroupDeployments.NumberOfDaysToKeep",
+      "Label": "Number Of Days To Keep.",
+      "HelpText": "Number Of Days To Keep. Defaults to empty and will not be used.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
   "Category": "Azure",
-  "LastModifiedBy": "kennymiyasato",
+  "SpaceId": "Spaces-1",
+  "LastModifiedBy": "bmdixon",
   "$Meta": {
-    "ExportedAt": "2018-03-29T21:19:55.999Z",
-    "OctopusVersion": "2018.3.4",
+    "ExportedAt": "2019-04-25T13:33:59.856Z",
+    "OctopusVersion": "2019.4.2",
     "Type": "ActionTemplate"
   }
 }


### PR DESCRIPTION
### Changes

- Replace aliased functions with full name (e.g '%' -> 'ForEach-Object').
- Replace variable validation function with example from https://www.daniellittle.xyz/making-great-octopus-powershell-step-templates
- Removed $appServiceName parameter as this is not a generic value and may not exist.
- Added support for deleting based on deployment age ($numberOfDaysToKeep).

### Behaviour

- If numberOfDaysToKeep is not provided then no date based deletion occurs.
- If numberOfDeploymentsToKeep is not provided then no max deployment count deletion occurs.
- If neither are provided then no deletion occurs.
- If both are provided then the numberOfDaysToKeep deletion occurs first, followed by the numberOfDeploymentsToKeep deletion.

---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author