### PR TITLE
Sitecore web deploy package (.scwdp) deployment

### DIFF
--- a/step-templates/sitecore-deploy-scwdp.json
+++ b/step-templates/sitecore-deploy-scwdp.json
@@ -1,14 +1,15 @@
 {
-  "Id": "07ee1c67-2426-4733-9447-57afbe834532",
+  "Id": "9a757194-4c7e-4e9e-a58f-7b0c12b8253a",
   "Name": "Sitecore web deploy package(.scwdp) deployment",
   "Description": "Step template to deploy Sitecore WDP(Web Deploy Package) package. \n\n**Useful links:**\n[Sitecore documentation.](https://doc.sitecore.com/developers/sat/24/sitecore-azure-toolkit/en/web-deploy-packages-for-a-module.html)\nHow to create [Sitecore Web Deploy Package](https://hls-consulting.com/2019/05/15/how-to-create-a-wdp-from-a-sitecore-package/)  by Hugo Santos. \nHow to install [Sitecore Web Deploy Package](https://hls-consulting.com/2019/06/03/how-to-install-a-wdp-in-a-sitecore-9-1-on-premises-instance/) by Hugo Santos.\n\n",
   "ActionType": "Octopus.Script",
-  "Version": 8,
+  "Version": 1,
   "CommunityActionTemplateId": null,
+  "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"Application Path\"]\n  $coreConnection = $OctopusParameters[\"Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"Web Admin Connection String\"]\n  \n  $package = $OctopusParameters[\"Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
+    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"Application Path\"]\n  $coreConnection = $OctopusParameters[\"Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
   },
   "Parameters": [
     {
@@ -17,8 +18,7 @@
       "Label": "Application Path",
       "HelpText": "Path, where package should be deployed",
       "DefaultValue": "",
-      "DisplaySettings": {},
-      "Links": {}
+      "DisplaySettings": {}
     },
     {
       "Id": "02031f37-6b13-4c58-95c0-b160f02193c7",
@@ -26,8 +26,7 @@
       "Label": "Web Admin Connection String",
       "HelpText": "Connection string to web database",
       "DefaultValue": "",
-      "DisplaySettings": {},
-      "Links": {}
+      "DisplaySettings": {}
     },
     {
       "Id": "95f75e2e-4679-403a-b1c8-dea0e529614a",
@@ -35,8 +34,7 @@
       "Label": "Master Admin Connection String",
       "HelpText": "Connection string to master database",
       "DefaultValue": "",
-      "DisplaySettings": {},
-      "Links": {}
+      "DisplaySettings": {}
     },
     {
       "Id": "bc921038-1de9-4d6d-9492-b27f291b25c5",
@@ -44,8 +42,7 @@
       "Label": "Core Admin Connection String",
       "HelpText": "Connection string to core database",
       "DefaultValue": "",
-      "DisplaySettings": {},
-      "Links": {}
+      "DisplaySettings": {}
     },
     {
       "Id": "0754e1e3-ee10-41fc-b198-3cc1d945ea13",
@@ -53,16 +50,14 @@
       "Label": "Package",
       "HelpText": "Path to .scwdp.zip package or name of package attached to release",
       "DefaultValue": "",
-      "DisplaySettings": {},
-      "Links": {}
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2020-05-30T14:43:05.531+00:00",
-  "LastModifiedBy": "Antonytm",
   "$Meta": {
-    "ExportedAt": "2020-05-31T19:31:52.421Z",
-    "OctopusVersion": "4.1.1",
+    "ExportedAt": "2020-06-09T22:42:41.727Z",
+    "OctopusVersion": "2020.2.11",
     "Type": "ActionTemplate"
   },
+  "LastModifiedBy": "antonytm",
   "Category": "sitecore"
 }

--- a/step-templates/sitecore-deploy-scwdp.json
+++ b/step-templates/sitecore-deploy-scwdp.json
@@ -3,13 +3,13 @@
   "Name": "Sitecore web deploy package(.scwdp) deployment",
   "Description": "Step template to deploy Sitecore WDP(Web Deploy Package) package. \n\n**Useful links:**\n[Sitecore documentation.](https://doc.sitecore.com/developers/sat/24/sitecore-azure-toolkit/en/web-deploy-packages-for-a-module.html)\nHow to create [Sitecore Web Deploy Package](https://hls-consulting.com/2019/05/15/how-to-create-a-wdp-from-a-sitecore-package/)  by Hugo Santos. \nHow to install [Sitecore Web Deploy Package](https://hls-consulting.com/2019/06/03/how-to-install-a-wdp-in-a-sitecore-9-1-on-premises-instance/) by Hugo Santos.\n\n",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"SCWDP Application Path\"]\n  $coreConnection = $OctopusParameters[\"SCWDP Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"SCWDP Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"SCWDP Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"SCWDP Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Output $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Error \"An error occurred:\"\n  Write-Error $_\n}"
+    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"SCWDP Application Path\"]\n  $coreConnection = $OctopusParameters[\"SCWDP Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"SCWDP Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"SCWDP Web Admin Connection String\"] \n  $msDeploy = $OctopusParameters[\"SCWDP MsDeploy Path\"] \n  \n  $package = $OctopusParameters[\"SCWDP Package\"]\n\n  $cmd = \"`\"\"+$msDeploy+\"`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Output $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Error \"An error occurred:\"\n  Write-Error $_\n}"
   },
   "Parameters": [
     {
@@ -51,11 +51,19 @@
       "HelpText": "Path to .scwdp.zip package or name of package attached to release",
       "DefaultValue": "",
       "DisplaySettings": {}
+    },
+    {
+      "Id": "c91f4571-1e61-4f0f-82e4-2dcea7024506",
+      "Name": "SCWDP MsDeploy Path",
+      "Label": "Path to MSDeploy Executable",
+      "HelpText": "It should be \"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe\" with default server setup",
+      "DefaultValue": "",
+      "DisplaySettings": {}
     }
   ],
   "$Meta": {
-    "ExportedAt": "2020-06-09T22:42:41.727Z",
-    "OctopusVersion": "2020.2.11",
+    "ExportedAt": "2020-06-19T05:40:59.376Z",
+    "OctopusVersion": "2020.2.13",
     "Type": "ActionTemplate"
   },
   "LastModifiedBy": "antonytm",

