### PR TITLE
Force TLS 1.2 for http test url step template

### DIFF
--- a/step-templates/http-test-url.json
+++ b/step-templates/http-test-url.json
@@ -3,9 +3,10 @@
   "Name": "HTTP - Test URL",
   "Description": "Makes a GET request to a HTTP(S) end point and verifies that a particular status code and response (optional) is returned within a specified period of time",
   "ActionType": "Octopus.Script",
-  "Version": 15,
+  "Version": 16,
+  "Packages": [],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "$uri = $OctopusParameters['Uri']\n$customHostHeader = $OctopusParameters['CustomHostHeader']\n$expectedCode = [int] $OctopusParameters['ExpectedCode']\n$timeoutSeconds = [int] $OctopusParameters['TimeoutSeconds']\n$Username = $OctopusParameters['AuthUsername']\n$Password = $OctopusParameters['AuthPassword']\n$UseWindowsAuth = [System.Convert]::ToBoolean($OctopusParameters['UseWindowsAuth'])\n$ExpectedResponse = $OctopusParameters['ExpectedResponse']\n$securityProtocol = $OctopusParameters['SecurityProtocol']\n\nWrite-Host \"Starting verification request to $uri\"\nif ($customHostHeader)\n{\n    Write-Host \"Using custom host header $customHostHeader\"\n}\n\nWrite-Host \"Expecting response code $expectedCode.\"\nWrite-Host \"Expecting response: $ExpectedResponse.\"\n\nif ($securityProtocol)\n{\n    Write-Host \"Using security protocol $securityProtocol\"\n    [Net.ServicePointManager]::SecurityProtocol = [Enum]::parse([Net.SecurityProtocolType], $securityProtocol) \n}\n\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\n$success = $false\ndo\n{\n    try\n    {\n        if ($Username -and $Password -and $UseWindowsAuth)\n        {\n            Write-Host \"Making request to $uri using windows authentication for user $Username\"\n            $request = [system.Net.WebRequest]::Create($uri)\n            $Credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Username, $(ConvertTo-SecureString -String $Password -AsPlainText -Force)\n            $request.Credentials = $Credential \n            \n            if ($customHostHeader)\n            {\n                $request.Host = $customHostHeader\n            }\n\n            try\n            {\n                $response = $request.GetResponse()\n            }\n            catch [System.Net.WebException]\n            {\n                Write-Host \"Request failed :-( System.Net.WebException\"\n                Write-Host $_.Exception\n                $response = $_.Exception.Response\n            }\n            \n        }\n\t\telseif ($Username -and $Password)\n        {\n            Write-Host \"Making request to $uri using basic authentication for user $Username\"\n            $Credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Username, $(ConvertTo-SecureString -String $Password -AsPlainText -Force)\n            if ($customHostHeader)\n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Credential $Credential -Headers @{\"Host\" = $customHostHeader} -TimeoutSec $timeoutSeconds\n            }\n            else \n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Credential $Credential -TimeoutSec $timeoutSeconds\n            }\n        }\n\t\telse\n        {\n            Write-Host \"Making request to $uri using anonymous authentication\"\n            if ($customHostHeader)\n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Headers @{\"Host\" = $customHostHeader} -TimeoutSec $timeoutSeconds\n            }\n            else \n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -TimeoutSec $timeoutSeconds\n            }\n        }\n        \n        $code = $response.StatusCode\n        $body = $response.Content;\n        Write-Host \"Recieved response code: $code\"\n        Write-Host \"Recieved response: $body\"\n\n        if($response.StatusCode -eq $expectedCode)\n        {\n            $success = $true\n        }\n        if ($success -and $ExpectedResponse)\n        {\n            $success = ($ExpectedResponse -eq $body)\n        }\n    }\n    catch\n    {\n        # Anything other than a 200 will throw an exception so\n        # we check the exception message which may contain the \n        # actual status code to verify\n        \n        Write-Host \"Request failed :-(\"\n        Write-Host $_.Exception\n\n        if($_.Exception -like \"*($expectedCode)*\")\n        {\n            $success = $true\n        }\n    }\n\n    if(!$success)\n    {\n        Write-Host \"Trying again in 5 seconds...\"\n        Start-Sleep -s 5\n    }\n}\nwhile(!$success -and $timer.Elapsed -le (New-TimeSpan -Seconds $timeoutSeconds))\n\n$timer.Stop()\n\n# Verify result\n\nif(!$success)\n{\n    throw \"Verification failed - giving up.\"\n}\n\nWrite-Host \"Sucesss! Found status code $expectedCode\"",
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n\n$uri = $OctopusParameters['Uri']\n$customHostHeader = $OctopusParameters['CustomHostHeader']\n$expectedCode = [int] $OctopusParameters['ExpectedCode']\n$timeoutSeconds = [int] $OctopusParameters['TimeoutSeconds']\n$Username = $OctopusParameters['AuthUsername']\n$Password = $OctopusParameters['AuthPassword']\n$UseWindowsAuth = [System.Convert]::ToBoolean($OctopusParameters['UseWindowsAuth'])\n$ExpectedResponse = $OctopusParameters['ExpectedResponse']\n$securityProtocol = $OctopusParameters['SecurityProtocol']\n\nWrite-Host \"Starting verification request to $uri\"\nif ($customHostHeader)\n{\n    Write-Host \"Using custom host header $customHostHeader\"\n}\n\nWrite-Host \"Expecting response code $expectedCode.\"\nWrite-Host \"Expecting response: $ExpectedResponse.\"\n\nif ($securityProtocol)\n{\n    Write-Host \"Using security protocol $securityProtocol\"\n    [Net.ServicePointManager]::SecurityProtocol = [Enum]::parse([Net.SecurityProtocolType], $securityProtocol) \n}\n\n$timer = [System.Diagnostics.Stopwatch]::StartNew()\n$success = $false\ndo\n{\n    try\n    {\n        if ($Username -and $Password -and $UseWindowsAuth)\n        {\n            Write-Host \"Making request to $uri using windows authentication for user $Username\"\n            $request = [system.Net.WebRequest]::Create($uri)\n            $Credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Username, $(ConvertTo-SecureString -String $Password -AsPlainText -Force)\n            $request.Credentials = $Credential \n            \n            if ($customHostHeader)\n            {\n                $request.Host = $customHostHeader\n            }\n\n            try\n            {\n                $response = $request.GetResponse()\n            }\n            catch [System.Net.WebException]\n            {\n                Write-Host \"Request failed :-( System.Net.WebException\"\n                Write-Host $_.Exception\n                $response = $_.Exception.Response\n            }\n            \n        }\n\t\telseif ($Username -and $Password)\n        {\n            Write-Host \"Making request to $uri using basic authentication for user $Username\"\n            $Credential = New-Object System.Management.Automation.PSCredential -ArgumentList $Username, $(ConvertTo-SecureString -String $Password -AsPlainText -Force)\n            if ($customHostHeader)\n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Credential $Credential -Headers @{\"Host\" = $customHostHeader} -TimeoutSec $timeoutSeconds\n            }\n            else \n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Credential $Credential -TimeoutSec $timeoutSeconds\n            }\n        }\n\t\telse\n        {\n            Write-Host \"Making request to $uri using anonymous authentication\"\n            if ($customHostHeader)\n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -Headers @{\"Host\" = $customHostHeader} -TimeoutSec $timeoutSeconds\n            }\n            else \n            {\n                $response = Invoke-WebRequest -Uri $uri -Method Get -UseBasicParsing -TimeoutSec $timeoutSeconds\n            }\n        }\n        \n        $code = $response.StatusCode\n        $body = $response.Content;\n        Write-Host \"Recieved response code: $code\"\n        Write-Host \"Recieved response: $body\"\n\n        if($response.StatusCode -eq $expectedCode)\n        {\n            $success = $true\n        }\n        if ($success -and $ExpectedResponse)\n        {\n            $success = ($ExpectedResponse -eq $body)\n        }\n    }\n    catch\n    {\n        # Anything other than a 200 will throw an exception so\n        # we check the exception message which may contain the \n        # actual status code to verify\n        \n        Write-Host \"Request failed :-(\"\n        Write-Host $_.Exception\n\n        if($_.Exception -like \"*($expectedCode)*\")\n        {\n            $success = $true\n        }\n    }\n\n    if(!$success)\n    {\n        Write-Host \"Trying again in 5 seconds...\"\n        Start-Sleep -s 5\n    }\n}\nwhile(!$success -and $timer.Elapsed -le (New-TimeSpan -Seconds $timeoutSeconds))\n\n$timer.Stop()\n\n# Verify result\n\nif(!$success)\n{\n    throw \"Verification failed - giving up.\"\n}\n\nWrite-Host \"Sucesss! Found status code $expectedCode\"",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline"
   },
