### PR TITLE
Support for TLS 1, 1.1 and 1.2 only

### DIFF
--- a/step-templates/elmahio-notify-deployment.json
+++ b/step-templates/elmahio-notify-deployment.json
@@ -3,7 +3,7 @@
   "Name": "elmah.io - Register Deployment",
   "Description": "Step template for notifying elmah.io about deployments on Octopus.",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 5,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",

--- a/step-templates/elmahio-notify-deployment.json
+++ b/step-templates/elmahio-notify-deployment.json
@@ -8,7 +8,7 @@
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "$version = $OctopusReleaseNumber\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nTry {\n  Invoke-RestMethod -Method Post -Uri $url -Body $body\n}\nCatch {\n  Write-Error $_.Exception.Message -ErrorAction Continue\n}",
+    "Octopus.Action.Script.ScriptBody": "$version = $OctopusReleaseNumber\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nTry {\n[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls\n  Invoke-RestMethod -Method Post -Uri $url -Body $body\n}\nCatch {\n  Write-Error $_.Exception.Message -ErrorAction Continue\n}",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null


### PR DESCRIPTION
I've modified the notify deployment script for elmah.io to use TLS 1, 1.1 or 1.2 only.