### PR TITLE
made datadog steps use basic parsing so they work with octopus cloud

### DIFF
--- a/step-templates/datadog-create-event.json
+++ b/step-templates/datadog-create-event.json
@@ -3,9 +3,9 @@
   "Name": "Datadog - Create Event",
   "Description": "Datadog is cloud monitoring service which allows you to push arbitrary events into via an api.  This task allows you to create an event to correlate with other data.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Lets handle our own errors here\n$ErrorActionPreference = \"continue\"\n\n$apiKey = $OctopusParameters['ApiKey']\n$title = $OctopusParameters['EventTitle']\n$body = $OctopusParameters['EventBody']\n$alertType = $OctopusParameters['AlertType']\n$priority = $OctopusParameters['Priority']\n$tags = $OctopusParameters['Tags']\n$endpoint = $OctopusParameters['DatadogEndpoint']\n$eventsApiEndpoint = \"/api/v1/events\"\n\n# Write out some debug information\nWrite-Host \"Event Title: $title\"\nWrite-Host \"Event Body: $body\"\nWrite-Host \"Alert Type: $alertType\"\nWrite-Host \"Priority: $priority\"\nWrite-Host \"Tags: $tags\"\nWrite-Host \"Datadog Endpoint: $endpoint$eventsApiEndpoint\"\n\n# Create the url from basic information\n$url = \"$endpoint$eventsApiEndpoint`?api_key=$apiKey\"\n$tagString = [system.String]::Join(\"`\",`\"\", $tags.Split(\",\"))\n\n$json = @\"\n{\n      \"title\": \"$title\",\n      \"text\": \"$body\",\n      \"priority\": \"$priority\",\n      \"tags\": [\"$tagString\"],\n      \"alert_type\": \"$alertType\"\n  }\n\"@\n\n# Make the response and handle exceptions **Requires PS 3.0 + \ntry {\n    $response = Invoke-WebRequest -Uri $url -Method POST -Body ($json | ConvertFrom-Json | ConvertTo-Json) -ContentType \"Application/json\"\n}catch{\n    Write-Error \"Error: $_\"\n    EXIT 0\n}\n\n# Some Error handling here\nif($response.StatusCode -ne 202){\n    Write-Error \"There was an error listing response content below to debug\"\n    $response.RawContent\n}else{\n    Write-Host \"Sent Successfully\"\n}\n\n# We usually don't want to fail a deployment because of this\nEXIT 0",
+    "Octopus.Action.Script.ScriptBody": "# Lets handle our own errors here\n$ErrorActionPreference = \"continue\"\n\n$apiKey = $OctopusParameters['ApiKey']\n$title = $OctopusParameters['EventTitle']\n$body = $OctopusParameters['EventBody']\n$alertType = $OctopusParameters['AlertType']\n$priority = $OctopusParameters['Priority']\n$tags = $OctopusParameters['Tags']\n$endpoint = $OctopusParameters['DatadogEndpoint']\n$eventsApiEndpoint = \"/api/v1/events\"\n\n# Write out some debug information\nWrite-Host \"Event Title: $title\"\nWrite-Host \"Event Body: $body\"\nWrite-Host \"Alert Type: $alertType\"\nWrite-Host \"Priority: $priority\"\nWrite-Host \"Tags: $tags\"\nWrite-Host \"Datadog Endpoint: $endpoint$eventsApiEndpoint\"\n\n# Create the url from basic information\n$url = \"$endpoint$eventsApiEndpoint`?api_key=$apiKey\"\n$tagString = [system.String]::Join(\"`\",`\"\", $tags.Split(\",\"))\n\n$json = @\"\n{\n      \"title\": \"$title\",\n      \"text\": \"$body\",\n      \"priority\": \"$priority\",\n      \"tags\": [\"$tagString\"],\n      \"alert_type\": \"$alertType\"\n  }\n\"@\n\n# Make the response and handle exceptions **Requires PS 3.0 + \ntry {\n    $response = Invoke-WebRequest -Uri $url -Method POST -Body ($json | ConvertFrom-Json | ConvertTo-Json) -ContentType \"Application/json\" -UseBasicParsing\n}catch{\n    Write-Error \"Error: $_\"\n    EXIT 0\n}\n\n# Some Error handling here\nif($response.StatusCode -ne 202){\n    Write-Error \"There was an error listing response content below to debug\"\n    $response.RawContent\n}else{\n    Write-Host \"Sent Successfully\"\n}\n\n# We usually don't want to fail a deployment because of this\nEXIT 0",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -53,8 +53,8 @@
       "DefaultValue": "https://app.datadoghq.com"
     }
   ],
