### PR TITLE
Variable to integer and output modification

### DIFF
--- a/step-templates/wait.json
+++ b/step-templates/wait.json
@@ -3,7 +3,7 @@
   "Name": "Wait",
   "Description": "Pauses the process for a set duration",
   "ActionType": "Octopus.Script",
-  "Version": 1.1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {

--- a/step-templates/wait.json
+++ b/step-templates/wait.json
@@ -7,7 +7,7 @@
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$Wait = $Seconds\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Verbose \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
+    "Octopus.Action.Script.ScriptBody": "[int]$Wait = $Seconds\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Output \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false"

--- a/step-templates/wait.json
+++ b/step-templates/wait.json
@@ -7,7 +7,7 @@
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[int]$Wait = $Seconds\nWrite-Output "Waiting for $seconds seconds"\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Verbose \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
+    "Octopus.Action.Script.ScriptBody": "[int]$Wait = $Seconds\nWrite-Output \"Waiting for $seconds seconds\"\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Verbose \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false"

--- a/step-templates/wait.json
+++ b/step-templates/wait.json
@@ -3,11 +3,11 @@
   "Name": "Wait",
   "Description": "Pauses the process for a set duration",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 1.1,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[int]$Wait = $Seconds\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Output \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
+    "Octopus.Action.Script.ScriptBody": "[int]$Wait = $Seconds\nWrite-Output "Waiting for $seconds seconds"\nfor ($CountDown = $Wait; $CountDown -ge 0; $CountDown--){\nWrite-Verbose \"$CountDown seconds remaining\"\nStart-Sleep 1\n}",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false"
@@ -24,7 +24,7 @@
       }
     }
   ],
-  "LastModifiedOn": "2019-12-17T20:15:05.736Z",
+  "LastModifiedOn": "2020-01-12T21:05:05.736Z",
   "LastModifiedBy": "biohazardhpk",
   "$Meta": {
     "ExportedAt": "2019-12-06T20:15:05.736Z",


### PR DESCRIPTION
---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
