### PR TITLE
Github - report deployment had invalid parameters

### DIFF
--- a/step-templates/github-report-deployment.json
+++ b/step-templates/github-report-deployment.json
@@ -3,7 +3,7 @@
   "Name": "GitHub - Report Deployment",
   "Description": "Creates or updates a deployment using [GitHub Deployments API](https://developer.github.com/v3/repos/deployments/)",
   "ActionType": "Octopus.Script",
-  "Version": 42,
+  "Version": 43,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {

--- a/step-templates/github-report-deployment.json
+++ b/step-templates/github-report-deployment.json
@@ -17,10 +17,7 @@
       "Name": "GitHubUserName",
       "Label": "GitHub user",
       "HelpText": "A username to be used to access GitHub.",
-      "DefaultValue": {
-        "HasValue": true,
-        "NewValue": null
-      },
+      "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
@@ -30,10 +27,7 @@
       "Name": "GitHubPassword",
       "Label": "GitHub password",
       "HelpText": "Password (access token) used to access GitHub. Use https://github.com/settings/tokens to generate a token. **repo_deployment** is the required scope for the token.",
-      "DefaultValue": {
-        "HasValue": true,
-        "NewValue": null
-      },
+      "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
       }
@@ -53,10 +47,7 @@
       "Name": "GitHubOwner",
       "Label": "GitHub owner",
       "HelpText": "Owner of the repository (organization or user).",
-      "DefaultValue": {
-        "HasValue": true,
-        "NewValue": null
-      },
+      "DefaultValue": null,
       "DisplaySettings": {}
     },
     {


### PR DESCRIPTION
The `github-report-deployment` step template had default values specified like
```
      "DefaultValue": {	      "DefaultValue": null,
        "HasValue": true,	
        "NewValue": null	
      },
```
where they should just be
```
    "DefaultValue": null,
```

This broke the parsing inside octopus

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
