### PR TITLE
Adding flyway info templates.

### DIFF
--- a/step-templates/flyway-info-bash.json
+++ b/step-templates/flyway-info-bash.json
@@ -1,0 +1,158 @@
+{
+    "Id": "a7ffdbc8-7876-4c5d-8856-5c17ee3df443",
+    "Name": "Flyway Info from a referenced package - Bash",
+    "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "Author": "twerthi",
+    "Packages": [
+      {
+        "Id": "c689ba0b-3aa6-4610-bc1a-c0daf1fdcb64",
+        "Name": "FlywayPackage",
+        "PackageId": "#{FlyWayPackageId}",
+        "FeedId": "#{FlyWayFeedId}",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "immediate"
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.ScriptBody": "# Get all of the Parameter values assigned to local variables\nrelativePath=$(get_octopusvariable \"RelativePath\")\nlocations=$(get_octopusvariable \"locations\")\ntargetUrl=$(get_octopusvariable \"targetUrl\")\ntargetUser=$(get_octopusvariable \"targetUser\")\ntargetPassword=$(get_octopusvariable \"targetPassword\")\nflywayPackageId=$(get_octopusvariable \"FlyWayPackageId\")\nflywayFeedId=$(get_octopusvariable \"FlyWayFeedId\")\n\n# Declaring the path to the NuGet package\npackagePath=$(get_octopusvariable \"Octopus.Action.Package[FlywayPackage].ExtractedPath\")\n\n# Delcaring path to FlyWay\nflywayPath=$packagePath\n\nif [[ ! -z \"$relativePath\" ]]\nthen\n    $flywayPath=$packagePath$relativePath\nfi\n\nflywayCmd=$flywayPath\"/flyway\"\n\nif [[ ! -z \"$locations\" ]]\nthen\n    locationsPath=$packagePath$locations\nelse\n    locationsPath=$flywayPath\"/sql\"\nfi\n\n# Logging for troubleshooting\necho \"*******************************************\"\necho \"Logging variables:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\necho \"FlywayPackageStep: $FlyWayPackageStep\"\necho \"FlywayPath: $flywayPath\"\necho \"LocationsPath: $locationsPath\"\necho \"Target DB -url: $targetUrl\"\necho \"Target DB -user: $targetUser\"\n\n# Executing deployment\necho \"*******************************************\"\necho \"Comparing scripts folder to schema:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\n    arguments=\"info -locations=filesystem:$locationsPath -url=$targetUrl -user=$targetUser -password=\"$targetPassword\"\"\necho \"Executing the following command:  $flywayCmd ${arguments//$targetPassword/********}\"\n\nbash $flywayCmd $arguments",
+      "Octopus.Action.Script.Syntax": "Bash",
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.SubstituteInFiles.Enabled": "True",
+      "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
+      "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[FlywayPackage].ExtractedPath}/sql/*.sql"
+    },
+    "Parameters": [
+      {
+        "Id": "1a88edf0-a7d5-4b49-9320-eeeff36e8d4f",
+        "Name": "RelativePath",
+        "Label": "Relative path to flyway.cmd (optional)",
+        "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "fde5fadb-570b-4086-8a84-14030ca05f21",
+        "Name": "locations",
+        "Label": "-locations (relative path, optional)",
+        "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "6dc461fe-6a00-4621-8447-9d4dca858c39",
+        "Name": "targetUrl",
+        "Label": "Target -url (required)",
+        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "2018b280-eedc-4987-bfc9-e38d82de1a51",
+        "Name": "targetUser",
+        "Label": "Target -user (required)",
+        "HelpText": "The username to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "d9ce910d-7b02-4dcc-a2b3-b2e6188f5d8f",
+        "Name": "targetPassword",
+        "Label": "Target -password (required)",
+        "HelpText": "The password to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "98de9e8c-f29b-44f2-8ca8-ce2d55a58b25",
+        "Name": "runDriftCheck",
+        "Label": "Run pre-deploy drift check",
+        "HelpText": "Check for drift with Redgate comparison tool.\n\n_Requirements_\n\nRequires that a Redgate command line comparison tool is installed on the target machine.\n\nFor SQL Server: SQL Compare\n\nhttp://www.red-gate.com/products/sql-development/sql-compare/\n\nFor Oracle: Schema Compare for Oracle\n\nhttp://www.red-gate.com/products/oracle-development/schema-compare-for-oracle/\n\nFor MySQL: MySQL Compare\n\nhttps://www.red-gate.com/products/mysql/mysql-compare/\n\nAll tools include a free trial licence for a limited period of time.\n\n_Limitations_\n\nSQL Server, Oracle and MySQL only",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "6faf7e70-49d0-4f5d-a3ea-ec997ad27fa0",
+        "Name": "comparePath",
+        "Label": "Path to Redgate comparison tool (required for drift-check)",
+        "HelpText": "Checking for drift requires a database comparison tool. This template uses the Redgate tooling.\n\nPlease provide the path to a Redgate command line tool. The default paths are\n\nSQL Compare (SQL Server):\n\nC:\\Program Files (x86)\\Red Gate\\SQL Automation Pack 1\\SC\\SQLCompare.exe\n\nSchema Compare for Oracle:\n\nC:\\Program Files\\Red Gate\\Schema Compare for Oracle 3\\SCO.exe\n\nMySQL Compare:\n\nC:\\Program Files (x86)\\Red Gate\\MySQL Compare 1\\MC.exe",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "4591dcc4-7889-41a0-bd47-85a89bf4d16c",
+        "Name": "shadowUrl",
+        "Label": "Shadow -url (required for drift-check)",
+        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "540e6120-8955-45a8-96e6-f3bd36ce0bd8",
+        "Name": "shadowUser",
+        "Label": "Shadow -user (required for drift-check)",
+        "HelpText": "The username to connect to the shadow database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "9af8f3f2-d36a-43e7-aa99-065c279d5561",
+        "Name": "shadowPassword",
+        "Label": "Shadow -password (required for drift-check)",
+        "HelpText": "The password to connect to the shadow database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "7a3d1982-ecc1-492c-af92-fabc0feea7a1",
+        "Name": "FlyWayPackageId",
+        "Label": "Flyway package Id",
+        "HelpText": "The package Id that contains the Flyway project.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "1ebf7c69-bac8-4ac8-aad7-162c75cae75f",
+        "Name": "FlyWayFeedId",
+        "Label": "Feed Id",
+        "HelpText": "The Id of the feed where the Flyway Package will be retrieved from",
+        "DefaultValue": "feeds-builtin",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      }
+    ],
+    "LastModifiedBy": "twerthi",
+    "$Meta": {
+      "ExportedAt": "2020-03-11T16:56:47.731Z",
+      "OctopusVersion": "2019.13.7",
+      "Type": "ActionTemplate"
+    },
+    "Category": "flyway"
+  }

--- a/step-templates/flyway-info-bash.json
+++ b/step-templates/flyway-info-bash.json
@@ -20,7 +20,7 @@
     }
   ],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Get all of the Parameter values assigned to local variables\nrelativePath=$(get_octopusvariable \"RelativePath\")\nlocations=$(get_octopusvariable \"locations\")\ntargetUrl=$(get_octopusvariable \"targetUrl\")\ntargetUser=$(get_octopusvariable \"targetUser\")\ntargetPassword=$(get_octopusvariable \"targetPassword\")\n\n# Declaring the path to the NuGet package\npackagePath=$(get_octopusvariable \"Octopus.Action.Package[FlyWayPackage].ExtractedPath\")\n\n# Delcaring path to FlyWay\nflywayPath=$packagePath\n\nif [[ ! -z \"$relativePath\" ]]\nthen\n    $flywayPath=$packagePath$relativePath\nfi\n\nflywayCmd=$flywayPath\"/flyway\"\n\nif [[ ! -z \"$locations\" ]]\nthen\n    locationsPath=$packagePath$locations\nelse\n    locationsPath=$flywayPath\"/sql\"\nfi\n\n# Logging for troubleshooting\necho \"*******************************************\"\necho \"Logging variables:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\necho \"FlywayPackageStep: $FlyWayPackageStep\"\necho \"FlywayPath: $flywayPath\"\necho \"LocationsPath: $locationsPath\"\necho \"Target DB -url: $targetUrl\"\necho \"Target DB -user: $targetUser\"\n\n# Executing deployment\necho \"*******************************************\"\necho \"Comparing scripts folder to schema:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\n    arguments=\"info -locations=filesystem:$locationsPath -url=$targetUrl -user=$targetUser -password=\"$targetPassword\"\"\necho \"Executing the following command:  $flywayCmd ${arguments//$targetPassword/********}\"\n\nbash $flywayCmd $arguments",
+    "Octopus.Action.Script.ScriptBody": "# Get all of the Parameter values assigned to local variables\nrelativePath=$(get_octopusvariable \"flywayRelativePath\")\nlocations=$(get_octopusvariable \"flywaylocations\")\ntargetUrl=$(get_octopusvariable \"flywaytargetUrl\")\ntargetUser=$(get_octopusvariable \"flywaytargetUser\")\ntargetPassword=$(get_octopusvariable \"flywaytargetPassword\")\n\n# Declaring the path to the NuGet package\npackagePath=$(get_octopusvariable \"Octopus.Action.Package[FlyWayPackage].ExtractedPath\")\n\n# Delcaring path to FlyWay\nflywayPath=$packagePath\n\nif [[ ! -z \"$relativePath\" ]]\nthen\n    $flywayPath=$packagePath$relativePath\nfi\n\nflywayCmd=$flywayPath\"/flyway\"\n\nif [[ ! -z \"$locations\" ]]\nthen\n    locationsPath=$packagePath$locations\nelse\n    locationsPath=$flywayPath\"/sql\"\nfi\n\n# Logging for troubleshooting\necho \"*******************************************\"\necho \"Logging variables:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\necho \"FlywayPackageStep: $FlyWayPackageStep\"\necho \"FlywayPath: $flywayPath\"\necho \"LocationsPath: $locationsPath\"\necho \"Target DB -url: $targetUrl\"\necho \"Target DB -user: $targetUser\"\n\n# Executing deployment\necho \"*******************************************\"\necho \"Comparing scripts folder to schema:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\n    arguments=\"info -locations=filesystem:$locationsPath -url=$targetUrl -user=$targetUser -password=\"$targetPassword\"\"\necho \"Executing the following command:  $flywayCmd ${arguments//$targetPassword/********}\"\n\nbash $flywayCmd $arguments",
     "Octopus.Action.Script.Syntax": "Bash",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.SubstituteInFiles.Enabled": "True",
@@ -30,7 +30,7 @@
   "Parameters": [
     {
       "Id": "1a88edf0-a7d5-4b49-9320-eeeff36e8d4f",
-      "Name": "RelativePath",
+      "Name": "flywayRelativePath",
       "Label": "Relative path to flyway.cmd (optional)",
       "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
       "DefaultValue": "",
@@ -40,7 +40,7 @@
     },
     {
       "Id": "fde5fadb-570b-4086-8a84-14030ca05f21",
-      "Name": "locations",
+      "Name": "flywaylocations",
       "Label": "-locations (relative path, optional)",
       "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
       "DefaultValue": "",
@@ -50,7 +50,7 @@
     },
     {
       "Id": "6dc461fe-6a00-4621-8447-9d4dca858c39",
-      "Name": "targetUrl",
+      "Name": "flywaytargetUrl",
       "Label": "Target -url (required)",
       "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
       "DefaultValue": "",
@@ -60,7 +60,7 @@
     },
     {
       "Id": "2018b280-eedc-4987-bfc9-e38d82de1a51",
-      "Name": "targetUser",
+      "Name": "flywaytargetUser",
       "Label": "Target -user (required)",
       "HelpText": "The username to connect to the target database.",
       "DefaultValue": "",
@@ -70,7 +70,7 @@
     },
     {
       "Id": "d9ce910d-7b02-4dcc-a2b3-b2e6188f5d8f",
-      "Name": "targetPassword",
+      "Name": "flywaytargetPassword",
       "Label": "Target -password (required)",
       "HelpText": "The password to connect to the target database.",
       "DefaultValue": "",

--- a/step-templates/flyway-info-bash.json
+++ b/step-templates/flyway-info-bash.json
@@ -1,158 +1,99 @@
 {
-    "Id": "a7ffdbc8-7876-4c5d-8856-5c17ee3df443",
-    "Name": "Flyway Info from a referenced package - Bash",
-    "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
-    "ActionType": "Octopus.Script",
-    "Version": 1,
-    "Author": "twerthi",
-    "Packages": [
-      {
-        "Id": "c689ba0b-3aa6-4610-bc1a-c0daf1fdcb64",
-        "Name": "FlywayPackage",
-        "PackageId": "#{FlyWayPackageId}",
-        "FeedId": "#{FlyWayFeedId}",
-        "AcquisitionLocation": "Server",
-        "Properties": {
-          "Extract": "True",
-          "SelectionMode": "immediate"
-        }
+  "Id": "a7ffdbc8-7876-4c5d-8856-5c17ee3df443",
+  "Name": "Flyway Info from a referenced package - Bash",
+  "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Author": "twerthi",
+  "Packages": [
+    {
+      "Id": "69db0748-ec8d-42a2-bf8f-84f6161ce571",
+      "Name": "FlyWayPackage",
+      "PackageId": null,
+      "FeedId": "feeds-builtin",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "FlyWayPackage"
       }
-    ],
-    "Properties": {
-      "Octopus.Action.Script.ScriptBody": "# Get all of the Parameter values assigned to local variables\nrelativePath=$(get_octopusvariable \"RelativePath\")\nlocations=$(get_octopusvariable \"locations\")\ntargetUrl=$(get_octopusvariable \"targetUrl\")\ntargetUser=$(get_octopusvariable \"targetUser\")\ntargetPassword=$(get_octopusvariable \"targetPassword\")\nflywayPackageId=$(get_octopusvariable \"FlyWayPackageId\")\nflywayFeedId=$(get_octopusvariable \"FlyWayFeedId\")\n\n# Declaring the path to the NuGet package\npackagePath=$(get_octopusvariable \"Octopus.Action.Package[FlywayPackage].ExtractedPath\")\n\n# Delcaring path to FlyWay\nflywayPath=$packagePath\n\nif [[ ! -z \"$relativePath\" ]]\nthen\n    $flywayPath=$packagePath$relativePath\nfi\n\nflywayCmd=$flywayPath\"/flyway\"\n\nif [[ ! -z \"$locations\" ]]\nthen\n    locationsPath=$packagePath$locations\nelse\n    locationsPath=$flywayPath\"/sql\"\nfi\n\n# Logging for troubleshooting\necho \"*******************************************\"\necho \"Logging variables:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\necho \"FlywayPackageStep: $FlyWayPackageStep\"\necho \"FlywayPath: $flywayPath\"\necho \"LocationsPath: $locationsPath\"\necho \"Target DB -url: $targetUrl\"\necho \"Target DB -user: $targetUser\"\n\n# Executing deployment\necho \"*******************************************\"\necho \"Comparing scripts folder to schema:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\n    arguments=\"info -locations=filesystem:$locationsPath -url=$targetUrl -user=$targetUser -password=\"$targetPassword\"\"\necho \"Executing the following command:  $flywayCmd ${arguments//$targetPassword/********}\"\n\nbash $flywayCmd $arguments",
-      "Octopus.Action.Script.Syntax": "Bash",
-      "Octopus.Action.Script.ScriptSource": "Inline",
-      "Octopus.Action.SubstituteInFiles.Enabled": "True",
-      "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
-      "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[FlywayPackage].ExtractedPath}/sql/*.sql"
-    },
-    "Parameters": [
-      {
-        "Id": "1a88edf0-a7d5-4b49-9320-eeeff36e8d4f",
-        "Name": "RelativePath",
-        "Label": "Relative path to flyway.cmd (optional)",
-        "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "fde5fadb-570b-4086-8a84-14030ca05f21",
-        "Name": "locations",
-        "Label": "-locations (relative path, optional)",
-        "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "6dc461fe-6a00-4621-8447-9d4dca858c39",
-        "Name": "targetUrl",
-        "Label": "Target -url (required)",
-        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "2018b280-eedc-4987-bfc9-e38d82de1a51",
-        "Name": "targetUser",
-        "Label": "Target -user (required)",
-        "HelpText": "The username to connect to the target database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "d9ce910d-7b02-4dcc-a2b3-b2e6188f5d8f",
-        "Name": "targetPassword",
-        "Label": "Target -password (required)",
-        "HelpText": "The password to connect to the target database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "98de9e8c-f29b-44f2-8ca8-ce2d55a58b25",
-        "Name": "runDriftCheck",
-        "Label": "Run pre-deploy drift check",
-        "HelpText": "Check for drift with Redgate comparison tool.\n\n_Requirements_\n\nRequires that a Redgate command line comparison tool is installed on the target machine.\n\nFor SQL Server: SQL Compare\n\nhttp://www.red-gate.com/products/sql-development/sql-compare/\n\nFor Oracle: Schema Compare for Oracle\n\nhttp://www.red-gate.com/products/oracle-development/schema-compare-for-oracle/\n\nFor MySQL: MySQL Compare\n\nhttps://www.red-gate.com/products/mysql/mysql-compare/\n\nAll tools include a free trial licence for a limited period of time.\n\n_Limitations_\n\nSQL Server, Oracle and MySQL only",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "6faf7e70-49d0-4f5d-a3ea-ec997ad27fa0",
-        "Name": "comparePath",
-        "Label": "Path to Redgate comparison tool (required for drift-check)",
-        "HelpText": "Checking for drift requires a database comparison tool. This template uses the Redgate tooling.\n\nPlease provide the path to a Redgate command line tool. The default paths are\n\nSQL Compare (SQL Server):\n\nC:\\Program Files (x86)\\Red Gate\\SQL Automation Pack 1\\SC\\SQLCompare.exe\n\nSchema Compare for Oracle:\n\nC:\\Program Files\\Red Gate\\Schema Compare for Oracle 3\\SCO.exe\n\nMySQL Compare:\n\nC:\\Program Files (x86)\\Red Gate\\MySQL Compare 1\\MC.exe",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "4591dcc4-7889-41a0-bd47-85a89bf4d16c",
-        "Name": "shadowUrl",
-        "Label": "Shadow -url (required for drift-check)",
-        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "540e6120-8955-45a8-96e6-f3bd36ce0bd8",
-        "Name": "shadowUser",
-        "Label": "Shadow -user (required for drift-check)",
-        "HelpText": "The username to connect to the shadow database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "9af8f3f2-d36a-43e7-aa99-065c279d5561",
-        "Name": "shadowPassword",
-        "Label": "Shadow -password (required for drift-check)",
-        "HelpText": "The password to connect to the shadow database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "7a3d1982-ecc1-492c-af92-fabc0feea7a1",
-        "Name": "FlyWayPackageId",
-        "Label": "Flyway package Id",
-        "HelpText": "The package Id that contains the Flyway project.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "1ebf7c69-bac8-4ac8-aad7-162c75cae75f",
-        "Name": "FlyWayFeedId",
-        "Label": "Feed Id",
-        "HelpText": "The Id of the feed where the Flyway Package will be retrieved from",
-        "DefaultValue": "feeds-builtin",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Get all of the Parameter values assigned to local variables\nrelativePath=$(get_octopusvariable \"RelativePath\")\nlocations=$(get_octopusvariable \"locations\")\ntargetUrl=$(get_octopusvariable \"targetUrl\")\ntargetUser=$(get_octopusvariable \"targetUser\")\ntargetPassword=$(get_octopusvariable \"targetPassword\")\n\n# Declaring the path to the NuGet package\npackagePath=$(get_octopusvariable \"Octopus.Action.Package[FlyWayPackage].ExtractedPath\")\n\n# Delcaring path to FlyWay\nflywayPath=$packagePath\n\nif [[ ! -z \"$relativePath\" ]]\nthen\n    $flywayPath=$packagePath$relativePath\nfi\n\nflywayCmd=$flywayPath\"/flyway\"\n\nif [[ ! -z \"$locations\" ]]\nthen\n    locationsPath=$packagePath$locations\nelse\n    locationsPath=$flywayPath\"/sql\"\nfi\n\n# Logging for troubleshooting\necho \"*******************************************\"\necho \"Logging variables:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\necho \"FlywayPackageStep: $FlyWayPackageStep\"\necho \"FlywayPath: $flywayPath\"\necho \"LocationsPath: $locationsPath\"\necho \"Target DB -url: $targetUrl\"\necho \"Target DB -user: $targetUser\"\n\n# Executing deployment\necho \"*******************************************\"\necho \"Comparing scripts folder to schema:\"\necho \" - - - - - - - - - - - - - - - - - - - - -\"\n    arguments=\"info -locations=filesystem:$locationsPath -url=$targetUrl -user=$targetUser -password=\"$targetPassword\"\"\necho \"Executing the following command:  $flywayCmd ${arguments//$targetPassword/********}\"\n\nbash $flywayCmd $arguments",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.SubstituteInFiles.Enabled": "True",
+    "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
+    "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[FlywayPackage].ExtractedPath}/sql/*.sql"
+  },
+  "Parameters": [
+    {
+      "Id": "1a88edf0-a7d5-4b49-9320-eeeff36e8d4f",
+      "Name": "RelativePath",
+      "Label": "Relative path to flyway.cmd (optional)",
+      "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
       }
-    ],
-    "LastModifiedBy": "twerthi",
-    "$Meta": {
-      "ExportedAt": "2020-03-11T16:56:47.731Z",
-      "OctopusVersion": "2019.13.7",
-      "Type": "ActionTemplate"
     },
-    "Category": "flyway"
-  }
+    {
+      "Id": "fde5fadb-570b-4086-8a84-14030ca05f21",
+      "Name": "locations",
+      "Label": "-locations (relative path, optional)",
+      "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6dc461fe-6a00-4621-8447-9d4dca858c39",
+      "Name": "targetUrl",
+      "Label": "Target -url (required)",
+      "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2018b280-eedc-4987-bfc9-e38d82de1a51",
+      "Name": "targetUser",
+      "Label": "Target -user (required)",
+      "HelpText": "The username to connect to the target database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d9ce910d-7b02-4dcc-a2b3-b2e6188f5d8f",
+      "Name": "targetPassword",
+      "Label": "Target -password (required)",
+      "HelpText": "The password to connect to the target database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "7a3d1982-ecc1-492c-af92-fabc0feea7a1",
+      "Name": "FlyWayPackage",
+      "Label": "Flyway package",
+      "HelpText": "The package that contains the Flyway project.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    }
+  ],
+  "LastModifiedBy": "twerthi",
+  "$Meta": {
+    "ExportedAt": "2020-03-12T05:29:08.388Z",
+    "OctopusVersion": "2019.13.7",
+    "Type": "ActionTemplate"
+  },
+  "Category": "flyway"
+}

--- a/step-templates/flyway-info.json
+++ b/step-templates/flyway-info.json
@@ -20,7 +20,7 @@
     }
   ],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[FlywayPackage].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($relativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $relativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($locations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $locations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $targetUrl\"\nWrite-Host \"Target DB -user: $targetUser\"\n\n# Drift check preperation\n$dbPlatform = \"Unknown\"\n$targetDbVersion = 0\n$targetDbPath = \"Unknown\"\n\n# Generate info\nWrite-Host \"*******************************************\"\nWrite-Host \"Comparing scripts folder to schema :\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"info\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=`\"$targetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
+    "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[FlywayPackage].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($flywayrelativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $flywayrelativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($flywaylocations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $flywaylocations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $flywaytargetUrl\"\nWrite-Host \"Target DB -user: $flywaytargetUser\"\n\n# Generate info\nWrite-Host \"*******************************************\"\nWrite-Host \"Comparing scripts folder to schema :\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"info\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$flywaytargetUrl\",\n        \"-user=$flywaytargetUser\",\n        \"-password=`\"$flywaytargetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.SubstituteInFiles.Enabled": "True",
@@ -30,7 +30,7 @@
   "Parameters": [
     {
       "Id": "e30a5acd-a2f5-4422-b91a-ac18fca278e0",
-      "Name": "RelativePath",
+      "Name": "flywayRelativePath",
       "Label": "Relative path to flyway.cmd (optional)",
       "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
       "DefaultValue": "",
@@ -40,7 +40,7 @@
     },
     {
       "Id": "0c491fea-716c-4a18-8790-275263a8e5aa",
-      "Name": "locations",
+      "Name": "flywaylocations",
       "Label": "-locations (relative path, optional)",
       "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
       "DefaultValue": "",
@@ -50,7 +50,7 @@
     },
     {
       "Id": "82b8ebc9-aaba-40ba-b839-4ba70da178d4",
-      "Name": "targetUrl",
+      "Name": "flywaytargetUrl",
       "Label": "Target -url (required)",
       "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
       "DefaultValue": "",
@@ -60,7 +60,7 @@
     },
     {
       "Id": "9cf3894a-e47e-4d5c-9602-84954ea142df",
-      "Name": "targetUser",
+      "Name": "flywaytargetUser",
       "Label": "Target -user (required)",
       "HelpText": "The username to connect to the target database.",
       "DefaultValue": "",
@@ -70,7 +70,7 @@
     },
     {
       "Id": "b7d1ef19-0a14-487a-9891-dfd486dc20aa",
-      "Name": "targetPassword",
+      "Name": "flywaytargetPassword",
       "Label": "Target -password (required)",
       "HelpText": "The password to connect to the target database.",
       "DefaultValue": "",

--- a/step-templates/flyway-info.json
+++ b/step-templates/flyway-info.json
@@ -1,0 +1,108 @@
+{
+    "Id": "797d5839-8cdd-4b05-b15b-c36df547a3cd",
+    "Name": "Flyway Info from a referenced package",
+    "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "Author": "twerthi",
+    "Packages": [
+      {
+        "Id": "c689ba0b-3aa6-4610-bc1a-c0daf1fdcb64",
+        "Name": "Flyway Package",
+        "PackageId": "#{FlyWayPackageId}",
+        "FeedId": "#{FlyWayFeedId}",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "immediate"
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway Package].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($relativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $relativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($locations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $locations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $targetUrl\"\nWrite-Host \"Target DB -user: $targetUser\"\n\n# Drift check preperation\n$dbPlatform = \"Unknown\"\n$targetDbVersion = 0\n$targetDbPath = \"Unknown\"\n\n# Generate info\nWrite-Host \"*******************************************\"\nWrite-Host \"Comparing scripts folder to schema :\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"info\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=`\"$targetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.SubstituteInFiles.Enabled": "True",
+      "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
+      "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[Flyway Package].ExtractedPath}\\sql\\*.sql"
+    },
+    "Parameters": [
+      {
+        "Id": "e30a5acd-a2f5-4422-b91a-ac18fca278e0",
+        "Name": "RelativePath",
+        "Label": "Relative path to flyway.cmd (optional)",
+        "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "0c491fea-716c-4a18-8790-275263a8e5aa",
+        "Name": "locations",
+        "Label": "-locations (relative path, optional)",
+        "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "82b8ebc9-aaba-40ba-b839-4ba70da178d4",
+        "Name": "targetUrl",
+        "Label": "Target -url (required)",
+        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "9cf3894a-e47e-4d5c-9602-84954ea142df",
+        "Name": "targetUser",
+        "Label": "Target -user (required)",
+        "HelpText": "The username to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "b7d1ef19-0a14-487a-9891-dfd486dc20aa",
+        "Name": "targetPassword",
+        "Label": "Target -password (required)",
+        "HelpText": "The password to connect to the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "1f50e74b-1843-4e95-b3fc-46ae5809ac30",
+        "Name": "FlyWayPackageId",
+        "Label": "Flyway package Id",
+        "HelpText": "The package Id that contains the Flyway project.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "8ec3b027-8bde-43b5-8bc1-0c34aa258c97",
+        "Name": "FlyWayFeedId",
+        "Label": "Feed Id",
+        "HelpText": "The Id of the feed where the Flyway Package will be retrieved from",
+        "DefaultValue": "feeds-builtin",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      }
+    ],
+    "LastModifiedBy": "twerthi",
+    "$Meta": {
+      "ExportedAt": "2020-03-11T16:18:30.880Z",
+      "OctopusVersion": "2019.13.7",
+      "Type": "ActionTemplate"
+    },
+    "Category": "flyway"
+  }

--- a/step-templates/flyway-info.json
+++ b/step-templates/flyway-info.json
@@ -1,108 +1,99 @@
 {
-    "Id": "797d5839-8cdd-4b05-b15b-c36df547a3cd",
-    "Name": "Flyway Info from a referenced package",
-    "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
-    "ActionType": "Octopus.Script",
-    "Version": 1,
-    "Author": "twerthi",
-    "Packages": [
-      {
-        "Id": "c689ba0b-3aa6-4610-bc1a-c0daf1fdcb64",
-        "Name": "Flyway Package",
-        "PackageId": "#{FlyWayPackageId}",
-        "FeedId": "#{FlyWayFeedId}",
-        "AcquisitionLocation": "Server",
-        "Properties": {
-          "Extract": "True",
-          "SelectionMode": "immediate"
-        }
+  "Id": "797d5839-8cdd-4b05-b15b-c36df547a3cd",
+  "Name": "Flyway Info from a referenced package",
+  "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Author": "twerthi",
+  "Packages": [
+    {
+      "Id": "78529e7d-498d-4490-92d7-1f0929bbd923",
+      "Name": "FlyWayPackage",
+      "PackageId": null,
+      "FeedId": "feeds-builtin",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "FlyWayPackage"
       }
-    ],
-    "Properties": {
-      "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway Package].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($relativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $relativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($locations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $locations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $targetUrl\"\nWrite-Host \"Target DB -user: $targetUser\"\n\n# Drift check preperation\n$dbPlatform = \"Unknown\"\n$targetDbVersion = 0\n$targetDbPath = \"Unknown\"\n\n# Generate info\nWrite-Host \"*******************************************\"\nWrite-Host \"Comparing scripts folder to schema :\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"info\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=`\"$targetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
-      "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptSource": "Inline",
-      "Octopus.Action.SubstituteInFiles.Enabled": "True",
-      "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
-      "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[Flyway Package].ExtractedPath}\\sql\\*.sql"
-    },
-    "Parameters": [
-      {
-        "Id": "e30a5acd-a2f5-4422-b91a-ac18fca278e0",
-        "Name": "RelativePath",
-        "Label": "Relative path to flyway.cmd (optional)",
-        "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "0c491fea-716c-4a18-8790-275263a8e5aa",
-        "Name": "locations",
-        "Label": "-locations (relative path, optional)",
-        "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "82b8ebc9-aaba-40ba-b839-4ba70da178d4",
-        "Name": "targetUrl",
-        "Label": "Target -url (required)",
-        "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "9cf3894a-e47e-4d5c-9602-84954ea142df",
-        "Name": "targetUser",
-        "Label": "Target -user (required)",
-        "HelpText": "The username to connect to the target database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "b7d1ef19-0a14-487a-9891-dfd486dc20aa",
-        "Name": "targetPassword",
-        "Label": "Target -password (required)",
-        "HelpText": "The password to connect to the target database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "1f50e74b-1843-4e95-b3fc-46ae5809ac30",
-        "Name": "FlyWayPackageId",
-        "Label": "Flyway package Id",
-        "HelpText": "The package Id that contains the Flyway project.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "8ec3b027-8bde-43b5-8bc1-0c34aa258c97",
-        "Name": "FlyWayFeedId",
-        "Label": "Feed Id",
-        "HelpText": "The Id of the feed where the Flyway Package will be retrieved from",
-        "DefaultValue": "feeds-builtin",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\n# Declaring the path to the NuGet package\n$packagePath = $OctopusParameters[\"Octopus.Action.Package[FlywayPackage].ExtractedPath\"]\n\n# Delcaring path to FlyWay\n$flywayPath = $packagePath\nif ($relativePath -ne $null){\n    $flywayPath = Join-Path -Path $packagePath -ChildPath $relativePath\n}\n\n$flywayCmd = Join-Path -Path $flywayPath -ChildPath 'flyway.cmd'\n\nif ($locations -ne $null){\n    $locationsPath = Join-Path -Path $packagePath -ChildPath $locations\n}\nelse{\n    $locationsPath = Join-Path -Path $flywayPath -ChildPath \"sql\"\n}\n\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"FlywayPackageStep: $FlyWayPackageStep\"\nWrite-Host \"FlywayPath: $flywayPath\"\nWrite-Host \"LocationsPath: $locationsPath\"\nWrite-Host \"Target DB -url: $targetUrl\"\nWrite-Host \"Target DB -user: $targetUser\"\n\n# Drift check preperation\n$dbPlatform = \"Unknown\"\n$targetDbVersion = 0\n$targetDbPath = \"Unknown\"\n\n# Generate info\nWrite-Host \"*******************************************\"\nWrite-Host \"Comparing scripts folder to schema :\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\n    $arguments = @(\n        \"info\"\n        \"-locations=filesystem:$locationsPath\",\n        \"-url=$targetUrl\",\n        \"-user=$targetUser\",\n        \"-password=`\"$targetPassword`\"\"\n    )\nWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\n& $flywayCmd $arguments",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.SubstituteInFiles.Enabled": "True",
+    "Octopus.Action.EnabledFeatures": "Octopus.Features.SubstituteInFiles",
+    "Octopus.Action.SubstituteInFiles.TargetFiles": "#{Octopus.Action.Package[FlywayPackage].ExtractedPath}\\sql\\*.sql"
+  },
+  "Parameters": [
+    {
+      "Id": "e30a5acd-a2f5-4422-b91a-ac18fca278e0",
+      "Name": "RelativePath",
+      "Label": "Relative path to flyway.cmd (optional)",
+      "HelpText": "If your FlyWay project is not in the root of your NuGet package specify the relative path here.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
       }
-    ],
-    "LastModifiedBy": "twerthi",
-    "$Meta": {
-      "ExportedAt": "2020-03-11T16:18:30.880Z",
-      "OctopusVersion": "2019.13.7",
-      "Type": "ActionTemplate"
     },
-    "Category": "flyway"
-  }
+    {
+      "Id": "0c491fea-716c-4a18-8790-275263a8e5aa",
+      "Name": "locations",
+      "Label": "-locations (relative path, optional)",
+      "HelpText": "Comma-separated list of locations to scan recursively for migrations. The location type is determined by its prefix.\nUnprefixed locations or locations starting with classpath: point to a package on the classpath and may contain both sql and java-based migrations.\nLocations starting with filesystem: point to a directory on the filesystem and may only contain sql migrations.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "82b8ebc9-aaba-40ba-b839-4ba70da178d4",
+      "Name": "targetUrl",
+      "Label": "Target -url (required)",
+      "HelpText": "The url of the target database in the format specified in the default flyway.conf file.\n\nE.g.\nSQL Server: jdbc:jtds:sqlserver://host:port/database\nOracle: jdbc:oracle:thin:@//host:port/service\nMySQL: jdbc:mysql://host:port/database",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "9cf3894a-e47e-4d5c-9602-84954ea142df",
+      "Name": "targetUser",
+      "Label": "Target -user (required)",
+      "HelpText": "The username to connect to the target database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b7d1ef19-0a14-487a-9891-dfd486dc20aa",
+      "Name": "targetPassword",
+      "Label": "Target -password (required)",
+      "HelpText": "The password to connect to the target database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "1f50e74b-1843-4e95-b3fc-46ae5809ac30",
+      "Name": "FlyWayPackage",
+      "Label": "Flyway package",
+      "HelpText": "The package that contains the Flyway project.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    }
+  ],
+  "LastModifiedBy": "twerthi",
+  "$Meta": {
+    "ExportedAt": "2020-03-12T04:58:11.448Z",
+    "OctopusVersion": "2019.13.7",
+    "Type": "ActionTemplate"
+  },
+  "Category": "flyway"
+}


### PR DESCRIPTION

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it


