### PR TITLE
Fixing Flyway migrate from a referenced package name

### DIFF
--- a/step-templates/flyway-migrate-referenced-package.json
+++ b/step-templates/flyway-migrate-referenced-package.json
@@ -1,6 +1,6 @@
 {
     "Id": "80fa2e44-95ca-4d25-9013-cddd536afe85",
-    "Name": "Flyway Migrate Copy",
+    "Name": "Flyway Migrate from a referenced package",
     "Description": "Deploy a database using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
     "ActionType": "Octopus.Script",
     "Version": 1,


### PR DESCRIPTION
---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it