--- a/step-templates/sitecore-deploy-scwdp.json
+++ b/step-templates/sitecore-deploy-scwdp.json
@@ -1,0 +1,68 @@
+{
+  "Id": "07ee1c67-2426-4733-9447-57afbe834532",
+  "Name": "Sitecore web deploy package(.scwdp) deployment",
+  "Description": "Step template to deploy Sitecore WDP(Web Deploy Package) package. \n\n**Useful links:**\n[Sitecore documentation.](https://doc.sitecore.com/developers/sat/24/sitecore-azure-toolkit/en/web-deploy-packages-for-a-module.html)\nHow to create [Sitecore Web Deploy Package](https://hls-consulting.com/2019/05/15/how-to-create-a-wdp-from-a-sitecore-package/)  by Hugo Santos. \nHow to install [Sitecore Web Deploy Package](https://hls-consulting.com/2019/06/03/how-to-install-a-wdp-in-a-sitecore-9-1-on-premises-instance/) by Hugo Santos.\n\n",
+  "ActionType": "Octopus.Script",
+  "Version": 8,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"Application Path\"]\n  $coreConnection = $OctopusParameters[\"Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"Web Admin Connection String\"]\n  \n  $package = $OctopusParameters[\"Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
+  },
+  "Parameters": [
+    {
+      "Id": "8a064359-6d40-472d-8839-383eb886e1e4",
+      "Name": "Application Path",
+      "Label": "Application Path",
+      "HelpText": "Path, where package should be deployed",
+      "DefaultValue": "",
+      "DisplaySettings": {},
+      "Links": {}
+    },
+    {
+      "Id": "02031f37-6b13-4c58-95c0-b160f02193c7",
+      "Name": "Web Admin Connection String",
+      "Label": "Web Admin Connection String",
+      "HelpText": "Connection string to web database",
+      "DefaultValue": "",
+      "DisplaySettings": {},
+      "Links": {}
+    },
+    {
+      "Id": "95f75e2e-4679-403a-b1c8-dea0e529614a",
+      "Name": "Master Admin Connection String",
+      "Label": "Master Admin Connection String",
+      "HelpText": "Connection string to master database",
+      "DefaultValue": "",
+      "DisplaySettings": {},
+      "Links": {}
+    },
+    {
+      "Id": "bc921038-1de9-4d6d-9492-b27f291b25c5",
+      "Name": "Core Admin Connection String",
+      "Label": "Core Admin Connection String",
+      "HelpText": "Connection string to core database",
+      "DefaultValue": "",
+      "DisplaySettings": {},
+      "Links": {}
+    },
+    {
+      "Id": "0754e1e3-ee10-41fc-b198-3cc1d945ea13",
+      "Name": "Package",
+      "Label": "Package",
+      "HelpText": "Path to .scwdp.zip package or name of package attached to release",
+      "DefaultValue": "",
+      "DisplaySettings": {},
+      "Links": {}
+    }
+  ],
+  "LastModifiedOn": "2020-05-30T14:43:05.531+00:00",
+  "LastModifiedBy": "Antonytm",
+  "$Meta": {
+    "ExportedAt": "2020-05-31T19:31:52.421Z",
+    "OctopusVersion": "4.1.1",
+    "Type": "ActionTemplate"
+  },
+  "Category": "sitecore"
+}

