### PR TITLE
Add File System - rsync template

### DIFF
--- a/step-templates/file-system-rsync.json
+++ b/step-templates/file-system-rsync.json
@@ -9,7 +9,7 @@
     "Properties": {
         "Octopus.Action.Script.ScriptSource": "Inline",
         "Octopus.Action.Script.Syntax": "Bash",
-        "Octopus.Action.Script.ScriptBody": "rsyncPath=$(get_octopusvariable \"Rsync.Path\")\nrsyncOptions=$(get_octopusvariable \"Rsync.Options\")\nrsyncSource=$(get_octopusvariable \"Rsync.Source\")\nrsyncDestination=$(get_octopusvariable \"Rsync.Destination\")\nprintCommand=$(get_octopusvariable \"FirebaseDeploy.PrintCommand\")\n\nif [ ! -z \"$rsyncPath\" ] ; then\n   \tPATH=$rsyncPath:$PATH\nfi\n\nif [ \"$printCommand\" = \"True\" ] ; then\n    set -x\nfi\n\nrsync ${rsyncOptions:+ $rsyncOptions} ${rsyncSource:+ $rsyncSource} ${rsyncDestination:+ $rsyncDestination}"
+        "Octopus.Action.Script.ScriptBody": "rsyncPath=$(get_octopusvariable \"Rsync.Path\")\nrsyncOptions=$(get_octopusvariable \"Rsync.Options\")\nrsyncSource=$(get_octopusvariable \"Rsync.Source\")\nrsyncDestination=$(get_octopusvariable \"Rsync.Destination\")\nprintCommand=$(get_octopusvariable \"Rsync.PrintCommand\")\n\nif [ ! -z \"$rsyncPath\" ] ; then\n   \tPATH=$rsyncPath:$PATH\nfi\n\nif [ \"$printCommand\" = \"True\" ] ; then\n    set -x\nfi\n\nrsync ${rsyncOptions:+ $rsyncOptions} ${rsyncSource:+ $rsyncSource} ${rsyncDestination:+ $rsyncDestination}"
     },
     "Parameters": [
         {

--- a/step-templates/file-system-rsync.json
+++ b/step-templates/file-system-rsync.json
@@ -1,0 +1,73 @@
+{
+    "Id": "d8dfa484-59ed-491f-a22a-3098d4c2a6be",
+    "Name": "File System - rsync (bash)",
+    "Description": "Run [rsync](http://manpages.org/rsync) on a target or worker.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [],
+    "Properties": {
+        "Octopus.Action.Script.ScriptSource": "Inline",
+        "Octopus.Action.Script.Syntax": "Bash",
+        "Octopus.Action.Script.ScriptBody": "rsyncPath=$(get_octopusvariable \"Rsync.Path\")\nrsyncOptions=$(get_octopusvariable \"Rsync.Options\")\nrsyncSource=$(get_octopusvariable \"Rsync.Source\")\nrsyncDestination=$(get_octopusvariable \"Rsync.Destination\")\nprintCommand=$(get_octopusvariable \"FirebaseDeploy.PrintCommand\")\n\nif [ ! -z \"$rsyncPath\" ] ; then\n   \tPATH=$rsyncPath:$PATH\nfi\n\nif [ \"$printCommand\" = \"True\" ] ; then\n    set -x\nfi\n\nrsync ${rsyncOptions:+ $rsyncOptions} ${rsyncSource:+ $rsyncSource} ${rsyncDestination:+ $rsyncDestination}"
+    },
+    "Parameters": [
+        {
+            "Id": "da47b530-69dd-482c-9b97-f9c0b1dcca5c",
+            "Name": "Rsync.Path",
+            "Label": "Executable Path",
+            "HelpText": "Optional path to `rsync` if it is not in the environment's path variable.",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "7d315721-f2b2-4f0b-8eb1-3b946f711a59",
+            "Name": "Rsync.Options",
+            "Label": "Options",
+            "HelpText": "[Options](http://manpages.org/rsync#options) to provide to `rsync`.",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "a908f5a3-8284-42b9-992d-528993c5b55f",
+            "Name": "Rsync.Source",
+            "Label": "Source",
+            "HelpText": "The location of the source files to copy.",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "366ad01c-1ef9-408e-bbed-58d0a7a3e4db",
+            "Name": "Rsync.Destination",
+            "Label": "Destination",
+            "HelpText": "The destination to copy the source files to.",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "d969ceca-d823-4967-afbe-80672cd55051",
+            "Name": "Rsync.PrintCommand",
+            "Label": "Print Command?",
+            "HelpText": "Prints the command in the logs using `set -x`. This will cause a warning when the step runs.",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Checkbox"
+            }
+        }
+    ],
+    "$Meta": {
+        "ExportedAt": "2020-06-15T21:11:29.969Z",
+        "OctopusVersion": "2020.2.11",
+        "Type": "ActionTemplate"
+    },
+    "LastModifiedBy": "ryanrousseau",
+    "Category": "filesystem"
+}


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
