### PR TITLE
Update readme. Fix sync issue caused by invalid json.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ When reviewing a PR, keep the following things in mind:
 * `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
 * `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
 * Parameter names should not start with `$`
+* The `DefaultValue`s of `Parameter`s should be either a string or null.
 * `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
 * If a new `Category` has been created:
    * An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder

--- a/step-templates/gitlab-create-tag.json
+++ b/step-templates/gitlab-create-tag.json
@@ -25,10 +25,7 @@
       "Name": "personalAccessToken",
       "Label": "Personal access token",
       "HelpText": "The Gitlab [personal access token](https://docs.gitlab.com/ee/api/README.html#personal-access-tokens)\n#{GitlabTag.PersonalAccessToken} as default value",
-      "DefaultValue": {
-        "HasValue": true,
-        "NewValue": null
-      },
+      "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
       }


### PR DESCRIPTION
When step templates are exported from Octopus Deploy, if the parameter is sensitive it will be exported as an object, which causes issues with syncing. We will look into better validation for this. For now I've updated the readme to remind us to check that parameter `DefaultValue`s are either a string or null, and not an object.

This PR also updates the `gitlab-create-tag.json` file to fix the same issue.