-  "LastModifiedOn": "2014-07-08T02:15:54.920+00:00",
-  "LastModifiedBy": "bigbam505",
+  "LastModifiedOn": "2019-09-18T00:54:17.669Z",
+  "LastModifiedBy": "baynewc1",
   "$Meta": {
     "ExportedAt": "2014-07-08T02:19:06.141+00:00",
     "OctopusVersion": "2.4.10.235",

--- a/step-templates/datadog-schedule-downtime.json
+++ b/step-templates/datadog-schedule-downtime.json
@@ -3,10 +3,10 @@
   "Name": "Datadog - Schedule Downtime",
   "Description": "Datadog is cloud monitoring service which allows you to push arbitrary events into via an api. This task allows you to schedule a downtime event to prevent error alerts during a deployment.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "# Lets handle our own errors here\r\n$ErrorActionPreference = \"continue\"\r\n\r\n$apiKey = $OctopusParameters['ApiKey']\r\n$appKey = $OctopusParameters['AppKey']\r\n$endpoint = $OctopusParameters['DatadogEndpoint']\r\n$downtimeApiEndpoint = \"/api/v1/downtime\"\r\n$scope = $OctopusParameters['Environment']\r\n$durstring = $OctopusParameters['Duration']\r\n\r\n[int]$duration = [convert]::ToInt32($durstring,10)\r\n\r\n# Write out some debug information\r\nWrite-Host \"Scheduling Downtime for: $scope\"\r\nWrite-Host \"Datadog Endpoint: $endpoint$downtimeApiEndpoint\"\r\n\r\n# Create the url from basic information\r\n$url = \"$endpoint$downtimeApiEndpoint`?api_key=$apiKey&application_key=$appKey\"\r\n\r\nWrite-Host $url\r\n\r\n$start=[Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat \"%s\"))\r\n$end = $start + $duration\r\n$json = @\"\r\n{\r\n      \"scope\": \"env:$scope\",\r\n      \"start\": \"$start\",\r\n      \"end\": \"$end\"\r\n  }\r\n\"@\r\n\r\n# Make the response and handle exceptions **Requires PS 3.0 + \r\ntry {\r\n    $response = Invoke-WebRequest -Uri $url -Method POST -Body ($json | ConvertFrom-Json | ConvertTo-Json) -ContentType \"Application/json\"\r\n}catch{\r\n    Write-Error \"Error: $_\"\r\n    EXIT 0\r\n}\r\n\r\n# Some Error handling here\r\nif($response.StatusCode -ne 200){\r\n    Write-Error \"There was an error listing response content below to debug\"\r\n    $response.RawContent\r\n}else{\r\n    Write-Host \"Sent Successfully\"\r\n}\r\n\r\n# We usually don't want to fail a deployment because of this\r\nEXIT 0"
+    "Octopus.Action.Script.ScriptBody": "# Lets handle our own errors here\r\n$ErrorActionPreference = \"continue\"\r\n\r\n$apiKey = $OctopusParameters['ApiKey']\r\n$appKey = $OctopusParameters['AppKey']\r\n$endpoint = $OctopusParameters['DatadogEndpoint']\r\n$downtimeApiEndpoint = \"/api/v1/downtime\"\r\n$scope = $OctopusParameters['Environment']\r\n$durstring = $OctopusParameters['Duration']\r\n\r\n[int]$duration = [convert]::ToInt32($durstring,10)\r\n\r\n# Write out some debug information\r\nWrite-Host \"Scheduling Downtime for: $scope\"\r\nWrite-Host \"Datadog Endpoint: $endpoint$downtimeApiEndpoint\"\r\n\r\n# Create the url from basic information\r\n$url = \"$endpoint$downtimeApiEndpoint`?api_key=$apiKey&application_key=$appKey\"\r\n\r\nWrite-Host $url\r\n\r\n$start=[Math]::Floor([decimal](Get-Date(Get-Date).ToUniversalTime()-uformat \"%s\"))\r\n$end = $start + $duration\r\n$json = @\"\r\n{\r\n      \"scope\": \"env:$scope\",\r\n      \"start\": \"$start\",\r\n      \"end\": \"$end\"\r\n  }\r\n\"@\r\n\r\n# Make the response and handle exceptions **Requires PS 3.0 + \r\ntry {\r\n    $response = Invoke-WebRequest -Uri $url -Method POST -Body ($json | ConvertFrom-Json | ConvertTo-Json) -ContentType \"Application/json\" -UseBasicParsing\r\n}catch{\r\n    Write-Error \"Error: $_\"\r\n    EXIT 0\r\n}\r\n\r\n# Some Error handling here\r\nif($response.StatusCode -ne 200){\r\n    Write-Error \"There was an error listing response content below to debug\"\r\n    $response.RawContent\r\n}else{\r\n    Write-Host \"Sent Successfully\"\r\n}\r\n\r\n# We usually don't want to fail a deployment because of this\r\nEXIT 0"
   },
   "SensitiveProperties": {},
   "Parameters": [
@@ -55,10 +55,9 @@
         "Octopus.ControlType": "SingleLineText"
       }
     }
-
   ],
-  "LastModifiedOn": "2016-03-01T02:15:54.920+00:00",
-  "LastModifiedBy": "ryankelley",
+  "LastModifiedOn": "2019-09-18T00:54:17.669Z",
+  "LastModifiedBy": "baynewc1",
   "$Meta": {
     "ExportedAt": "2016-03-01T23:11:19.809Z",
     "OctopusVersion": "3.2.0",


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **To minimize the risk of step template parameters clashing with other variables in a project that uses the step template, ensure that you prefix your parameter names (e.g. an abbreviated name for the step template or the category of the step template**
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it