--- a/step-templates/sitecore-deploy-scwdp.json
+++ b/step-templates/sitecore-deploy-scwdp.json
@@ -3,18 +3,18 @@
   "Name": "Sitecore web deploy package(.scwdp) deployment",
   "Description": "Step template to deploy Sitecore WDP(Web Deploy Package) package. \n\n**Useful links:**\n[Sitecore documentation.](https://doc.sitecore.com/developers/sat/24/sitecore-azure-toolkit/en/web-deploy-packages-for-a-module.html)\nHow to create [Sitecore Web Deploy Package](https://hls-consulting.com/2019/05/15/how-to-create-a-wdp-from-a-sitecore-package/)  by Hugo Santos. \nHow to install [Sitecore Web Deploy Package](https://hls-consulting.com/2019/06/03/how-to-install-a-wdp-in-a-sitecore-9-1-on-premises-instance/) by Hugo Santos.\n\n",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"Application Path\"]\n  $coreConnection = $OctopusParameters[\"Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
+    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"SCWDP Application Path\"]\n  $coreConnection = $OctopusParameters[\"SCWDP Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"SCWDP Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"SCWDP Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"SCWDP Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
   },
   "Parameters": [
     {
       "Id": "8a064359-6d40-472d-8839-383eb886e1e4",
-      "Name": "Application Path",
+      "Name": "SCWDP Application Path",
       "Label": "Application Path",
       "HelpText": "Path, where package should be deployed",
       "DefaultValue": "",
@@ -22,7 +22,7 @@
     },
     {
       "Id": "02031f37-6b13-4c58-95c0-b160f02193c7",
-      "Name": "Web Admin Connection String",
+      "Name": "SCWDP Web Admin Connection String",
       "Label": "Web Admin Connection String",
       "HelpText": "Connection string to web database",
       "DefaultValue": "",
@@ -30,7 +30,7 @@
     },
     {
       "Id": "95f75e2e-4679-403a-b1c8-dea0e529614a",
-      "Name": "Master Admin Connection String",
+      "Name": "SCWDP Master Admin Connection String",
       "Label": "Master Admin Connection String",
       "HelpText": "Connection string to master database",
       "DefaultValue": "",
@@ -38,7 +38,7 @@
     },
     {
       "Id": "bc921038-1de9-4d6d-9492-b27f291b25c5",
-      "Name": "Core Admin Connection String",
+      "Name": "SCWDP Core Admin Connection String",
       "Label": "Core Admin Connection String",
       "HelpText": "Connection string to core database",
       "DefaultValue": "",
@@ -46,7 +46,7 @@
     },
     {
       "Id": "0754e1e3-ee10-41fc-b198-3cc1d945ea13",
-      "Name": "Package",
+      "Name": "SCWDP Package",
       "Label": "Package",
       "HelpText": "Path to .scwdp.zip package or name of package attached to release",
       "DefaultValue": "",

--- a/step-templates/sitecore-deploy-scwdp.json
+++ b/step-templates/sitecore-deploy-scwdp.json
@@ -3,13 +3,13 @@
   "Name": "Sitecore web deploy package(.scwdp) deployment",
   "Description": "Step template to deploy Sitecore WDP(Web Deploy Package) package. \n\n**Useful links:**\n[Sitecore documentation.](https://doc.sitecore.com/developers/sat/24/sitecore-azure-toolkit/en/web-deploy-packages-for-a-module.html)\nHow to create [Sitecore Web Deploy Package](https://hls-consulting.com/2019/05/15/how-to-create-a-wdp-from-a-sitecore-package/)  by Hugo Santos. \nHow to install [Sitecore Web Deploy Package](https://hls-consulting.com/2019/06/03/how-to-install-a-wdp-in-a-sitecore-9-1-on-premises-instance/) by Hugo Santos.\n\n",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"SCWDP Application Path\"]\n  $coreConnection = $OctopusParameters[\"SCWDP Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"SCWDP Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"SCWDP Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"SCWDP Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Host $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Host \"An error occurred:\"\n  Write-Host $_\n}"
+    "Octopus.Action.Script.ScriptBody": "try { \n  $applicationPath = $OctopusParameters[\"SCWDP Application Path\"]\n  $coreConnection = $OctopusParameters[\"SCWDP Core Admin Connection String\"]\n  $masterConnection = $OctopusParameters[\"SCWDP Master Admin Connection String\"]\n  $webConnection = $OctopusParameters[\"SCWDP Web Admin Connection String\"] \n  \n  $package = $OctopusParameters[\"SCWDP Package\"]\n\n  $cmd = \"`\"C:\\Program Files (x86)\\IIS\\Microsoft Web Deploy V3\\msdeploy.exe`\" -verb:sync -source:package=`\"\"+$package+\"`\" -dest:auto -enableRule:DoNotDeleteRule -setParam:`\"Application Path`\"=`\"\"+$applicationPath+\"`\" -setParam:`\"Core Admin Connection String`\"=`\"\"+$coreConnection+\"`\" -setParam:`\"Master Admin Connection String`\"=`\"\"+$masterConnection+\"`\" -setParam:`\"Web Admin Connection String`\"=`\"\"+$webConnection+\"`\" -verbose\"\n\n  Write-Output $cmd\n  cmd.exe /c $cmd\n}\ncatch {\n  Write-Error \"An error occurred:\"\n  Write-Error $_\n}"
   },
   "Parameters": [
     {


### PR DESCRIPTION
### Step template guidelines

* Is the template a minor variation on an existing one? If so, please consider improving the existing template if possible.
* Is the name of the template consistent with the examples already in the library, in style ("Noun - Verb"), layout and casing?
* Are all parameters in the template consistent with the examples here, including help text documented with Markdown?
* Is the description of the template complete, correct Markdown?
* Is the `.json` filename consistent with the name of the template?
* Do scripts in the template validate required arguments and fail by returning a non-zero exit code when things go wrong?
* Do scripts in the template produce worthwhile status messages as they execute?
* Are you happy to contribute your template under the terms of the [license](https://github.com/OctopusDeploy/Library/blob/master/LICENSE)? If you produced the template while working for your employer please obtain written permission from them before submitting it here.
* Are the default values of parameters validly applicable in other user's environments? Don't use the default values as examples if the user will have to change them
* For how to deal with parameters and testing take a look at the article [Making great Octopus PowerShell step templates](https://www.daniellittle.xyz/making-great-octopus-powershell-step-templates/)
* For another example of how to test your step template script body before submitting a PR take a look at this [gist](https://gist.github.com/JCapriotti/45639e06ba777ee974b1)

_Before submitting your PR, please delete everything above the line below._

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
