### PR TITLE
Bug: Exported default value breaks sync.

### DIFF
--- a/step-templates/letsencrypt-route-53.json
+++ b/step-templates/letsencrypt-route-53.json
@@ -83,7 +83,7 @@
             }
         }
     ],
-    "LastModifiedAt": "2020-04-06T09:57:29.498Z",
+    "LastModifiedAt": "2020-04-07T03:51:58.819Z",
     "LastModifiedBy": "jeremycade",
     "$Meta": {
         "ExportedAt": "2020-04-03T13:26:06.262Z",

--- a/step-templates/letsencrypt-route-53.json
+++ b/step-templates/letsencrypt-route-53.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - Route53",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt](https://letsencrypt.org) Certificate Authority making use of [AWS Route53](https://aws.amazon.com/route53/) for the domain validation. Supports Wild Cards and the latest ACMEv2 standards. Verified to work on both Windows and Linux (PowerShell Core).",
     "ActionType": "Octopus.Script",
-    "Version": 2,
+    "Version": 3,
     "Packages": [],
     "Properties": {
         "Octopus.Action.Script.ScriptSource": "Inline",

--- a/step-templates/letsencrypt-route-53.json
+++ b/step-templates/letsencrypt-route-53.json
@@ -27,10 +27,7 @@
             "Name": "LE_Route53_PfxPassword",
             "Label": "PFX Password",
             "HelpText": "Password to use when converting to / from PFX. ",
-            "DefaultValue": {
-                "HasValue": true,
-                "NewValue": null
-            },
+            "DefaultValue": "",
             "DisplaySettings": {
                 "Octopus.ControlType": "Sensitive"
             }


### PR DESCRIPTION
The follow line in Route53 step template parameters breaks E2E Tests in 2020.1 release stream. 

```
"DefaultValue": {
    "HasValue": true,	
    "NewValue": null	
}
```