### PR TITLE
Fixed hardcoded value of Spaces-1 builtin feed

### DIFF
--- a/step-templates/ssis-deploy-ispac-from-referenced-package.json
+++ b/step-templates/ssis-deploy-ispac-from-referenced-package.json
@@ -10,7 +10,7 @@
         "Id": "7a1f5eb6-0b6a-4319-a0e8-7b4d13ea609e",
         "Name": "SSIS Package",
         "PackageId": "#{ssisPackageId}",
-        "FeedId": "#{TemplatePackageFeedId}feeds-builtin",
+        "FeedId": "#{TemplatePackageFeedId}",
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True"

--- a/step-templates/ssis-deploy-ispac-from-referenced-package.json
+++ b/step-templates/ssis-deploy-ispac-from-referenced-package.json
@@ -3,15 +3,15 @@
     "Name": "Deploy ispac SSIS project from Referenced Package",
     "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
     "ActionType": "Octopus.Script",
-    "Version": 2,
+    "Version": 3,
     "CommunityActionTemplateId": null,
     "Packages": [
       {
         "Id": "7a1f5eb6-0b6a-4319-a0e8-7b4d13ea609e",
         "Name": "SSIS Package",
         "PackageId": "#{ssisPackageId}",
-        "FeedId": "feeds-builtin",
-        "AcquisitionLocation": "",
+        "FeedId": "#{TemplatePackageFeedId}feeds-builtin",
+        "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True"
         }
@@ -24,7 +24,7 @@
     },
     "Parameters": [
       {
-        "Id": "5344bb06-cf88-4a7a-9af5-28fad31ee245",
+        "Id": "97e5d9db-fd73-4620-84f7-91d6e31e0c4b",
         "Name": "ServerName",
         "Label": "Database server name (\\instance)",
         "HelpText": "Name of the SQL Server you are deploying to.",
@@ -34,7 +34,7 @@
         }
       },
       {
-        "Id": "546bd85e-50db-457d-9c35-fc9cce880327",
+        "Id": "b5adc9a7-2bcb-45c8-9a64-02e0dc286981",
         "Name": "sqlAccountUsername",
         "Label": "SQL Authentication Username",
         "HelpText": "(Optional) Username of the SQL Authentication account.  Use this approach when deploying to Azure Databases with SSIS configured.  If SQL Authentication Username and Password are blank, Integrated Authentication is used.",
@@ -44,7 +44,7 @@
         }
       },
       {
-        "Id": "3bc54c85-b273-408b-84c2-0905d227e7ce",
+        "Id": "0646a66e-5ba5-4761-a388-8a8bc73492ec",
         "Name": "sqlAccountPassword",
         "Label": "SQL Authentication Password",
         "HelpText": "(Optional) Password of the SQL Authentication account.",
@@ -54,7 +54,7 @@
         }
       },
       {
-        "Id": "03d1ce40-7f14-4d41-b317-6f722198e079",
+        "Id": "46e7103c-2833-4bf0-9f98-b5d2a0bbcabf",
         "Name": "EnableCLR",
         "Label": "Enable SQL CLR",
         "HelpText": "This will reconfigure SQL Server to enable the SQL CLR.  It is highly recommended that this be previously authorized by your Database Administrator.",
@@ -64,7 +64,7 @@
         }
       },
       {
-        "Id": "e3bcfd5a-2b30-441f-8251-67fa0ecbcb69",
+        "Id": "970702e3-e0bf-4ea7-b1ba-067128a3f8c3",
         "Name": "CatalogName",
         "Label": "Catalog name",
         "HelpText": "Name of the catalog to create in Integration Services Catalogs on SQL Server.  When using the GUI, this value gets hardcoded to SSISDB and cannot be changed.  It is recommended that you do not change the default value.",
@@ -74,7 +74,7 @@
         }
       },
       {
-        "Id": "f7966798-0aab-445b-a978-cb3e19cf4f17",
+        "Id": "ccc0a5bf-467b-4695-bcef-912043e27d49",
         "Name": "CatalogPwd",
         "Label": "Catalog password",
         "HelpText": "Password to the Integration Services Catalog.",
@@ -84,7 +84,7 @@
         }
       },
       {
-        "Id": "215ca282-20bf-4680-8b00-9e10e1f9d053",
+        "Id": "5c02a114-b06e-4547-bb0f-b2aba1869d8e",
         "Name": "FolderName",
         "Label": "Folder name",
         "HelpText": "Name of the folder to use within the Integration Services Catalog",
@@ -94,7 +94,7 @@
         }
       },
       {
-        "Id": "5d0897e6-ffeb-4635-a561-ce59a8fd59b6",
+        "Id": "88ffb943-5525-4484-9963-0a34c89a7085",
         "Name": "ProjectName",
         "Label": "Project name",
         "HelpText": "Name of the project within the folder of the Integration Services catalog",
@@ -104,7 +104,7 @@
         }
       },
       {
-        "Id": "e5cb66b2-c7f5-4c5d-87b2-1b6cd191094b",
+        "Id": "b8c29eac-a60f-4b25-96b8-f3b2e3fd8806",
         "Name": "UseEnvironment",
         "Label": "Use environment",
         "HelpText": "This will make a project reference to the defined environment.",
@@ -114,7 +114,7 @@
         }
       },
       {
-        "Id": "f57ec5e0-0fab-4c6d-92f5-7abb95841c14",
+        "Id": "156a4b55-26e4-4c70-bf91-8729ca131c62",
         "Name": "EnvironmentName",
         "Label": "Environment name",
         "HelpText": "Name of the environment to reference the project to. If the environment doesn't exist, it will create it.",
@@ -124,7 +124,7 @@
         }
       },
       {
-        "Id": "4b7a2342-4481-4437-900e-91345fc7152d",
+        "Id": "0339168d-9a53-4d8a-97d9-7a76605bdc55",
         "Name": "ReferenceProjectParametersToEnvironmentVairables",
         "Label": "Reference project parameters to environment variables",
         "HelpText": "Checking this box will make Project Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects that an Octopus variable of the same name exists.",
@@ -134,7 +134,7 @@
         }
       },
       {
-        "Id": "f8bd471e-6532-4ea1-ae9f-6f56afbe844c",
+        "Id": "5f6b7788-4957-451a-bec7-092e471291f2",
         "Name": "ReferencePackageParametersToEnvironmentVairables",
         "Label": "Reference package parameters to environment variables",
         "HelpText": "Checking this box will make Package Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects than an Octopus variable of the same name exists.",
@@ -144,7 +144,7 @@
         }
       },
       {
-        "Id": "1c33e299-df5f-41b0-9d8b-6fcd1963d349",
+        "Id": "cc4819a4-a6e4-4220-a581-0f2aed51f4a6",
         "Name": "UseFullyQualifiedVariableNames",
         "Label": "Use Fully Qualified Variable Names",
         "HelpText": "When true the package variables names must be represented in `dtsx_name_without_extension.variable_name`",
@@ -154,7 +154,7 @@
         }
       },
       {
-        "Id": "a35898ec-abb3-42dc-997f-3635326de029",
+        "Id": "bb22984a-43ed-45c7-978d-72fddec96fe1",
         "Name": "UseCustomFilter",
         "Label": "Use Custom Filter for connection manager properties",
         "HelpText": "Custom filter should contain the regular expression for ignoring properties when setting will occur during the auto-mapping",
@@ -164,7 +164,7 @@
         }
       },
       {
-        "Id": "35f30601-52ca-4196-ad56-28ec9a98b819",
+        "Id": "d9bba05b-d8a7-40b0-9893-4c878a264de6",
         "Name": "CustomFilter",
         "Label": "Custom Filter for connection manager properties",
         "HelpText": "Regular expression for filtering out the connection manager properties during the auto-mapping process. This string is used when `UseCustomFilter` is set to true",
@@ -174,7 +174,7 @@
         }
       },
       {
-        "Id": "c1a92fe3-7076-44a9-89e0-4a5519913cf6",
+        "Id": "77237f87-bc01-4541-b477-005f7416dce2",
         "Name": "SyncEnvironment",
         "Label": "Clean obsolete variables from environment",
         "HelpText": "When `true` synchronizes the environment:\n- Removes obsolete variables\n- Removes renamed variables\n- Replaces values of valid variables (also when `false`)",
@@ -184,18 +184,28 @@
         }
       },
       {
-        "Id": "3365feb9-221e-443c-ba64-f213bb05715e",
+        "Id": "34dcc677-6091-4e92-8b40-9ab09ed18fa3",
         "Name": "ssisPackageId",
         "Label": "Package Id",
         "HelpText": "Id of the package to deploy, used to support deployment with Workers.",
         "DefaultValue": "",
         "DisplaySettings": {}
+      },
+      {
+        "Id": "8338dc00-27ab-4c60-809a-2badd22250e9",
+        "Name": "TemplatePackageFeedId",
+        "Label": "Package Feed Id",
+        "HelpText": "ID of the package feed the referenced package resides in.",
+        "DefaultValue": "feeds-builtin",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
       }
     ],
     "LastModifiedBy": "twerthi",
     "$Meta": {
-      "ExportedAt": "2019-06-29T03:11:06.630Z",
-      "OctopusVersion": "2019.5.12",
+      "ExportedAt": "2019-08-22T23:13:12.345Z",
+      "OctopusVersion": "2019.7.12",
       "Type": "ActionTemplate"
     },
     "Category": "sql"


### PR DESCRIPTION

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_

Fixes issue where feed for referenced package was hardcoded to the Default feed id.  It's now a variable that can be changed.
