### PR TITLE
Updated Import Certificate to work with cloud instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scriptcs_packages.config
 step-templates/*.ps1
 step-templates/*.sh
 /.vs
+/.vscode

--- a/step-templates/octopus-import-certificate.json
+++ b/step-templates/octopus-import-certificate.json
@@ -3,22 +3,32 @@
   "Name": "Octopus - Import Certificate",
   "Description": "Create or replace an [Octopus Certificate](https://octopus.com/docs/deploying-applications/certificates) from a certificate file",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "<#\n ----- Octopus - Import Certificate ----- \n    Paul Marston @paulmarsy (paul@marston.me)\nLinks\n    https://github.com/OctopusDeploy/Library/commits/master/step-templates/octopus-import-certificate.json\n#>    \n    \n$ErrorActionPreference = 'Stop'\n\n$StepTemplate_BaseUrl = $OctopusParameters['Octopus.Web.BaseUrl'].Trim('/')\nif ([string]::IsNullOrWhiteSpace($StepTemplate_ApiKey)) {\n    throw \"The step parameter 'API Key' was not found. This step requires an API Key to function, please provide one and try again.\"\n}\nfilter Out-Verbose {\n    Write-Verbose ($_ | Out-String)\n}\nfilter Out-Indented {\n    $_ | Out-String | % Trim | % Split \"`n\" | % { \"`t$_\" }  \n}\nfunction Invoke-OctopusApi {\n    param(\n        [Parameter(Position = 0, Mandatory)]$Uri,\n        [ValidateSet(\"Get\", \"Post\")]$Method = 'Get',\n        $Body\n    )\n    $requestParameters = @{\n        Uri = ('{0}/{1}' -f $StepTemplate_BaseUrl, $Uri.TrimStart('/'))\n        Method = $Method\n        Headers = @{ \"X-Octopus-ApiKey\" = $StepTemplate_ApiKey }\n        UseBasicParsing = $true\n    }\n    Write-Verbose \"$($Method.ToUpperInvariant()) $($requestParameters.Uri)\"   \n    if ($null -ne $Body) { $requestParameters.Add('Body', ($Body | ConvertTo-Json -Depth 10)) }\n    try {\n        Invoke-WebRequest @requestParameters | % Content | ConvertFrom-Json | Write-Output\n    }\n    catch [System.Net.WebException] {\n        if ($_.Exception.Response) {\n            $errorResponse = [System.IO.StreamReader]::new($_.Exception.Response.GetResponseStream()).ReadToEnd()\n            throw (\"$($_.Exception.Message)`n{0}\" -f $errorResponse)\n        }\n    }\n}\n\nfunction Test-SpacesApi {\n\tWrite-Verbose \"Checking API compatibility\";\n\t$rootDocument = Invoke-OctopusApi 'api/';\n    if($rootDocument.Links -ne $null -and $rootDocument.Links.Spaces -ne $null) {\n    \tWrite-Verbose \"Spaces API found\"\n    \treturn $true;\n    }\n    Write-Verbose \"Pre-spaces API found\"\n    return $false;\n}\n\nif(Test-SpacesApi) {\n\t$spaceId = $OctopusParameters['Octopus.Space.Id'];\n    if([string]::IsNullOrWhiteSpace($spaceId)) {\n        throw \"This step needs to be run in a context that provides a value for the 'Octopus.Space.Id' system variable. In this case, we received a blank value, which isn't expected - please reach out to our support team at https://help.octopus.com if you encounter this error.\";\n    }\n\t$baseApiUrl = \"/api/$spaceId\" ;\n} else {\n\t$baseApiUrl = \"/api\" ;\n}\n\n$certificate = switch ($StepTemplate_CertEncoding) {\n    'file' {   \n        if (!(Test-Path $StepTemplate_Certificate)) {\n            throw \"Certificate file $StepTemplate_Certificate does not exist\"\n        }\n        $certificateBytes = Get-Content -Path $StepTemplate_Certificate -Encoding Byte\n        [System.Convert]::ToBase64String($certificateBytes)\n    }\n    'base64' {\n        $StepTemplate_Certificate\n    }\n}\n\n$existingCert = Invoke-OctopusApi \"$baseApiUrl/certificates\" | % Items | ? Name -eq $StepTemplate_CertificateName\nif ($existingCert) {\n    Write-Host 'Existing certificate will be archived & replaced...'\n    Invoke-OctopusApi (\"$baseApiUrl/certificates/{0}/replace\" -f $existingCert.Id) -Method Post -Body @{\n        certificateData = $certificate\n        password = $StepTemplate_Password\n    } | % {\n        $_.CertificateData = $null\n        $_.Password = $null\n        $_\n    } | Out-Verbose\n} else {\n    Write-Host 'Creating & importing new certificate...'\n    Invoke-OctopusApi \"$baseApiUrl/certificates\" -Method Post -Body @{\n        Name = $StepTemplate_CertificateName\n        CertificateData = @{\n            HasValue = $true\n            NewValue = $certificate\n        }\n        Password = @{\n            HasValue = $true\n            NewValue = $StepTemplate_Password\n        }\n    } | Out-Verbose\n}\nWrite-Host 'Certificate has been imported:'\nInvoke-OctopusApi \"$baseApiUrl/certificates\" | % Items | ? Name -eq $StepTemplate_CertificateName | Out-Indented",
+    "Octopus.Action.Script.ScriptBody": "<#\n ----- Octopus - Import Certificate ----- \n    Paul Marston @paulmarsy (paul@marston.me)\nLinks\n    https://github.com/OctopusDeploy/Library/commits/master/step-templates/octopus-import-certificate.json\n#>\n\n$securityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12\n[Net.ServicePointManager]::SecurityProtocol = $securityProtocol\n\n$ErrorActionPreference = 'Stop'\n\n$StepTemplate_BaseUrl = $StepTemplate_OctopusUrl.Trim('/')\n\nif ([string]::IsNullOrWhiteSpace($StepTemplate_ApiKey)) {\n    throw \"The step parameter 'API Key' was not found. This step requires an API Key to function, please provide one and try again.\"\n}\nfilter Out-Verbose {\n    Write-Verbose ($_ | Out-String)\n}\nfilter Out-Indented {\n    $_ | Out-String | % Trim | % Split \"`n\" | % { \"`t$_\" }  \n}\nfunction Invoke-OctopusApi {\n    param(\n        [Parameter(Position = 0, Mandatory)]$Uri,\n        [ValidateSet(\"Get\", \"Post\")]$Method = 'Get',\n        $Body\n    )\n    $requestParameters = @{\n        Uri = ('{0}/{1}' -f $StepTemplate_BaseUrl, $Uri.TrimStart('/'))\n        Method = $Method\n        Headers = @{ \"X-Octopus-ApiKey\" = $StepTemplate_ApiKey }\n        UseBasicParsing = $true\n    }\n    Write-Verbose \"$($Method.ToUpperInvariant()) $($requestParameters.Uri)\"   \n    if ($null -ne $Body) { $requestParameters.Add('Body', ($Body | ConvertTo-Json -Depth 10)) }\n    try {\n        Invoke-WebRequest @requestParameters | % Content | ConvertFrom-Json | Write-Output\n    }\n    catch [System.Net.WebException] {\n        if ($_.Exception.Response) {\n            $errorResponse = [System.IO.StreamReader]::new($_.Exception.Response.GetResponseStream()).ReadToEnd()\n            throw (\"$($_.Exception.Message)`n{0}\" -f $errorResponse)\n        }\n        \n        if ($_.Exception.Message) {\n        \t$message = $_.Exception.Message\n        \tWrite-Highlight $message\n            throw \"$message\"\n        }\n    }\n}\n\nfunction Test-SpacesApi {\n\tWrite-Verbose \"Checking API compatibility\";\n\t$rootDocument = Invoke-OctopusApi 'api/';\n    if($rootDocument.Links -ne $null -and $rootDocument.Links.Spaces -ne $null) {\n    \tWrite-Verbose \"Spaces API found\"\n    \treturn $true;\n    }\n    Write-Verbose \"Pre-spaces API found\"\n    return $false;\n}\n\nif(Test-SpacesApi) {\n\t$spaceId = $OctopusParameters['Octopus.Space.Id'];\n    if([string]::IsNullOrWhiteSpace($spaceId)) {\n        throw \"This step needs to be run in a context that provides a value for the 'Octopus.Space.Id' system variable. In this case, we received a blank value, which isn't expected - please reach out to our support team at https://help.octopus.com if you encounter this error.\";\n    }\n\t$baseApiUrl = \"/api/$spaceId\" ;\n} else {\n\t$baseApiUrl = \"/api\" ;\n}\n\n$certificate = switch ($StepTemplate_CertEncoding) {\n    'file' {   \n        if (!(Test-Path $StepTemplate_Certificate)) {\n            throw \"Certificate file $StepTemplate_Certificate does not exist\"\n        }\n        $certificateBytes = Get-Content -Path $StepTemplate_Certificate -Encoding Byte\n        [System.Convert]::ToBase64String($certificateBytes)\n    }\n    'base64' {\n        $StepTemplate_Certificate\n    }\n}\n\n$existingCert = Invoke-OctopusApi \"$baseApiUrl/certificates\" | % Items | ? Name -eq $StepTemplate_CertificateName\nif ($existingCert) {\n    Write-Host 'Existing certificate will be archived & replaced...'\n    Invoke-OctopusApi (\"$baseApiUrl/certificates/{0}/replace\" -f $existingCert.Id) -Method Post -Body @{\n        certificateData = $certificate\n        password = $StepTemplate_Password\n    } | % {\n        $_.CertificateData = $null\n        $_.Password = $null\n        $_\n    } | Out-Verbose\n} else {\n    Write-Host 'Creating & importing new certificate...'\n    Invoke-OctopusApi \"$baseApiUrl/certificates\" -Method Post -Body @{\n        Name = $StepTemplate_CertificateName\n        CertificateData = @{\n            HasValue = $true\n            NewValue = $certificate\n        }\n        Password = @{\n            HasValue = $true\n            NewValue = $StepTemplate_Password\n        }\n    } | Out-Verbose\n}\nWrite-Host 'Certificate has been imported:'\nInvoke-OctopusApi \"$baseApiUrl/certificates\" | % Items | ? Name -eq $StepTemplate_CertificateName | Out-Indented",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null
   },
   "Parameters": [
     {
+      "Id": "6a723531-1272-4c7f-ae04-9576051396ad",
+      "Name": "StepTemplate_OctopusUrl",
+      "Label": "Octopus Url",
+      "HelpText": "Provide the URL of your Octopus Server. The default is `Octopus.Web.BaseUrl`. Cloud instances should use `Octopus.Web.ServerUri`. See [System Variables - Server](https://octopus.com/docs/projects/variables/system-variables#Systemvariables-Server) for more info.",
+      "DefaultValue": "#{Octopus.Web.BaseUrl}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
       "Id": "9a84f62c-99f7-4349-bf6d-f42397f4de73",
       "Name": "StepTemplate_ApiKey",
       "Label": "API Key",
-      "HelpText": "Provide an Octopus API Key with appropriate permissions to save the certificate",
+      "HelpText": "Provide an Octopus API Key with appropriate permissions to save the certificate.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
@@ -71,11 +81,12 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy": "paulmarsy",
+  "LastModifiedBy": "ryanrousseau",
   "$Meta": {
-    "ExportedAt": "2017-05-31T00:37:02.264Z",
-    "OctopusVersion": "3.13.7",
+    "ExportedAt": "2020-04-06T22:12:36.689Z",
+    "OctopusVersion": "2020.1.8",
     "Type": "ActionTemplate"
   },
-  "Category": "octopus"
+  "Category": "octopus",
+  "Author": "paulmarsy"
 }


### PR DESCRIPTION
# Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author

Added a parameter to provide the Octopus Server URL. It is defaulted to Octopus.Web.BaseUrl to match current functionality. Cloud instances need to use Octopus.Web.ServerUri.

Also added the TLS logic needed by cloud instances to make requests to the API.