@@ -15,7 +16,7 @@
       "Name": "Uri",
       "Label": "URI",
       "HelpText": "The full Uri of the endpoint",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {}
     },
     {
@@ -23,7 +24,7 @@
       "Name": "CustomHostHeader",
       "Label": "Custom HOST header",
       "HelpText": "An optional custom HOST header which will be passed with the request",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
@@ -33,7 +34,7 @@
       "Name": "SecurityProtocol",
       "Label": "Security Protocol",
       "HelpText": "The optional security protocol version to use for HTTPS requests.",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
         "Octopus.SelectOptions": "SystemDefault\nSsl3\nTls\nTls11\nTls12"
@@ -60,7 +61,7 @@
       "Name": "AuthUsername",
       "Label": "Username",
       "HelpText": "Username for authentication. Leave blank to use Anonymous.",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
@@ -70,7 +71,7 @@
       "Name": "AuthPassword",
       "Label": "Password",
       "HelpText": "Password for authentication. Leave blank for Anonymous.",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
       }
@@ -90,16 +91,16 @@
       "Name": "ExpectedResponse",
       "Label": "Expected Response",
       "HelpText": "The response should be this text",
-      "DefaultValue": null,
+      "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     }
   ],
-  "LastModifiedBy": "Pietrowicz",
+  "LastModifiedBy": "harrisonmeister",
   "$Meta": {
-    "ExportedAt": "2018-04-19T04:22:23.191Z",
-    "OctopusVersion": "2018.3.13",
+    "ExportedAt": "2020-04-06T15:38:12.574Z",
+    "OctopusVersion": "2020.1.6",
     "Type": "ActionTemplate"
   },
   "Category": "http"


### PR DESCRIPTION
### Step template guidelines

* Is the template a minor variation on an existing one? If so, please consider improving the existing template if possible.
* Is the name of the template consistent with the examples already in the library, in style ("Noun - Verb"), layout and casing?
* Are all parameters in the template consistent with the examples here, including help text documented with Markdown?
* Is the description of the template complete, correct Markdown?
* Is the `.json` filename consistent with the name of the template?
* Do scripts in the template validate required arguments and fail by returning a non-zero exit code when things go wrong?
* Do scripts in the template produce worthwhile status messages as they execute?
* Are you happy to contribute your template under the terms of the [license](https://github.com/OctopusDeploy/Library/blob/master/LICENSE)? If you produced the template while working for your employer please obtain written permission from them before submitting it here.
* Are the default values of parameters validly applicable in other user's environments? Don't use the default values as examples if the user will have to change them
* For how to deal with parameters and testing take a look at the article [Making great Octopus PowerShell step templates](https://www.daniellittle.xyz/making-great-octopus-powershell-step-templates/)
* For another example of how to test your step template script body before submitting a PR take a look at this [gist](https://gist.github.com/JCapriotti/45639e06ba777ee974b1)

_Before submitting your PR, please delete everything above the line below._

---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
