### PR TITLE
Fix scheduled-task-changepath for Server 2012

### DIFF
--- a/step-templates/windows-scheduled-task-changepath.json
+++ b/step-templates/windows-scheduled-task-changepath.json
@@ -3,9 +3,9 @@
   "Name": "Windows Scheduled Task - Change Path",
   "Description": "Changes the execution path of a Windows Scheduled Task for both 2008 and 2012.",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$taskName   = $OctopusParameters['TaskName']\r$taskFolder = $OctopusParameters['TaskFolder']\r$taskExe    = $OctopusParameters['TaskExe']\r$userName   = $OctopusParameters['TaskUserName']\r$password   = $OctopusParameters['TaskPassword']\r\r$taskPath = Join-Path $taskFolder $taskExe\rWrite-Output \"Changing execution path of $taskName to $taskPath\"\r\r$userName = \"`\"$userName`\"\"\r\r#Check if 2008 Server\rif ((Get-WmiObject Win32_OperatingSystem).Name.Contains(\"2008\"))\r{\r    schtasks /Change /RU $userName /RP $password /TR $taskPath /TN $taskName\r}\relse\r{\r    Set-ScheduledTask -TaskName $taskName -TaskPath $taskPath -User $userName -Password $password;\r}",
+    "Octopus.Action.Script.ScriptBody": "$taskName   = $OctopusParameters['TaskName']\r$taskFolder = $OctopusParameters['TaskFolder']\r$taskExe    = $OctopusParameters['TaskExe']\r$userName   = $OctopusParameters['TaskUserName']\r$password   = $OctopusParameters['TaskPassword']\r\r$taskPath = Join-Path $taskFolder $taskExe\rWrite-Output \"Changing execution path of $taskName to $taskPath\"\r\r#Check if 2008 Server\rif ((Get-WmiObject Win32_OperatingSystem).Name.Contains(\"2008\"))\r{\r    $userName = \"`\"$userName`\"\"\r    schtasks /Change /RU $userName /RP $password /TR $taskPath /TN $taskName\r}\relse\r{\r    $action = New-ScheduledTaskAction -Execute $taskPath\r    Set-ScheduledTask -TaskName $taskName -Action $action -User $userName -Password $password;\r}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -50,8 +50,8 @@
       "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2019-09-26T18:19:00.000+00:00",
-  "LastModifiedBy": "hayer",
+  "LastModifiedOn": "2019-12-12T20:56:00.000+00:00",
+  "LastModifiedBy": "rmsy",
   "$Meta": {
     "ExportedAt": "2014-12-10T18:00:42.218+00:00",
     "OctopusVersion": "2.5.12.666",


### PR DESCRIPTION
The "Windows Scheduled Task - Change Path" step template has logic to behave differently on Server 2012 vs. Server 2008. I found a couple of issues in the 2012 logic.

First, the username is enclosed in quotes when passed as an argument to the command, which was needed for the 2008 command, but fails with the 2012 command. I have made this behavior specific to 2008.

Secondly, the PowerShell command to define the action for the scheduled task was incorrect. The script was attempting to use the `-TaskPath` argument in `Set-ScheduledTask` to set the path of the executable - however, [that is not the purpose of `TaskPath`](https://docs.microsoft.com/en-us/powershell/module/scheduledtasks/set-scheduledtask?view=winserver2012r2-ps). Instead, an action needs to be created with [`New-ScheduledTaskAction`](https://docs.microsoft.com/en-us/powershell/module/scheduledtasks/new-scheduledtaskaction?view=winserver2012r2-ps) and passed to the `Set-ScheduledTask` command with the `-Action` parameter.

After making both of these changes, the script now works on both 2008 and 2012 for me.

---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it