### PR TITLE
Adding new template for flyway 

### DIFF
--- a/step-templates/flyway-migrate-referenced-package.json
+++ b/step-templates/flyway-migrate-referenced-package.json
@@ -1,0 +1,157 @@
+{
+    "Id": "80fa2e44-95ca-4d25-9013-cddd536afe85",
+    "Name": "Flyway Migrate Copy",
+    "Description": "Deploy a database using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "Packages": [
+      {
+        "Id": "c689ba0b-3aa6-4610-bc1a-c0daf1fdcb64",
+        "Name": "Flyway Package",
+        "PackageId": "#{FlyWayPackageId}",
+        "FeedId": "#{FlyWayFeedId}",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "immediate"
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway Package].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($relativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $relativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($locations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $locations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $targetUrl\"\nWrite-Host \"Target DB -user: $targetUser\"\nWrite-Host \"Run drift-check?: $runDriftCheck\"\nWrite-Host \"Compare tool path: $comparePath\"\nWrite-Host \"Shadow DB -url: $shadowUrl\"\nWrite-Host \"Shadow DB -user: $shadowUser\"\n\nif ($runDriftCheck){\n    # Can't do drift check without a shadow DB\n    if($shadowUrl -eq $null){\n        Write-Output \"Cannot run drift check because Shadow DB not provided.\"\n        $runDriftCheck = $FALSE\n    }\n    # Can't do drift check without a comparison tool\n    if($comparePath -eq $null){\n        Write-Output \"Cannot run drift check as path to comparison tool not provided.\"\n        $runDriftCheck = $FALSE\n    }\n}\n\n\n# Drift check preperation\n$dbPlatform = \"Unknown\"\n$targetDbVersion = 0\n$targetDbPath = \"Unknown\"\n\nif($runDriftCheck)\n{\n    # Determining name and version of target database\n    Write-Host \"*******************************************\"\n    Write-Host \"Determining name and version of target database:\"\n    Write-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    \n    # Saving target DB info\n    $arguments = @(\n        \"info\", \n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=$targetPassword\"\n    )\n    Write-Host \"Determining version of target database:\"\n    Write-Host \"Executing the following: & $flywayCmd $arguments\"\n    $targetDbInfo = & $flywayCmd $arguments\n    Write-Host \"Target DB info:\"\n    Write-Host $targetDbInfo\n\n    # Finding intended version number of target database\n    $targetDbVersion = ($targetDbInfo | ? {$_.StartsWith(\"|\") } | ? { $_ -notcontains \"No migrations found\" } | % { $parts = $_.Split('|'); New-Object PSObject -Property @{Version = $parts[1].Trim(); State = $parts[4].Trim()}} | ? { $_.State -eq \"Success\" } | Select-Object -Last 1).Version\n    Write-Host \"Target database is at version $targetDbVersion\"\n\n    # Finding connection string for target DB\n    Write-Host \"Target database connection string $targetUrl\"\n    \n    if ($targetUrl -like '*sqlserver*'){\n        $dbPlatform = \"SQLServer\"       \n    }\n    \n    if ($targetUrl -like '*mysql*'){\n        $dbPlatform = \"MySQL\"       \n    }\n    \n    if ($targetUrl -like '*oracle*'){\n        $dbPlatform = \"Oracle\"       \n    }    \n    \n    Write-Output \"Database platform $dbPlatform detected.\"\n}\n\nif ($dbPlatform -eq \"Unknown\" -And $runDriftCheck){\n    Write-Host \"Cannot run drift check!\"\n    Write-Host \"Drift check only supported for SQL Server, Oracle or MySQL.\"\n    Write-Host \"Cannot determine from FlyWay info if your database platform is supported.\"\n    $runDriftCheck = $FALSE      \n}\n\nif ($runDriftCheck -eq $true)\n{\n    # Building a shadow DB for drift check\n    Write-Host \"*******************************************\"\n    Write-Host \"Building a shadow DB for drift check:\"\n    Write-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    #   In a future version it would be cool to build the shadow DB ourselves\n    #   and to clean up afterwards. For now, however, asking the user to provide \n    #   a shadow DB for us removes the requirement to work out how to build a fresh\n    #   DB on 3 different DB platforms. It also means we don't need to worry about\n    #   credentials etc\n    #   $shadowDbPath = $targetDbPath + \"_SHADOW\"\n    \n    Write-Host \"Cleaning shadow database\"\n    $arguments = @(\n        \"clean\", \n        \"-url=$shadowUrl\",\n        \"-user=$shadowUser\",\n        \"-password=$shadowPassword\"\n    )\n    Write-Host \"Executing the following: &$flywayCmd $arguments\"\n    &$flywayCmd $arguments\n    \n    Write-Host \"Migrating shadow database up to current target version\"\n    $arguments = @(\n        \"migrate\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$shadowUrl\",\n        \"-user=$shadowUser\",\n        \"-password=$shadowPassword\",\n        \"-target=$targetDbVersion\"\n    )\n    Write-Host \"Executing the following: &$flywayCmd $arguments\"\n    &$flywayCmd $arguments\n\n    # Using comparison tool to check for drift\n    Write-Host \"*******************************************\"\n    Write-Host \"Using comparison tool to check for drift:\"\n    Write-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    \n    function getServer ($connectionsString){\n        return ($connectionsString -split \"/\")[2]\n    }\n\n    function getDbName ($connectionsString){\n        # Note: For MySQL this may return key values as well. e.g:\n        # <database>?<key1>=<value1>&<key2>=<value2>...\n        # Should fix this!!!!\n        Write-Host \"Warning: Function getDbName() does not handle MySQL connection strings fully!\"\n        return ($connectionsString -split \"/\")[3]\n    }\n\n    # SQL Server\n    if ($dbPlatform -eq \"SQLServer\"){\n        \n        # Details for target DB\n        $targetServer = getServer($targetUrl)\n        $targetDb = getDbName($targetUrl)\n        \n        # Details for shadow DB\n        $shadowServer = getServer($shadowUrl)\n        $shadowDb = getDbName($shadowUrl) \n        \n        # Drift report name and location\n        $date = Get-Date -format yyyyMMddHHmmss\n        $reportName = \"FlySQLDriftReport_$targetDb_$date.\"\n        $reportPath = Join-Path -Path $flywayPath -ChildPath \"driftReport\"\n        \n        New-Item $reportPath -type directory\n        \n        $arguments = @(\n            \"/s1=$targetServer\",  \n            \"/db1=$targetDb\", \n            \"/u1=$targetUser\",  \n            \"/p1=$targetPassword\", \n            \"/s2=$shadowServer\",  \n            \"/db2=$shadowDb\", \n            \"/u2=$shadowUser\",  \n            \"/p2=$shadowPassword\",\n            \"/assertidentical\",\n            \"/r=$reportPath\\reportName.html\",\n            \"/rt=Simple\"\n        )\n\n        Write-Host \"Executing the following command: & $comparePath $arguments\"\n        & $comparePath $arguments \n        if ($LASTEXITCODE -ne 0){\n            Throw \"Drift check failed. For details see report here: $reportPath\"\n        }\n        else{\n            Write-Host \"Drift check passed.\"\n        }\n    }\n    \n    # Oracle\n    if ($dbPlatform -eq \"Oracle\"){\n        \n        # \"Target\" and \"Source\" names are very confusing.\n        # Consistently in this PS script I have used target\n        # to refer to the database we intend to deploy to.\n        # At this point we need to use that database as\n        # the source in order to create a roll-back\n        # script should the drift-check fail.\n        # Hence the terms source and target are used\n        # for opposite purposes when using Schema Compare\n        # for Oracle command line tool.\n        \n        # Details for target DB\n        $targetTns = getServer($targetUrl)\n        $targetSchema = getDbName($targetUrl)\n        $source = \"$targetUser/$targetPassword@$targetTns{$targetSchema}\"\n        \n        # Details for shadow DB\n        $shadowServer = getServer($shadowUrl)\n        $shadowDb = getDbName($shadowUrl) \n        $target = \"$sourceUser/$sourcePassword@$sourceTns{$sourceSchema}\"\n        \n        # Drift report name and location\n        $date = Get-Date -format yyyyMMddHHmmss\n        $reportName = \"FlySQLDriftReport_$targetSchema_$date.\"\n        $reportPath = Join-Path -Path $flywayPath -ChildPath \"driftReport\"\n        \n        New-Item $reportPath -type directory\n        \n        $arguments = @(\n            \"/source=$source\",  \n            \"/target=$target\",\n            \"/r=$reportPath\\reportName.html\",\n            \"/rt=Simple\"\n        )\n\n        Write-Host \"Executing the following command: & $comparePath $arguments\"\n        & $comparePath $arguments \n        if ($LASTEXITCODE -ne 0){\n            Throw \"Drift check failed. For details see report here: $reportPath\"\n        }\n        else{\n            Write-Host \"Drift check passed.\"\n        }\n        \n    }\n    # MySQL\n    if ($dbPlatform -eq \"MySQL\"){\n\n        # Details for target DB\n        $targetServerPort = getServer($targetUrl)\n        $targetServer = ($targetServerPort -Split \":\")[0]\n        $targetPort = ($targetServerPort -Split \":\")[1]\n        $targetDb = getDbName($targetUrl)\n\n        # Details for shadow DB        \n        $shadowServerPort = getServer($targetUrl)\n        $shadowServer = ($targetServerPort -Split \":\")[0]\n        $shadowPort = ($targetServerPort -Split \":\")[1]\n        $shadowDb = getDbName($shadowUrl) \n\n        # Drift report name and location        \n        $date = Get-Date -format yyyyMMddHHmmss\n        $reportName = \"FlySQLDriftReport_$targetDb_$date\"\n        $reportPath = Join-Path -Path $flywayPath -ChildPath \"driftReport\"\n        \n        New-Item $reportPath -type directory\n        \n        $arguments = @(\n            \"-verbose\", \n            \"-server1=$shadowServer\",  \n            \"-port1=$shadowPort\",\n            \"-database1=$shadowDb\", \n            \"-username1=$shadowUser\",  \n            \"-password1=$shadowPassword\",\n\n            \"-server2=$targetServer\",  \n            \"-database2=$targetDb\", \n            \"-port2=$targetPort\",\n            \"-username2=$targetUser\",\n            \"-password2=$targetPassword\", \n\n            \"-assertIdentical\",\n            \"-report=$reportPath\\$reportName.html\",\n            \"-reportType=Simple\",\n            \"-scriptfile=$reportPath\\undoDrift.sql\"\n        )\n\n        Write-Host \"Executing the following command: & $comparePath $arguments\"\n        & $comparePath $arguments \n        if ($LASTEXITCODE -ne 0){\n            Throw \"Drift check failed. For details see report here: $reportPath\"\n        }\n        else {\n            Write-Host \"Drift check passed.\"\n        }\n    }\n}\n\n# Executing deployment\nWrite-Host \"*******************************************\"\nWrite-Host \"Executing deployment:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"migrate\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=`\"$targetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.SubstituteInFiles.Enabled": "True",
+      "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
+      "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[Flyway Package].ExtractedPath}\\sql\\*.sql"
+    },
+    "Parameters": [
+      {
+        "Id": "9c802c3d-4b2c-46d0-93a5-f8b55ec331c2",
+        "Name": "RelativePath",
+        "Label": "Relative path to flyway.cmd (optional)",
+        "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "3630e99d-2855-4a8e-9ec2-e72cd9a753a0",
+        "Name": "locations",
+        "Label": "-locations (relative path, optional)",
+        "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "eee3d0b8-5f7c-4f4a-9e77-d418a428c42a",
+        "Name": "targetUrl",
+        "Label": "Target -url (required)",
+        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "8225bcf9-dec6-46d3-bca6-e2b51c935755",
+        "Name": "targetUser",
+        "Label": "Target -user (required)",
+        "HelpText": "The username to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "6d0152d9-ebe4-4504-a7e6-34cc99af8288",
+        "Name": "targetPassword",
+        "Label": "Target -password (required)",
+        "HelpText": "The password to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "78462057-ced4-458d-ac57-f4f3a0b5d7a6",
+        "Name": "runDriftCheck",
+        "Label": "Run pre-deploy drift check",
+        "HelpText": "Check for drift with Redgate comparison tool.\n\n_Requirements_\n\nRequires that a Redgate command line comparison tool is installed on the target machine.\n\nFor SQL Server: SQL Compare\n\nhttp://www.red-gate.com/products/sql-development/sql-compare/\n\nFor Oracle: Schema Compare for Oracle\n\nhttp://www.red-gate.com/products/oracle-development/schema-compare-for-oracle/\n\nFor MySQL: MySQL Compare\n\nhttps://www.red-gate.com/products/mysql/mysql-compare/\n\nAll tools include a free trial licence for a limited period of time.\n\n_Limitations_\n\nSQL Server, Oracle and MySQL only",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "e15c2077-8658-4e24-9f9d-c2cf386ea8ee",
+        "Name": "comparePath",
+        "Label": "Path to Redgate comparison tool (required for drift-check)",
+        "HelpText": "Checking for drift requires a database comparison tool. This template uses the Redgate tooling.\n\nPlease provide the path to a Redgate command line tool. The default paths are\n\nSQL Compare (SQL Server):\n\nC:\\Program Files (x86)\\Red Gate\\SQL Automation Pack 1\\SC\\SQLCompare.exe\n\nSchema Compare for Oracle:\n\nC:\\Program Files\\Red Gate\\Schema Compare for Oracle 3\\SCO.exe\n\nMySQL Compare:\n\nC:\\Program Files (x86)\\Red Gate\\MySQL Compare 1\\MC.exe",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "ad924633-c031-4dfd-8b55-0a32c434d777",
+        "Name": "shadowUrl",
+        "Label": "Shadow -url (required for drift-check)",
+        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "12943c41-51c1-4904-b077-c8aea750690c",
+        "Name": "shadowUser",
+        "Label": "Shadow -user (required for drift-check)",
+        "HelpText": "The username to connect to the shadow database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "dbe4c707-f7b2-4c38-bad5-4e790cacfe6e",
+        "Name": "shadowPassword",
+        "Label": "Shadow -password (required for drift-check)",
+        "HelpText": "The password to connect to the shadow database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "3f8478c2-555f-4b5c-9782-8db4c374ba53",
+        "Name": "FlyWayPackageId",
+        "Label": "Flyway package Id",
+        "HelpText": "The package Id that contains the Flyway project.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "f1760f75-afc5-46bd-a2c8-82afeb1af009",
+        "Name": "FlyWayFeedId",
+        "Label": "Feed Id",
+        "HelpText": "The Id of the feed where the Flyway Package will be retrieved from",
+        "DefaultValue": "feeds-builtin",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      }
+    ],
+    "LastModifiedBy": "twerthi",
+    "$Meta": {
+      "ExportedAt": "2020-01-08T23:09:14.764Z",
+      "OctopusVersion": "2019.11.3",
+      "Type": "ActionTemplate"
+    },
+    "Category": "flyway"
+  }


### PR DESCRIPTION
This version will allow the step to be executed from a worker by use of a referenced package.
---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
