### PR TITLE
Adding templates for Windows Updates

### DIFF
--- a/step-templates/apply-windows-updates-with-no-restart-check.json
+++ b/step-templates/apply-windows-updates-with-no-restart-check.json
@@ -1,7 +1,7 @@
 {
     "Id": "5f24981d-1452-4b51-9887-431cf747a6df",
-    "Name": "Apply Windows Updates",
-    "Description": "Apply Windows Updates",
+    "Name": "Apply Windows Updates with no restart checks",
+    "Description": "Apply Windows Updates with no restart checks",
     "ActionType": "Octopus.Script",
     "Version": 1,
     "CommunityActionTemplateId": null,

--- a/step-templates/apply-windows-updates-with-no-restart-check.json
+++ b/step-templates/apply-windows-updates-with-no-restart-check.json
@@ -1,17 +1,18 @@
 {
     "Id": "5f24981d-1452-4b51-9887-431cf747a6df",
-    "Name": "Apply Windows Updates with Restart check",
-    "Description": null,
+    "Name": "Apply Windows Updates",
+    "Description": "Apply Windows Updates",
     "ActionType": "Octopus.Script",
-    "Version": 0,
+    "Version": 1,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
       "Octopus.Action.Script.ScriptSource": "Inline",
       "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\nInstall-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force\nInstall-Module PSWindowsUpdate –Force\nGet-WindowsUpdate \nInstall-WindowsUpdate -AcceptAll -AutoReboot"
+      "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\nInstall-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force\nInstall-Module PSWindowsUpdate –Force\nGet-WindowsUpdate \nInstall-WindowsUpdate -AcceptAll"
     },
     "Parameters": [],
+    "LastModifiedAt": "2020-15-14T02:53:50.268Z",
     "LastModifiedBy": "devopsderek",
     "$Meta": {
       "ExportedAt": "2020-04-15T14:14:48.270Z",

--- a/step-templates/apply-windows-updates-with-no-restart-check.json
+++ b/step-templates/apply-windows-updates-with-no-restart-check.json
@@ -1,0 +1,22 @@
+{
+    "Id": "5f24981d-1452-4b51-9887-431cf747a6df",
+    "Name": "Apply Windows Updates with Restart check",
+    "Description": null,
+    "ActionType": "Octopus.Script",
+    "Version": 0,
+    "CommunityActionTemplateId": null,
+    "Packages": [],
+    "Properties": {
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\nInstall-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force\nInstall-Module PSWindowsUpdate –Force\nGet-WindowsUpdate \nInstall-WindowsUpdate -AcceptAll -AutoReboot"
+    },
+    "Parameters": [],
+    "LastModifiedBy": "devopsderek",
+    "$Meta": {
+      "ExportedAt": "2020-04-15T14:14:48.270Z",
+      "OctopusVersion": "2020.1.10",
+      "Type": "ActionTemplate"
+    },
+    "Category": "windows"
+}

--- a/step-templates/apply-windows-updates-with-restart-check.json
+++ b/step-templates/apply-windows-updates-with-restart-check.json
@@ -1,0 +1,22 @@
+{
+    "Id": "8096216f-7a4f-480a-b131-c1ffb4bb9704",
+    "Name": "Apply Windows Updates with Restart check",
+    "Description": null,
+    "ActionType": "Octopus.Script",
+    "Version": 0,
+    "CommunityActionTemplateId": null,
+    "Packages": [],
+    "Properties": {
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\nInstall-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force\nInstall-Module PSWindowsUpdate –Force\nGet-WindowsUpdate \nInstall-WindowsUpdate -AcceptAll -AutoReboot"
+    },
+    "Parameters": [],
+    "LastModifiedBy": "devopsderek",
+    "$Meta": {
+      "ExportedAt": "2020-04-15T14:14:48.270Z",
+      "OctopusVersion": "2020.1.10",
+      "Type": "ActionTemplate"
+    },
+    "Category": "windows"
+}

--- a/step-templates/apply-windows-updates-with-restart-check.json
+++ b/step-templates/apply-windows-updates-with-restart-check.json
@@ -1,9 +1,9 @@
 {
     "Id": "8096216f-7a4f-480a-b131-c1ffb4bb9704",
-    "Name": "Apply Windows Updates with Restart check",
-    "Description": null,
+    "Name": "Apply Windows Updates and restart if required",
+    "Description": "Apply Windows Updates and restart if required",
     "ActionType": "Octopus.Script",
-    "Version": 0,
+    "Version": 1,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
@@ -12,6 +12,7 @@
       "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\nInstall-PackageProvider -Name NuGet -RequiredVersion 2.8.5.201 -Force\nInstall-Module PSWindowsUpdate –Force\nGet-WindowsUpdate \nInstall-WindowsUpdate -AcceptAll -AutoReboot"
     },
     "Parameters": [],
+    "LastModifiedAt": "2020-15-14T02:53:50.268Z",
     "LastModifiedBy": "devopsderek",
     "$Meta": {
       "ExportedAt": "2020-04-15T14:14:48.270Z",
@@ -19,4 +20,4 @@
       "Type": "ActionTemplate"
     },
     "Category": "windows"
-}
+  }


### PR DESCRIPTION
### Step template checklist

- [*] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [*] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [*] Parameter names should not start with `$`
- [*] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [*] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [*] If a new `Category` has been created:
   - [*] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [*] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

