### PR TITLE
Add Pulumi Step Template to be used for Windows workers

### DIFF
--- a/step-templates/run-pulumi-on-linux.json
+++ b/step-templates/run-pulumi-on-linux.json
@@ -3,7 +3,7 @@
   "Name": "Run Pulumi (Linux)",
   "Description": "Allows you to run Pulumi commands using the Pulumi CLI. For Pulumi stacks that deploy AWS resources, make sure your Octopus Project contains a variable called `AWS` of type `AWS Account`. For Pulumi stacks that deploy Azure resources, set the variable `Azure` of type `Azure Subscriptions` (Service Principal).\n\nLearn more about adding an [AWS Account](https://octopus.com/docs/infrastructure/deployment-targets/aws#create-an-aws-account) or [Azure Subscriptions](https://octopus.com/docs/infrastructure/deployment-targets/azure#azure-service-principal) to your Octopus Deploy instance.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {

--- a/step-templates/run-pulumi-on-linux.json
+++ b/step-templates/run-pulumi-on-linux.json
@@ -1,7 +1,7 @@
 {
   "Id": "76296cd1-7d8c-47e8-b33f-027ecd3ff6b5",
   "Name": "Run Pulumi (Linux)",
-  "Description": "Run Pulumi commands using the Pulumi CLI.",
+  "Description": "Allows you to run Pulumi commands using the Pulumi CLI. For Pulumi stacks that deploy AWS resources, make sure your Octopus Project contains a variable called `AWS` of type `AWS Account`. For Pulumi stacks that deploy Azure resources, set the variable `Azure` of type `Azure Subscriptions` (Service Principal).\n\nLearn more about adding an [AWS Account](https://octopus.com/docs/infrastructure/deployment-targets/aws#create-an-aws-account) or [Azure Subscriptions](https://octopus.com/docs/infrastructure/deployment-targets/azure#azure-service-principal) to your Octopus Deploy instance.",
   "ActionType": "Octopus.Script",
   "Version": 1,
   "CommunityActionTemplateId": null,

--- a/step-templates/run-pulumi-on-windows.json
+++ b/step-templates/run-pulumi-on-windows.json
@@ -1,0 +1,102 @@
+{
+  "Id": "b63d2573-9ff4-4ffe-83c7-153fad24ea57",
+  "Name": "Run Pulumi (Windows)",
+  "Description": "Allows you to run Pulumi commands using the Pulumi CLI. For Pulumi stacks that deploy AWS resources, make sure your Octopus Project contains a variable called `AWS` of type `AWS Account`. For Pulumi stacks that deploy Azure resources, set the variable `Azure` of type `Azure Subscriptions` (Service Principal).\n\nLearn more about adding an [AWS Account](https://octopus.com/docs/infrastructure/deployment-targets/aws#create-an-aws-account) or [Azure Subscriptions](https://octopus.com/docs/infrastructure/deployment-targets/azure#azure-service-principal) to your Octopus Deploy instance.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Test-CommandExists\n{\n\tParam ($command)\n\t$oldPreference = $ErrorActionPreference\n\t$ErrorActionPreference = 'stop'\n\tTry {\n    \tif(Get-Command $command){\n        \treturn $true\n        }\n    } Catch {\n    \tWrite-Host \"$command does not exist\"\n        return $false\n    } Finally {\n    \t$ErrorActionPreference=$oldPreference\n   \t}\n}\n\nIf ([string]::IsNullOrWhiteSpace($OctopusParameters[\"Pulumi.AccessToken\"])) {\n\tFail-Step \"Parameter Pulumi.AccessToken cannot be empty.\"\n}\n\n$env:PULUMI_ACCESS_TOKEN=$OctopusParameters[\"Pulumi.AccessToken\"]\n\nIf ((Test-CommandExists pulumi) -eq $false) {\n\t(new-object net.webclient).DownloadFile(\"https://get.pulumi.com/install.ps1\",\"local.ps1\")\n    ./local.ps1\n\t$pulumiInstallRoot=(Join-Path $env:UserProfile \".pulumi\")\n\t$binRoot=(Join-Path $pulumiInstallRoot \"bin\")\n\t$env:Path+=\";$binRoot\"\n}\n\n# Check for AWS access key credentials and set those in the env.\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"AWS.AccessKey\"])) {\n\t$env:AWS_ACCESS_KEY_ID=$OctopusParameters[\"AWS.AccessKey\"]\n}\n\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"AWS.SecretKey\"])) {\n\t$env:AWS_SECRET_ACCESS_KEY=$OctopusParameters[\"AWS.SecretKey\"]\n}\n\n# Check for Azure SP/personal account credentials and set those in the env.\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"Azure.ClientId\"])) {\n\t$env:ARM_CLIENT_ID=$OctopusParameters[\"Azure.ClientId\"]\n}\n\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"Azure.Password\"])) {\n\t$env:ARM_CLIENT_SECRET=$OctopusParameters[\"Azure.Password\"]\n}\n\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"Azure.TenantId\"])) {\n\t$env:ARM_TENANT_ID=$OctopusParameters[\"Azure.TenantId\"]\n}\n\nIf (![string]::IsNullOrWhiteSpace($OctopusParameters[\"Azure.SubscriptionId\"])) {\n\t$env:ARM_SUBSCRIPTION_ID=$OctopusParameters[\"Azure.SubscriptionId\"]\n}\n\nWrite-Host \"Logging in to Pulumi using access token\"\npulumi login\n\n$cwd=$OctopusParameters[\"Pulumi.WorkingDirectory\"]\nIf (![string]::IsNullOrWhiteSpace($cwd)) {\n\tcd $cwd\n}\n\n$stackName=$OctopusParameters[\"Pulumi.StackName\"]\nWrite-Host \"Selecting stack $stackName\"\nTry {\n\tpulumi stack select $stackName\n}\nCatch {\n\t$createStackIfNotExists = $OctopusParameters[\"Pulumi.CreateStack\"]\n\tIf ($createStackIfNotExists -eq \"True\") {\n    \tpulumi stack init $stackName\n    } Else {\n    \tFail-Step \"Stack $stackName does not exist.\"\n    }\n}\n\n$restoreDeps=$OctopusParameters[\"Pulumi.RestoreDeps\"]\nIf ($restoreDeps -eq \"True\") {\n\tWrite-Host \"Restoring dependencies...\"\n    $restoreDepsCmd = $OctopusParameters[\"Pulumi.RestoreCmd\"]\n    Invoke-Expression $restoreDepsCmd\n}\n\n$pulCmd=$OctopusParameters[\"Pulumi.Command\"]\n$pulArgs=$OctopusParameters[\"Pulumi.Args\"]\nIf (![string]::IsNullOrWhiteSpace($pulArgs)) {\n\tpulumi $pulCmd $pulArgs\n}\nElse {\n\tpulumi $pulCmd\n}\n"
+  },
+  "Parameters": [{
+      "Id": "94a93122-235e-4edd-8217-adbe63db85f1",
+      "Name": "Pulumi.StackName",
+      "Label": "Stack Name",
+      "HelpText": "The fully-qualified stack name against which the Pulumi commands will be run. Hint: `{orgName}/{projectName}/{stackName}`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "29e68d5d-5c46-4290-993c-51672a431812",
+      "Name": "Pulumi.Command",
+      "Label": "Command",
+      "HelpText": "Eg. `preview`, `up`, `destroy` etc. Learn more [here](https://www.pulumi.com/docs/reference/cli/).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "362423a8-aab4-451f-b79b-3896725b8c84",
+      "Name": "Pulumi.Args",
+      "Label": "Command Args",
+      "HelpText": "Arguments to pass to the Pulumi command. Eg. `-v` to set the verbosity or `--logtostderr` to log to the standard error. [Learn more](https://www.pulumi.com/docs/reference/cli/) about the available commands and the arguments you can pass to each of them.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "9f6bda9f-39dd-47cf-9233-5499a837c4fb",
+      "Name": "Pulumi.AccessToken",
+      "Label": "Pulumi Access Token",
+      "HelpText": "The [Pulumi access token](https://www.pulumi.com/docs/intro/console/accounts-and-organizations/accounts/#access-tokens) to use. The access token must have access to the stack, which you are deploying. [Click here](https://app.pulumi.com/account/tokens) to go to the Access Tokens page on the Pulumi Console now.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "aa4310d6-52eb-4b37-9575-db6cfe7c3e3a",
+      "Name": "Pulumi.WorkingDirectory",
+      "Label": "Pulumi Working Directory",
+      "HelpText": "The working directory where the Pulumi app is extracted to. If this parameter is specified, then the step will `cd` into that directory. To avoid this, you can pass the `--cwd C:\\path\\to\\your\\dir` in the `Command Args` parameter as one of the args.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "04d21e39-3f74-435f-803d-b80c104e5c07",
+      "Name": "Pulumi.CreateStack",
+      "Label": "Create Stack",
+      "HelpText": "Whether to create a new stack if it does not exist already.",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "4775234d-4d5c-454e-888c-1171f1b1c258",
+      "Name": "Pulumi.RestoreDeps",
+      "Label": "Restore Dependencies",
+      "HelpText": "Whether to restore dependencies.",
+      "DefaultValue": "true",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "6a1ddea9-76dd-4c32-bbf5-a5c451d6e251",
+      "Name": "Pulumi.RestoreCmd",
+      "Label": "The command used to restore dependencies.",
+      "HelpText": "(Optional) Required only if `Restore Dependencies` is true. The command used to restore dependencies for your Pulumi app. This is dependent on the runtime your Pulumi app uses. For example, if your Pulumi app uses the `nodejs` runtime, then use the command `npm install` here to restore dependencies.",
+      "DefaultValue": "npm install",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "LastModifiedBy": "praneetloke",
+  "$Meta": {
+    "ExportedAt": "2019-12-03T05:49:17.461Z",
+    "OctopusVersion": "2019.10.4",
+    "Type": "ActionTemplate"
+  },
+  "Category": "pulumi"
+}


### PR DESCRIPTION
In a previous PR I contributed the Step Template for Pulumi that can be used with Linux-based Workers. This adds the Windows version, which utilizes PowerShell.

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] ~~If a new `Category` has been created:~~ (**Not introducing a new category with this PR.**)
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
