### PR TITLE
Adding new template to maintain backwards compatibility with existing

### DIFF
--- a/step-templates/ssis-deploy-ispac-from-package-parameter.json
+++ b/step-templates/ssis-deploy-ispac-from-package-parameter.json
@@ -1,206 +1,206 @@
 {
-    "Id": "4beed3f8-3ba4-463d-9731-8d2ed82543ae",
-    "Name": "Deploy ispac SSIS project from a Package Parameter",
-    "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
-    "ActionType": "Octopus.Script",
-    "Version": 1,
-    "Author": "twerthi",
-    "Packages": [
-      {
-        "Id": "96816ead-d26f-423b-8c24-2fb312aa3e23",
-        "Name": "ssisPackageId",
-        "PackageId": null,
-        "FeedId": "feeds-builtin",
-        "AcquisitionLocation": "Server",
-        "Properties": {
-          "Extract": "True",
-          "SelectionMode": "deferred",
-          "PackageParameterName": "ssisPackageId"
-        }
+  "Id": "27567d46-b935-4ee6-8b2d-8c165edada4e",
+  "Name": "Deploy ispac SSIS project from Referenced Package Copy",
+  "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "Author": "twerthi",
+  "Packages": [
+    {
+      "Id": "5ce9da08-a4ed-4b69-92d1-ab88c705cf08",
+      "Name": "SSIS.Template.ssisPackageId",
+      "PackageId": null,
+      "FeedId": "feeds-builtin",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "SSIS.Template.ssisPackageId"
       }
-    ],
-    "Properties": {
-      "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "#region Functions\n\n# Define functions\nfunction Get-SqlModuleInstalled\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName\n    )\n\n    # Check to see if the module is installed\n    if ($null -ne (Get-Module -ListAvailable -Name $PowerShellModuleName))\n    {\n        # It is installed\n        return $true\n    }\n    else\n    {\n        # Module not installed\n        return $false\n    }\n}\n\nfunction Get-NugetPackageProviderNotInstalled\n{\n\t# See if the nuget package provider has been installed\n    return ($null -eq (Get-PackageProvider -ListAvailable -Name Nuget -ErrorAction SilentlyContinue))\n}\n\nfunction Install-SqlServerPowerShellModule\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName,\n        $LocalModulesPath\n    )\n\n\t# Check to see if the package provider has been installed\n    if ((Get-NugetPackageProviderNotInstalled) -ne $false)\n    {\n    \t# Display that we need the nuget package provider\n        Write-Host \"Nuget package provider not found, installing ...\"\n        \n        # Install Nuget package provider\n        Install-PackageProvider -Name Nuget -Force\n    }\n\n\t# Save the module in the temporary location\n    Save-Module -Name $PowerShellModuleName -Path $LocalModulesPath -Force\n\n\t# Display\n    Write-Output \"Importing module $PowerShellModuleName ...\"\n\n    # Import the module\n    Import-Module -Name $PowerShellModuleName\n}\n\nFunction Load-SqlServerAssmblies\n{\n\t# Declare parameters\n    \n\t# Get the folder where the SqlServer module ended up in\n\t$sqlServerModulePath = [System.IO.Path]::GetDirectoryName((Get-Module SqlServer).Path)\n    \n    # Loop through the assemblies\n    foreach($assemblyFile in (Get-ChildItem -Path $sqlServerModulePath -Exclude msv*.dll | Where-Object {$_.Extension -eq \".dll\"}))\n    {\n        # Load the assembly\n        [Reflection.Assembly]::LoadFile($assemblyFile.FullName) | Out-Null\n    }    \n}\n\n#region Get-Catalog\nFunction Get-Catalog\n{\n     # define parameters\n    Param ($CatalogName)\n    # NOTE: using $integrationServices variable defined in main\n    \n    # define working varaibles\n    $Catalog = $null\n    # check to see if there are any catalogs\n    if($integrationServices.Catalogs.Count -gt 0 -and $integrationServices.Catalogs[$CatalogName])\n    {\n    \t# get reference to catalog\n    \t$Catalog = $integrationServices.Catalogs[$CatalogName]\n    }\n    else\n    {\n    \tif((Get-CLREnabled) -eq 0)\n    \t{\n    \t\tif(-not $EnableCLR)\n    \t\t{\n    \t\t\t# throw error\n    \t\t\tthrow \"SQL CLR is not enabled.\"\n    \t\t}\n    \t\telse\n    \t\t{\n    \t\t\t# display sql clr isn't enabled\n    \t\t\tWrite-Warning \"SQL CLR is not enabled on $($sqlConnection.DataSource).  This feature must be enabled for SSIS catalogs.\"\n    \n    \t\t\t# enablign SQLCLR\n    \t\t\tWrite-Host \"Enabling SQL CLR ...\"\n    \t\t\tEnable-SQLCLR\n    \t\t\tWrite-Host \"SQL CLR enabled\"\n    \t\t}\n    \t}\n    \n    \t# Provision a new SSIS Catalog\n    \tWrite-Host \"Creating SSIS Catalog ...\"\n    \n    \t$Catalog = New-Object \"$ISNamespace.Catalog\" ($integrationServices, $CatalogName, $CatalogPwd)\n    \t$Catalog.Create()\n    \n    \n    }\n    \n    # return the catalog\n    return $Catalog\n}\n#endregion\n\n#region Get-CLREnabled\nFunction Get-CLREnabled\n{\n    # define parameters\n    # Not using any parameters, but am using $sqlConnection defined in main\n    \n    # define working variables\n    $Query = \"SELECT * FROM sys.configurations WHERE name = 'clr enabled'\"\n    \n    # execute script\n    $CLREnabled = Invoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query | Select value\n    \n    # return value\n    return $CLREnabled.Value\n}\n#endregion\n\n#region Enable-SQLCLR\nFunction Enable-SQLCLR\n{\n    $QueryArray = \"sp_configure 'show advanced options', 1\", \"RECONFIGURE\", \"sp_configure 'clr enabled', 1\", \"RECONFIGURE \"\n    # execute script\n    \n    foreach($Query in $QueryArray)\n    {\n    \tInvoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query\n    }\n    \n    # check that it's enabled\n    if((Get-CLREnabled) -ne 1)\n    {\n    \t# throw error\n    \tthrow \"Failed to enable SQL CLR\"\n    }\n}\n#endregion\n\n#region Get-Folder\nFunction Get-Folder\n{\n # parameters\n    Param($FolderName, $Catalog)\n    \n    $Folder = $null\n    # try to get reference to folder\n    \n    if(!($Catalog.Folders -eq $null))\n    {\n    \t$Folder = $Catalog.Folders[$FolderName]\n    }\n    \n    # check to see if $Folder has a value\n    if($Folder -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Folder $FolderName doesn't exist, creating folder...\"\n    \n    \t# create the folder\n    \t$Folder = New-Object \"$ISNamespace.CatalogFolder\" ($Catalog, $FolderName, $FolderName) \n    \t$Folder.Create() \n    }\n    \n    # return the folde reference\n    return $Folder\n}\n#endregion\n\n#region Get-Environment\nFunction Get-Environment\n{\n     # define parameters\n    Param($Folder, $EnvironmentName)\n    \n    $Environment = $null\n    # get reference to Environment\n    if(!($Folder.Environments -eq $null) -and $Folder.Environments.Count -gt 0)\n    {\n    \t$Environment = $Folder.Environments[$EnvironmentName]\n    }\n    \n    # check to see if it's a null reference\n    if($Environment -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Environment $EnvironmentName doesn't exist, creating environment...\"\n    \n    \t# create environment\n    \t$Environment = New-Object \"$ISNamespace.EnvironmentInfo\" ($Folder, $EnvironmentName, $EnvironmentName)\n    \t$Environment.Create() \n    }\n    \n    # return the environment\n    return $Environment\n}\n#endregion\n\n#region Set-EnvironmentReference\nFunction Set-EnvironmentReference\n{\n     # define parameters\n    Param($Project, $Environment, $Folder)\n    \n    # get reference\n    $Reference = $null\n    \n    if(!($Project.References -eq $null))\n    {\n    \t$Reference = $Project.References[$Environment.Name, $Folder.Name]\n    \n    }\n    \n    # check to see if it's a null reference\n    if($Reference -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Project does not reference environment $($Environment.Name), creating reference...\"\n    \n    \t# create reference\n    \t$Project.References.Add($Environment.Name, $Folder.Name)\n    \t$Project.Alter() \n    }\n}\n#endregion\n\n#region Set-ProjectParametersToEnvironmentVariablesReference\nFunction Set-ProjectParametersToEnvironmentVariablesReference\n{\n     # define parameters\n    Param($Project, $Environment)\n    \n    $UpsertedVariables = @()\n\n    if($Project.Parameters -eq $null)\n    {\n        Write-Host \"No project parameters exist\"\n        return\n    }\n\n    # loop through project parameters\n    foreach($Parameter in $Project.Parameters)\n    {\n        # skip if the parameter is included in custom filters\n        if ($UseCustomFilter) \n        {\n            if ($Parameter.Name -match $CustomFilter)\n            {\n                Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                continue\n            }\n        }\n\n        # Add variable to list of variable\n        $UpsertedVariables += $Parameter.Name\n\n        $Variable = $null\n        if(!($Environment.Variables -eq $null))\n        {\n    \t    # get reference to variable\n    \t    $Variable = $Environment.Variables[$Parameter.Name]\n        }\n    \n    \t# check to see if variable exists\n    \tif($Variable -eq $null)\n    \t{\n    \t\t# add the environment variable\n    \t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $Parameter.Name\n    \n    \t\t# get reference to the newly created variable\n    \t\t$Variable = $Environment.Variables[$Parameter.Name]\n    \t}\n    \n    \t# set the environment variable value\n    \tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $Parameter.Name\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n    $Project.Alter()\n\n    return $UpsertedVariables\n}\n#endregion\n\nFunction Set-PackageVariablesToEnvironmentVariablesReference\n{\n    # define parameters\n    Param($Project, $Environment)\n\n    $Variables = @()\n    $UpsertedVariables = @()\n\n    # loop through packages in project in order to store a temp collection of variables\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n    \t\t# add to the temporary variable collection\n    \t\t$Variables += $Parameter.Name\n    \t}\n    }\n\n    # loop through packages in project\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n            if ($UseFullyQualifiedVariableNames)\n            {\n                # Set fully qualified variable name\n                $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n            }\n            else\n            {\n                # check if exists a variable with the same name\n                $VariableNameOccurrences = $($Variables | Where-Object { $_ -eq $Parameter.Name }).count\n                $ParameterName = $Parameter.Name\n                \n                if ($VariableNameOccurrences -gt 1)\n                {\n                    $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n                }\n            }\n            \n            if ($UseCustomFilter)\n            {\n                if ($ParameterName -match $CustomFilter)\n                {\n                    Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                    continue\n                }\n            }\n\n            # get reference to variable\n    \t\t$Variable = $Environment.Variables[$ParameterName]\n\n            # Add variable to list of variable\n            $UpsertedVariables += $ParameterName\n\n            # check to see if the parameter exists\n    \t\tif(!$Variable)\n    \t\t{\n    \t\t\t# add the environment variable\n    \t\t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $ParameterName\n    \n    \t\t\t# get reference to the newly created variable\n    \t\t\t$Variable = $Environment.Variables[$ParameterName]\n    \t\t}\n    \n    \t\t# set the environment variable value\n    \t\tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $ParameterName\n    \t}\n    \n    \t# alter the package\n    \t$Package.Alter()\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n\n    return $UpsertedVariables\n}\n\nFunction Sync-EnvironmentVariables\n{\n    # define parameters\n    Param($Environment, $VariablesToPreserveInEnvironment)\n\n    foreach($VariableToEvaluate in $Environment.Variables)\n    {\n        if ($VariablesToPreserveInEnvironment -notcontains $VariableToEvaluate.Name)\n        {\n            Write-Host \"- Removing environment variable: $($VariableToEvaluate.Name)\"\n            $VariableToRemove = $Environment.Variables[$VariableToEvaluate.Name]\n            $Environment.Variables.Remove($VariableToRemove) | Out-Null\n        }\n    }\n\n    # alter the environment\n    $Environment.Alter()\n}\n\n#region Add-EnvironmentVariable\nFunction Add-EnvironmentVariable\n{\n    # define parameters\n    Param($Environment, $Parameter, $ParameterName)\n    \n    # display \n    Write-Host \"- Adding environment variable $($ParameterName)\"\n    \n    # check to see if design default value is emtpy or null\n    if([string]::IsNullOrEmpty($Parameter.DesignDefaultValue))\n    {\n    \t# give it something\n    \t$DefaultValue = \"\" # sensitive variables will not return anything so when trying to use the property of $Parameter.DesignDefaultValue, the Alter method will fail.\n    }\n    else\n    {\n    \t# take the design\n    \t$DefaultValue = $Parameter.DesignDefaultValue\n    }\n    \n    # add variable with an initial value\n    $Environment.Variables.Add($ParameterName, $Parameter.DataType, $DefaultValue, $Parameter.Sensitive, $Parameter.Description)\n}\n#endregion\n\n#region Set-EnvironmentVariableValue\nFunction Set-EnvironmentVariableValue\n{\n     # define parameters\n    Param($Variable, $Parameter, $ParameterName)\n\n    # check to make sure variable value is available\n    if($OctopusParameters -and $OctopusParameters.ContainsKey($ParameterName))\n    {\n        # display \n        Write-Host \"- Updating environment variable $($ParameterName)\"\n\n    \t# set the variable value\n    \t$Variable.Value = $OctopusParameters[\"$($ParameterName)\"]\n    }\n    else\n    {\n    \t# warning\n    \tWrite-Host \"**- OctopusParameters collection is empty or $($ParameterName) not in the collection -**\"\n    }\n    \n    # Set reference\n    $Parameter.Set([Microsoft.SqlServer.Management.IntegrationServices.ParameterInfo+ParameterValueType]::Referenced, \"$($ParameterName)\")\n}\n#endregion\n\n# Define PowerShell Modules path\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\n\n# Check to see if SqlServer module is installed\nif ((Get-SqlModuleInstalled -PowerShellModuleName \"SqlServer\") -ne $true)\n{\n\t# Display message\n    Write-Output \"PowerShell module SqlServer not present, downloading temporary copy ...\"\n\n\t#Enable TLS 1.2 as default protocol\n\t[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12\n\n    # Download and install temporary copy\n    Install-SqlServerPowerShellModule -PowerShellModuleName \"SqlServer\" -LocalModulesPath $LocalModules\n    \n\t#region Dependent assemblies\n\tLoad-SqlServerAssmblies    \n}\nelse\n{\n\t# Load the IntegrationServices Assembly\n\t[Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.Management.IntegrationServices\") | Out-Null # Out-Null supresses a message that would normally be displayed saying it loaded out of GAC\n}\n\n#endregion\n\n# Store the IntegrationServices Assembly namespace to avoid typing it every time\n$ISNamespace = \"Microsoft.SqlServer.Management.IntegrationServices\"\n\n#endregion\n\n#region Main\ntry\n{   \n    # ensure all boolean variables are true booleans\n    $EnableCLR = [System.Convert]::ToBoolean(\"$EnableCLR\")\n    $UseEnvironment = [System.Convert]::ToBoolean(\"$UseEnvironment\")\n    $ReferenceProjectParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$ReferenceProjectParametersToEnvironmentVairables\")\n    \n    $ReferencePackageParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$ReferencePackageParametersToEnvironmentVairables\")\n    $UseFullyQualifiedVariableNames = [System.Convert]::ToBoolean(\"$UseFullyQualifiedVariableNames\")\n    $SyncEnvironment = [System.Convert]::ToBoolean(\"$SyncEnvironment\")\n    # custom names for filtering out the excluded variables by design\n    $UseCustomFilter = [System.Convert]::ToBoolean(\"$UseCustomFilter\")\n    $CustomFilter = [System.Convert]::ToString(\"$CustomFilter\")\n    # list of variables names to keep in target environment\n    $VariablesToPreserveInEnvironment = @()\n        \n\t# Get the extracted path\n\t$DeployedPath = $OctopusParameters[\"Octopus.Action.Package[$ssisPackageId].ExtractedPath\"]\n    \n\t# Get all .ispac files from the deployed path\n\t$IsPacFiles = Get-ChildItem -Recurse -Path $DeployedPath | Where {$_.Extension.ToLower() -eq \".ispac\"}\n\n\t# display number of files\n\tWrite-Host \"$($IsPacFiles.Count) .ispac file(s) found.\"\n\n\tWrite-Host \"Connecting to server ...\"\n\n\t# Create a connection to the server\n    $sqlConnectionString = \"Data Source=$ServerName;Initial Catalog=SSISDB;\"\n    \n    if (![string]::IsNullOrEmpty($sqlAccountUsername) -and ![string]::IsNullOrEmpty($sqlAccountPassword))\n    {\n    \t# Add username and password to connection string\n        $sqlConnectionString += \"User ID=$sqlAccountUsername; Password=$sqlAccountPassword;\"\n    }\n    else\n    {\n    \t# Use integrated\n        $sqlConnectionString += \"Integrated Security=SSPI;\"\n    }\n    \n    \n    # Create new connection object with connection string\n    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString\n\n\t# create integration services object\n\t$integrationServices = New-Object \"$ISNamespace.IntegrationServices\" $sqlConnection\n\n\t# get reference to the catalog\n\tWrite-Host \"Getting reference to catalog $CataLogName\"\n\t$Catalog = Get-Catalog -CatalogName $CataLogName\n\n\t# get folder reference\n\t$Folder = Get-Folder -FolderName $FolderName -Catalog $Catalog\n\n\t# loop through ispac files\n\tforeach($IsPacFile in $IsPacFiles)\n\t{\n\t\t# read project file\n\t\t$ProjectFile = [System.IO.File]::ReadAllBytes($IsPacFile.FullName)\n\n\t\t# deploy project\n\t\tWrite-Host \"Deploying project $($IsPacFile.Name)...\"\n\t\t$Folder.DeployProject($ProjectName, $ProjectFile) | Out-Null\n\n\t\t# get reference to deployed project\n\t\t$Project = $Folder.Projects[$ProjectName]\n\n\t\t# check to see if they want to use environments\n\t\tif($UseEnvironment)\n\t\t{\n\t\t\t# get environment reference\n\t\t\t$Environment = Get-Environment -Folder $Folder -EnvironmentName $EnvironmentName\n\n\t\t\t# set environment reference\n\t\t\tSet-EnvironmentReference -Project $Project -Environment $Environment -Folder $Folder\n\n\t\t\t# check to see if the user wants to convert project parameters to environment variables\n\t\t\tif($ReferenceProjectParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set environment variables\n\t\t\t\tWrite-Host \"Referencing Project Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-ProjectParametersToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n\n\t\t\t# check to see if the user wants to convert the package parameters to environment variables\n\t\t\tif($ReferencePackageParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set package variables\n\t\t\t\tWrite-Host \"Referencing Package Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-PackageVariablesToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n            \n            # Removes all unused variables from the environment\n            if ($SyncEnvironment)\n            {\n                Write-Host \"Sync package environment variables...\"\n                Sync-EnvironmentVariables -Environment $Environment -VariablesToPreserveInEnvironment $VariablesToPreserveInEnvironment\n            }\n\t\t}\n\t}\n}\n\nfinally\n{\n\t# check to make sure sqlconnection isn't null\n\tif($sqlConnection)\n\t{\n\t\t# check state of sqlconnection\n\t\tif($sqlConnection.State -eq [System.Data.ConnectionState]::Open)\n\t\t{\n\t\t\t# close the connection\n\t\t\t$sqlConnection.Close()\n\t\t}\n\n\t\t# cleanup\n\t\t$sqlConnection.Dispose()\n\t}\n}\n#endregion\n",
-      "Octopus.Action.Script.ScriptSource": "Inline"
-    },
-    "Parameters": [
-      {
-        "Id": "53aa9e3e-1292-4e75-8095-3666ebd5886b",
-        "Name": "ServerName",
-        "Label": "Database server name (\\instance)",
-        "HelpText": "Name of the SQL Server you are deploying to.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "c0605196-f184-44f6-9b3d-c043323e017c",
-        "Name": "sqlAccountUsername",
-        "Label": "SQL Authentication Username",
-        "HelpText": "(Optional) Username of the SQL Authentication account.  Use this approach when deploying to Azure Databases with SSIS configured.  If SQL Authentication Username and Password are blank, Integrated Authentication is used.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "224b913f-657c-4d1c-a3d8-0f286203c1ec",
-        "Name": "sqlAccountPassword",
-        "Label": "SQL Authentication Password",
-        "HelpText": "(Optional) Password of the SQL Authentication account.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "0abbb06c-5f98-44d8-b20d-b811b6bf18da",
-        "Name": "EnableCLR",
-        "Label": "Enable SQL CLR",
-        "HelpText": "This will reconfigure SQL Server to enable the SQL CLR.  It is highly recommended that this be previously authorized by your Database Administrator.",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "ebe9ab8b-3433-4aeb-bafb-642033a9b0a0",
-        "Name": "CatalogName",
-        "Label": "Catalog name",
-        "HelpText": "Name of the catalog to create in Integration Services Catalogs on SQL Server.  When using the GUI, this value gets hardcoded to SSISDB and cannot be changed.  It is recommended that you do not change the default value.",
-        "DefaultValue": "SSISDB",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "d111401b-504f-41f4-96de-b7667fcbf990",
-        "Name": "CatalogPwd",
-        "Label": "Catalog password",
-        "HelpText": "Password to the Integration Services Catalog.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "d2fefbf6-c68f-4a66-a5d1-3beb9e51a331",
-        "Name": "FolderName",
-        "Label": "Folder name",
-        "HelpText": "Name of the folder to use within the Integration Services Catalog",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "d6b05afa-6f7b-47cf-9b35-b92b87211dea",
-        "Name": "ProjectName",
-        "Label": "Project name",
-        "HelpText": "Name of the project within the folder of the Integration Services catalog",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "ec3589c1-360b-44fc-a19c-f2de0f57a323",
-        "Name": "UseEnvironment",
-        "Label": "Use environment",
-        "HelpText": "This will make a project reference to the defined environment.",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "718f2836-1c49-4119-a294-9b5488ead33b",
-        "Name": "EnvironmentName",
-        "Label": "Environment name",
-        "HelpText": "Name of the environment to reference the project to. If the environment doesn't exist, it will create it.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "303dd486-a389-48c2-a653-fe881c3b7d9a",
-        "Name": "ReferenceProjectParametersToEnvironmentVairables",
-        "Label": "Reference project parameters to environment variables",
-        "HelpText": "Checking this box will make Project Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects that an Octopus variable of the same name exists.",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "06079e96-3c10-4137-9c99-83da2051f8be",
-        "Name": "ReferencePackageParametersToEnvironmentVairables",
-        "Label": "Reference package parameters to environment variables",
-        "HelpText": "Checking this box will make Package Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects than an Octopus variable of the same name exists.",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "8c219bf1-0715-4c21-a131-f7bfb44690cd",
-        "Name": "UseFullyQualifiedVariableNames",
-        "Label": "Use Fully Qualified Variable Names",
-        "HelpText": "When true the package variables names must be represented in `dtsx_name_without_extension.variable_name`",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "6b29c969-3928-4faf-af17-0911d777d5b1",
-        "Name": "UseCustomFilter",
-        "Label": "Use Custom Filter for connection manager properties",
-        "HelpText": "Custom filter should contain the regular expression for ignoring properties when setting will occur during the auto-mapping",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "b33575e2-7246-4c04-b4fa-cd58e2b5e516",
-        "Name": "CustomFilter",
-        "Label": "Custom Filter for connection manager properties",
-        "HelpText": "Regular expression for filtering out the connection manager properties during the auto-mapping process. This string is used when `UseCustomFilter` is set to true",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "92b546d9-abf3-45e4-a61b-0315c21455df",
-        "Name": "SyncEnvironment",
-        "Label": "Clean obsolete variables from environment",
-        "HelpText": "When `true` synchronizes the environment:\n- Removes obsolete variables\n- Removes renamed variables\n- Replaces values of valid variables (also when `false`)",
-        "DefaultValue": "False",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "6a1fa441-9e14-4c13-b7f3-9c932d9b4e8e",
-        "Name": "ssisPackageId",
-        "Label": "Package Id",
-        "HelpText": "Id of the package to deploy, used to support deployment with Workers.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Package"
-        }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "#region Functions\n\n# Define functions\nfunction Get-SqlModuleInstalled\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName\n    )\n\n    # Check to see if the module is installed\n    if ($null -ne (Get-Module -ListAvailable -Name $PowerShellModuleName))\n    {\n        # It is installed\n        return $true\n    }\n    else\n    {\n        # Module not installed\n        return $false\n    }\n}\n\nfunction Get-NugetPackageProviderNotInstalled\n{\n\t# See if the nuget package provider has been installed\n    return ($null -eq (Get-PackageProvider -ListAvailable -Name Nuget -ErrorAction SilentlyContinue))\n}\n\nfunction Install-SqlServerPowerShellModule\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName,\n        $LocalModulesPath\n    )\n\n\t# Check to see if the package provider has been installed\n    if ((Get-NugetPackageProviderNotInstalled) -ne $false)\n    {\n    \t# Display that we need the nuget package provider\n        Write-Host \"Nuget package provider not found, installing ...\"\n        \n        # Install Nuget package provider\n        Install-PackageProvider -Name Nuget -Force\n    }\n\n\t# Save the module in the temporary location\n    Save-Module -Name $PowerShellModuleName -Path $LocalModulesPath -Force\n\n\t# Display\n    Write-Output \"Importing module $PowerShellModuleName ...\"\n\n    # Import the module\n    Import-Module -Name $PowerShellModuleName\n}\n\nFunction Load-SqlServerAssmblies\n{\n\t# Declare parameters\n    \n\t# Get the folder where the SqlServer module ended up in\n\t$sqlServerModulePath = [System.IO.Path]::GetDirectoryName((Get-Module SqlServer).Path)\n    \n    # Loop through the assemblies\n    foreach($assemblyFile in (Get-ChildItem -Path $sqlServerModulePath -Exclude msv*.dll | Where-Object {$_.Extension -eq \".dll\"}))\n    {\n        # Load the assembly\n        [Reflection.Assembly]::LoadFile($assemblyFile.FullName) | Out-Null\n    }    \n}\n\n#region Get-Catalog\nFunction Get-Catalog\n{\n     # define parameters\n    Param ($CatalogName)\n    # NOTE: using $integrationServices variable defined in main\n    \n    # define working varaibles\n    $Catalog = $null\n    # check to see if there are any catalogs\n    if($integrationServices.Catalogs.Count -gt 0 -and $integrationServices.Catalogs[$CatalogName])\n    {\n    \t# get reference to catalog\n    \t$Catalog = $integrationServices.Catalogs[$CatalogName]\n    }\n    else\n    {\n    \tif((Get-CLREnabled) -eq 0)\n    \t{\n    \t\tif(-not $EnableCLR)\n    \t\t{\n    \t\t\t# throw error\n    \t\t\tthrow \"SQL CLR is not enabled.\"\n    \t\t}\n    \t\telse\n    \t\t{\n    \t\t\t# display sql clr isn't enabled\n    \t\t\tWrite-Warning \"SQL CLR is not enabled on $($sqlConnection.DataSource).  This feature must be enabled for SSIS catalogs.\"\n    \n    \t\t\t# enablign SQLCLR\n    \t\t\tWrite-Host \"Enabling SQL CLR ...\"\n    \t\t\tEnable-SQLCLR\n    \t\t\tWrite-Host \"SQL CLR enabled\"\n    \t\t}\n    \t}\n    \n    \t# Provision a new SSIS Catalog\n    \tWrite-Host \"Creating SSIS Catalog ...\"\n    \n    \t$Catalog = New-Object \"$ISNamespace.Catalog\" ($integrationServices, $CatalogName, $OctopusParameters['SSIS.Template.CatalogPwd'])\n    \t$Catalog.Create()\n    \n    \n    }\n    \n    # return the catalog\n    return $Catalog\n}\n#endregion\n\n#region Get-CLREnabled\nFunction Get-CLREnabled\n{\n    # define parameters\n    # Not using any parameters, but am using $sqlConnection defined in main\n    \n    # define working variables\n    $Query = \"SELECT * FROM sys.configurations WHERE name = 'clr enabled'\"\n    \n    # execute script\n    $CLREnabled = Invoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query | Select value\n    \n    # return value\n    return $CLREnabled.Value\n}\n#endregion\n\n#region Enable-SQLCLR\nFunction Enable-SQLCLR\n{\n    $QueryArray = \"sp_configure 'show advanced options', 1\", \"RECONFIGURE\", \"sp_configure 'clr enabled', 1\", \"RECONFIGURE \"\n    # execute script\n    \n    foreach($Query in $QueryArray)\n    {\n    \tInvoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query\n    }\n    \n    # check that it's enabled\n    if((Get-CLREnabled) -ne 1)\n    {\n    \t# throw error\n    \tthrow \"Failed to enable SQL CLR\"\n    }\n}\n#endregion\n\n#region Get-Folder\nFunction Get-Folder\n{\n # parameters\n    Param($FolderName, $Catalog)\n    \n    $Folder = $null\n    # try to get reference to folder\n    \n    if(!($Catalog.Folders -eq $null))\n    {\n    \t$Folder = $Catalog.Folders[$FolderName]\n    }\n    \n    # check to see if $Folder has a value\n    if($Folder -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Folder $FolderName doesn't exist, creating folder...\"\n    \n    \t# create the folder\n    \t$Folder = New-Object \"$ISNamespace.CatalogFolder\" ($Catalog, $FolderName, $FolderName) \n    \t$Folder.Create() \n    }\n    \n    # return the folde reference\n    return $Folder\n}\n#endregion\n\n#region Get-Environment\nFunction Get-Environment\n{\n     # define parameters\n    Param($Folder, $EnvironmentName)\n    \n    $Environment = $null\n    # get reference to Environment\n    if(!($Folder.Environments -eq $null) -and $Folder.Environments.Count -gt 0)\n    {\n    \t$Environment = $Folder.Environments[$EnvironmentName]\n    }\n    \n    # check to see if it's a null reference\n    if($Environment -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Environment $EnvironmentName doesn't exist, creating environment...\"\n    \n    \t# create environment\n    \t$Environment = New-Object \"$ISNamespace.EnvironmentInfo\" ($Folder, $EnvironmentName, $EnvironmentName)\n    \t$Environment.Create() \n    }\n    \n    # return the environment\n    return $Environment\n}\n#endregion\n\n#region Set-EnvironmentReference\nFunction Set-EnvironmentReference\n{\n     # define parameters\n    Param($Project, $Environment, $Folder)\n    \n    # get reference\n    $Reference = $null\n    \n    if(!($Project.References -eq $null))\n    {\n    \t$Reference = $Project.References[$Environment.Name, $Folder.Name]\n    \n    }\n    \n    # check to see if it's a null reference\n    if($Reference -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Project does not reference environment $($Environment.Name), creating reference...\"\n    \n    \t# create reference\n    \t$Project.References.Add($Environment.Name, $Folder.Name)\n    \t$Project.Alter() \n    }\n}\n#endregion\n\n#region Set-ProjectParametersToEnvironmentVariablesReference\nFunction Set-ProjectParametersToEnvironmentVariablesReference\n{\n     # define parameters\n    Param($Project, $Environment)\n    \n    $UpsertedVariables = @()\n\n    if($Project.Parameters -eq $null)\n    {\n        Write-Host \"No project parameters exist\"\n        return\n    }\n\n    # loop through project parameters\n    foreach($Parameter in $Project.Parameters)\n    {\n        # skip if the parameter is included in custom filters\n        if ($UseCustomFilter) \n        {\n            if ($Parameter.Name -match $CustomFilter)\n            {\n                Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                continue\n            }\n        }\n\n        # Add variable to list of variable\n        $UpsertedVariables += $Parameter.Name\n\n        $Variable = $null\n        if(!($Environment.Variables -eq $null))\n        {\n    \t    # get reference to variable\n    \t    $Variable = $Environment.Variables[$Parameter.Name]\n        }\n    \n    \t# check to see if variable exists\n    \tif($Variable -eq $null)\n    \t{\n    \t\t# add the environment variable\n    \t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $Parameter.Name\n    \n    \t\t# get reference to the newly created variable\n    \t\t$Variable = $Environment.Variables[$Parameter.Name]\n    \t}\n    \n    \t# set the environment variable value\n    \tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $Parameter.Name\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n    $Project.Alter()\n\n    return $UpsertedVariables\n}\n#endregion\n\nFunction Set-PackageVariablesToEnvironmentVariablesReference\n{\n    # define parameters\n    Param($Project, $Environment)\n\n    $Variables = @()\n    $UpsertedVariables = @()\n\n    # loop through packages in project in order to store a temp collection of variables\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n    \t\t# add to the temporary variable collection\n    \t\t$Variables += $Parameter.Name\n    \t}\n    }\n\n    # loop through packages in project\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n            if ($UseFullyQualifiedVariableNames)\n            {\n                # Set fully qualified variable name\n                $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n            }\n            else\n            {\n                # check if exists a variable with the same name\n                $VariableNameOccurrences = $($Variables | Where-Object { $_ -eq $Parameter.Name }).count\n                $ParameterName = $Parameter.Name\n                \n                if ($VariableNameOccurrences -gt 1)\n                {\n                    $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n                }\n            }\n            \n            if ($UseCustomFilter)\n            {\n                if ($ParameterName -match $CustomFilter)\n                {\n                    Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                    continue\n                }\n            }\n\n            # get reference to variable\n    \t\t$Variable = $Environment.Variables[$ParameterName]\n\n            # Add variable to list of variable\n            $UpsertedVariables += $ParameterName\n\n            # check to see if the parameter exists\n    \t\tif(!$Variable)\n    \t\t{\n    \t\t\t# add the environment variable\n    \t\t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $ParameterName\n    \n    \t\t\t# get reference to the newly created variable\n    \t\t\t$Variable = $Environment.Variables[$ParameterName]\n    \t\t}\n    \n    \t\t# set the environment variable value\n    \t\tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $ParameterName\n    \t}\n    \n    \t# alter the package\n    \t$Package.Alter()\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n\n    return $UpsertedVariables\n}\n\nFunction Sync-EnvironmentVariables\n{\n    # define parameters\n    Param($Environment, $VariablesToPreserveInEnvironment)\n\n    foreach($VariableToEvaluate in $Environment.Variables)\n    {\n        if ($VariablesToPreserveInEnvironment -notcontains $VariableToEvaluate.Name)\n        {\n            Write-Host \"- Removing environment variable: $($VariableToEvaluate.Name)\"\n            $VariableToRemove = $Environment.Variables[$VariableToEvaluate.Name]\n            $Environment.Variables.Remove($VariableToRemove) | Out-Null\n        }\n    }\n\n    # alter the environment\n    $Environment.Alter()\n}\n\n#region Add-EnvironmentVariable\nFunction Add-EnvironmentVariable\n{\n    # define parameters\n    Param($Environment, $Parameter, $ParameterName)\n    \n    # display \n    Write-Host \"- Adding environment variable $($ParameterName)\"\n    \n    # check to see if design default value is emtpy or null\n    if([string]::IsNullOrEmpty($Parameter.DesignDefaultValue))\n    {\n    \t# give it something\n    \t$DefaultValue = \"\" # sensitive variables will not return anything so when trying to use the property of $Parameter.DesignDefaultValue, the Alter method will fail.\n    }\n    else\n    {\n    \t# take the design\n    \t$DefaultValue = $Parameter.DesignDefaultValue\n    }\n    \n    # add variable with an initial value\n    $Environment.Variables.Add($ParameterName, $Parameter.DataType, $DefaultValue, $Parameter.Sensitive, $Parameter.Description)\n}\n#endregion\n\n#region Set-EnvironmentVariableValue\nFunction Set-EnvironmentVariableValue\n{\n     # define parameters\n    Param($Variable, $Parameter, $ParameterName)\n\n    # check to make sure variable value is available\n    if($OctopusParameters -and $OctopusParameters.ContainsKey($ParameterName))\n    {\n        # display \n        Write-Host \"- Updating environment variable $($ParameterName)\"\n\n    \t# set the variable value\n    \t$Variable.Value = $OctopusParameters[\"$($ParameterName)\"]\n    }\n    else\n    {\n    \t# warning\n    \tWrite-Host \"**- OctopusParameters collection is empty or $($ParameterName) not in the collection -**\"\n    }\n    \n    # Set reference\n    $Parameter.Set([Microsoft.SqlServer.Management.IntegrationServices.ParameterInfo+ParameterValueType]::Referenced, \"$($ParameterName)\")\n}\n#endregion\n\n# Define PowerShell Modules path\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\n\n# Check to see if SqlServer module is installed\nif ((Get-SqlModuleInstalled -PowerShellModuleName \"SqlServer\") -ne $true)\n{\n\t# Display message\n    Write-Output \"PowerShell module SqlServer not present, downloading temporary copy ...\"\n\n\t#Enable TLS 1.2 as default protocol\n\t[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12\n\n    # Download and install temporary copy\n    Install-SqlServerPowerShellModule -PowerShellModuleName \"SqlServer\" -LocalModulesPath $LocalModules\n    \n\t#region Dependent assemblies\n\tLoad-SqlServerAssmblies    \n}\nelse\n{\n\t# Load the IntegrationServices Assembly\n\t[Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.Management.IntegrationServices\") | Out-Null # Out-Null supresses a message that would normally be displayed saying it loaded out of GAC\n}\n\n#endregion\n\n# Store the IntegrationServices Assembly namespace to avoid typing it every time\n$ISNamespace = \"Microsoft.SqlServer.Management.IntegrationServices\"\n\n#endregion\n\n#region Main\ntry\n{   \n    # ensure all boolean variables are true booleans\n    $EnableCLR = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.EnableCLR'])\")\n    $UseEnvironment = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.UseEnvironment'])\")\n    $ReferenceProjectParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.ReferenceProjectParametersToEnvironmentVairables'])\")\n    \n    $ReferencePackageParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.ReferencePackageParametersToEnvironmentVairables'])\")\n    $UseFullyQualifiedVariableNames = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.UseFullyQualifiedVariableNames'])\")\n    $SyncEnvironment = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.SyncEnvironment'])\")\n    # custom names for filtering out the excluded variables by design\n    $UseCustomFilter = [System.Convert]::ToBoolean(\"$($OctopusParameters['SSIS.Template.UseCustomFilter'])\")\n    $CustomFilter = [System.Convert]::ToString(\"$($OctopusParameters['SSIS.Template.CustomFilter'])\")\n    # list of variables names to keep in target environment\n    $VariablesToPreserveInEnvironment = @()\n    $ssisPackageId = $OctopusParameters['SSIS.Template.ssisPackageId']\n        \n\t# Get the extracted path\n\t$DeployedPath = $OctopusParameters[\"Octopus.Action.Package[$ssisPackageId].ExtractedPath\"]\n    \n\t# Get all .ispac files from the deployed path\n\t$IsPacFiles = Get-ChildItem -Recurse -Path $DeployedPath | Where {$_.Extension.ToLower() -eq \".ispac\"}\n\n\t# display number of files\n\tWrite-Host \"$($IsPacFiles.Count) .ispac file(s) found.\"\n\n\tWrite-Host \"Connecting to server ...\"\n\n\t# Create a connection to the server\n    $sqlConnectionString = \"Data Source=$($OctopusParameters['SSIS.Template.ServerName']);Initial Catalog=SSISDB;\"\n    \n    if (![string]::IsNullOrEmpty($OctopusParameters['SSIS.Template.sqlAccountUsername']) -and ![string]::IsNullOrEmpty($OctopusParameters['SSIS.Template.sqlAccountPassword']))\n    {\n    \t# Add username and password to connection string\n        $sqlConnectionString += \"User ID=$($OctopusParameters['SSIS.Template.sqlAccountUsername']); Password=$($OctopusParameters['SSIS.Template.sqlAccountPassword']);\"\n    }\n    else\n    {\n    \t# Use integrated\n        $sqlConnectionString += \"Integrated Security=SSPI;\"\n    }\n    \n    \n    # Create new connection object with connection string\n    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString\n\n\t# create integration services object\n\t$integrationServices = New-Object \"$ISNamespace.IntegrationServices\" $sqlConnection\n\n\t# get reference to the catalog\n\tWrite-Host \"Getting reference to catalog $($OctopusParameters['SSIS.Template.CataLogName'])\"\n\t$Catalog = Get-Catalog -CatalogName $OctopusParameters['SSIS.Template.CataLogName']\n\n\t# get folder reference\n\t$Folder = Get-Folder -FolderName $OctopusParameters['SSIS.Template.FolderName'] -Catalog $Catalog\n\n\t# loop through ispac files\n\tforeach($IsPacFile in $IsPacFiles)\n\t{\n\t\t# read project file\n\t\t$ProjectFile = [System.IO.File]::ReadAllBytes($IsPacFile.FullName)\n\n\t\t# deploy project\n\t\tWrite-Host \"Deploying project $($IsPacFile.Name)...\"\n\t\t$Folder.DeployProject($OctopusParameters['SSIS.Template.ProjectName'], $ProjectFile) | Out-Null\n\n\t\t# get reference to deployed project\n\t\t$Project = $Folder.Projects[$OctopusParameters['SSIS.Template.ProjectName']]\n\n\t\t# check to see if they want to use environments\n\t\tif($UseEnvironment)\n\t\t{\n\t\t\t# get environment reference\n\t\t\t$Environment = Get-Environment -Folder $Folder -EnvironmentName $OctopusParameters['SSIS.Template.EnvironmentName']\n\n\t\t\t# set environment reference\n\t\t\tSet-EnvironmentReference -Project $Project -Environment $Environment -Folder $Folder\n\n\t\t\t# check to see if the user wants to convert project parameters to environment variables\n\t\t\tif($ReferenceProjectParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set environment variables\n\t\t\t\tWrite-Host \"Referencing Project Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-ProjectParametersToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n\n\t\t\t# check to see if the user wants to convert the package parameters to environment variables\n\t\t\tif($ReferencePackageParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set package variables\n\t\t\t\tWrite-Host \"Referencing Package Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-PackageVariablesToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n            \n            # Removes all unused variables from the environment\n            if ($SyncEnvironment)\n            {\n                Write-Host \"Sync package environment variables...\"\n                Sync-EnvironmentVariables -Environment $Environment -VariablesToPreserveInEnvironment $VariablesToPreserveInEnvironment\n            }\n\t\t}\n\t}\n}\n\nfinally\n{\n\t# check to make sure sqlconnection isn't null\n\tif($sqlConnection)\n\t{\n\t\t# check state of sqlconnection\n\t\tif($sqlConnection.State -eq [System.Data.ConnectionState]::Open)\n\t\t{\n\t\t\t# close the connection\n\t\t\t$sqlConnection.Close()\n\t\t}\n\n\t\t# cleanup\n\t\t$sqlConnection.Dispose()\n\t}\n}\n#endregion\n",
+    "Octopus.Action.Script.ScriptSource": "Inline"
+  },
+  "Parameters": [
+    {
+      "Id": "53aa9e3e-1292-4e75-8095-3666ebd5886b",
+      "Name": "SSIS.Template.ServerName",
+      "Label": "Database server name (\\instance)",
+      "HelpText": "Name of the SQL Server you are deploying to.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
       }
-    ],
-    "$Meta": {
-      "ExportedAt": "2020-06-25T17:22:28.356Z",
-      "OctopusVersion": "2020.2.14",
-      "Type": "ActionTemplate"
     },
-    "LastModifiedBy": "twerthi",
-    "Category": "sql"
-  }
+    {
+      "Id": "c0605196-f184-44f6-9b3d-c043323e017c",
+      "Name": "SSIS.Template.sqlAccountUsername",
+      "Label": "SQL Authentication Username",
+      "HelpText": "(Optional) Username of the SQL Authentication account.  Use this approach when deploying to Azure Databases with SSIS configured.  If SQL Authentication Username and Password are blank, Integrated Authentication is used.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "224b913f-657c-4d1c-a3d8-0f286203c1ec",
+      "Name": "SSIS.Template.sqlAccountPassword",
+      "Label": "SQL Authentication Password",
+      "HelpText": "(Optional) Password of the SQL Authentication account.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "0abbb06c-5f98-44d8-b20d-b811b6bf18da",
+      "Name": "SSIS.Template.EnableCLR",
+      "Label": "Enable SQL CLR",
+      "HelpText": "This will reconfigure SQL Server to enable the SQL CLR.  It is highly recommended that this be previously authorized by your Database Administrator.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "ebe9ab8b-3433-4aeb-bafb-642033a9b0a0",
+      "Name": "SSIS.Template.CatalogName",
+      "Label": "Catalog name",
+      "HelpText": "Name of the catalog to create in Integration Services Catalogs on SQL Server.  When using the GUI, this value gets hardcoded to SSISDB and cannot be changed.  It is recommended that you do not change the default value.",
+      "DefaultValue": "SSISDB",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d111401b-504f-41f4-96de-b7667fcbf990",
+      "Name": "SSIS.Template.CatalogPwd",
+      "Label": "Catalog password",
+      "HelpText": "Password to the Integration Services Catalog.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "d2fefbf6-c68f-4a66-a5d1-3beb9e51a331",
+      "Name": "SSIS.Template.FolderName",
+      "Label": "Folder name",
+      "HelpText": "Name of the folder to use within the Integration Services Catalog",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d6b05afa-6f7b-47cf-9b35-b92b87211dea",
+      "Name": "SSIS.Template.ProjectName",
+      "Label": "Project name",
+      "HelpText": "Name of the project within the folder of the Integration Services catalog",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ec3589c1-360b-44fc-a19c-f2de0f57a323",
+      "Name": "SSIS.Template.UseEnvironment",
+      "Label": "Use environment",
+      "HelpText": "This will make a project reference to the defined environment.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "718f2836-1c49-4119-a294-9b5488ead33b",
+      "Name": "SSIS.Template.EnvironmentName",
+      "Label": "Environment name",
+      "HelpText": "Name of the environment to reference the project to. If the environment doesn't exist, it will create it.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "303dd486-a389-48c2-a653-fe881c3b7d9a",
+      "Name": "SSIS.Template.ReferenceProjectParametersToEnvironmentVairables",
+      "Label": "Reference project parameters to environment variables",
+      "HelpText": "Checking this box will make Project Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects that an Octopus variable of the same name exists.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "06079e96-3c10-4137-9c99-83da2051f8be",
+      "Name": "SSIS.Template.ReferencePackageParametersToEnvironmentVairables",
+      "Label": "Reference package parameters to environment variables",
+      "HelpText": "Checking this box will make Package Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects than an Octopus variable of the same name exists.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "8c219bf1-0715-4c21-a131-f7bfb44690cd",
+      "Name": "SSIS.Template.UseFullyQualifiedVariableNames",
+      "Label": "Use Fully Qualified Variable Names",
+      "HelpText": "When true the package variables names must be represented in `dtsx_name_without_extension.variable_name`",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "6b29c969-3928-4faf-af17-0911d777d5b1",
+      "Name": "SSIS.Template.UseCustomFilter",
+      "Label": "Use Custom Filter for connection manager properties",
+      "HelpText": "Custom filter should contain the regular expression for ignoring properties when setting will occur during the auto-mapping",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "b33575e2-7246-4c04-b4fa-cd58e2b5e516",
+      "Name": "SSIS.Template.CustomFilter",
+      "Label": "Custom Filter for connection manager properties",
+      "HelpText": "Regular expression for filtering out the connection manager properties during the auto-mapping process. This string is used when `UseCustomFilter` is set to true",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "92b546d9-abf3-45e4-a61b-0315c21455df",
+      "Name": "SSIS.Template.SyncEnvironment",
+      "Label": "Clean obsolete variables from environment",
+      "HelpText": "When `true` synchronizes the environment:\n- Removes obsolete variables\n- Removes renamed variables\n- Replaces values of valid variables (also when `false`)",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "6a1fa441-9e14-4c13-b7f3-9c932d9b4e8e",
+      "Name": "SSIS.Template.ssisPackageId",
+      "Label": "Package Id",
+      "HelpText": "Id of the package to deploy, used to support deployment with Workers.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2020-06-26T16:33:07.029Z",
+    "OctopusVersion": "2020.2.14",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "twerthi",
+  "Category": "sql"
+}

--- a/step-templates/ssis-deploy-ispac-from-package-parameter.json
+++ b/step-templates/ssis-deploy-ispac-from-package-parameter.json
@@ -1,0 +1,206 @@
+{
+    "Id": "4beed3f8-3ba4-463d-9731-8d2ed82543ae",
+    "Name": "Deploy ispac SSIS project from a Package Parameter",
+    "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "Author": "twerthi",
+    "Packages": [
+      {
+        "Id": "96816ead-d26f-423b-8c24-2fb312aa3e23",
+        "Name": "ssisPackageId",
+        "PackageId": null,
+        "FeedId": "feeds-builtin",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "deferred",
+          "PackageParameterName": "ssisPackageId"
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "#region Functions\n\n# Define functions\nfunction Get-SqlModuleInstalled\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName\n    )\n\n    # Check to see if the module is installed\n    if ($null -ne (Get-Module -ListAvailable -Name $PowerShellModuleName))\n    {\n        # It is installed\n        return $true\n    }\n    else\n    {\n        # Module not installed\n        return $false\n    }\n}\n\nfunction Get-NugetPackageProviderNotInstalled\n{\n\t# See if the nuget package provider has been installed\n    return ($null -eq (Get-PackageProvider -ListAvailable -Name Nuget -ErrorAction SilentlyContinue))\n}\n\nfunction Install-SqlServerPowerShellModule\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName,\n        $LocalModulesPath\n    )\n\n\t# Check to see if the package provider has been installed\n    if ((Get-NugetPackageProviderNotInstalled) -ne $false)\n    {\n    \t# Display that we need the nuget package provider\n        Write-Host \"Nuget package provider not found, installing ...\"\n        \n        # Install Nuget package provider\n        Install-PackageProvider -Name Nuget -Force\n    }\n\n\t# Save the module in the temporary location\n    Save-Module -Name $PowerShellModuleName -Path $LocalModulesPath -Force\n\n\t# Display\n    Write-Output \"Importing module $PowerShellModuleName ...\"\n\n    # Import the module\n    Import-Module -Name $PowerShellModuleName\n}\n\nFunction Load-SqlServerAssmblies\n{\n\t# Declare parameters\n    \n\t# Get the folder where the SqlServer module ended up in\n\t$sqlServerModulePath = [System.IO.Path]::GetDirectoryName((Get-Module SqlServer).Path)\n    \n    # Loop through the assemblies\n    foreach($assemblyFile in (Get-ChildItem -Path $sqlServerModulePath -Exclude msv*.dll | Where-Object {$_.Extension -eq \".dll\"}))\n    {\n        # Load the assembly\n        [Reflection.Assembly]::LoadFile($assemblyFile.FullName) | Out-Null\n    }    \n}\n\n#region Get-Catalog\nFunction Get-Catalog\n{\n     # define parameters\n    Param ($CatalogName)\n    # NOTE: using $integrationServices variable defined in main\n    \n    # define working varaibles\n    $Catalog = $null\n    # check to see if there are any catalogs\n    if($integrationServices.Catalogs.Count -gt 0 -and $integrationServices.Catalogs[$CatalogName])\n    {\n    \t# get reference to catalog\n    \t$Catalog = $integrationServices.Catalogs[$CatalogName]\n    }\n    else\n    {\n    \tif((Get-CLREnabled) -eq 0)\n    \t{\n    \t\tif(-not $EnableCLR)\n    \t\t{\n    \t\t\t# throw error\n    \t\t\tthrow \"SQL CLR is not enabled.\"\n    \t\t}\n    \t\telse\n    \t\t{\n    \t\t\t# display sql clr isn't enabled\n    \t\t\tWrite-Warning \"SQL CLR is not enabled on $($sqlConnection.DataSource).  This feature must be enabled for SSIS catalogs.\"\n    \n    \t\t\t# enablign SQLCLR\n    \t\t\tWrite-Host \"Enabling SQL CLR ...\"\n    \t\t\tEnable-SQLCLR\n    \t\t\tWrite-Host \"SQL CLR enabled\"\n    \t\t}\n    \t}\n    \n    \t# Provision a new SSIS Catalog\n    \tWrite-Host \"Creating SSIS Catalog ...\"\n    \n    \t$Catalog = New-Object \"$ISNamespace.Catalog\" ($integrationServices, $CatalogName, $CatalogPwd)\n    \t$Catalog.Create()\n    \n    \n    }\n    \n    # return the catalog\n    return $Catalog\n}\n#endregion\n\n#region Get-CLREnabled\nFunction Get-CLREnabled\n{\n    # define parameters\n    # Not using any parameters, but am using $sqlConnection defined in main\n    \n    # define working variables\n    $Query = \"SELECT * FROM sys.configurations WHERE name = 'clr enabled'\"\n    \n    # execute script\n    $CLREnabled = Invoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query | Select value\n    \n    # return value\n    return $CLREnabled.Value\n}\n#endregion\n\n#region Enable-SQLCLR\nFunction Enable-SQLCLR\n{\n    $QueryArray = \"sp_configure 'show advanced options', 1\", \"RECONFIGURE\", \"sp_configure 'clr enabled', 1\", \"RECONFIGURE \"\n    # execute script\n    \n    foreach($Query in $QueryArray)\n    {\n    \tInvoke-Sqlcmd -ServerInstance $sqlConnection.DataSource -Database \"master\" -Query $Query\n    }\n    \n    # check that it's enabled\n    if((Get-CLREnabled) -ne 1)\n    {\n    \t# throw error\n    \tthrow \"Failed to enable SQL CLR\"\n    }\n}\n#endregion\n\n#region Get-Folder\nFunction Get-Folder\n{\n # parameters\n    Param($FolderName, $Catalog)\n    \n    $Folder = $null\n    # try to get reference to folder\n    \n    if(!($Catalog.Folders -eq $null))\n    {\n    \t$Folder = $Catalog.Folders[$FolderName]\n    }\n    \n    # check to see if $Folder has a value\n    if($Folder -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Folder $FolderName doesn't exist, creating folder...\"\n    \n    \t# create the folder\n    \t$Folder = New-Object \"$ISNamespace.CatalogFolder\" ($Catalog, $FolderName, $FolderName) \n    \t$Folder.Create() \n    }\n    \n    # return the folde reference\n    return $Folder\n}\n#endregion\n\n#region Get-Environment\nFunction Get-Environment\n{\n     # define parameters\n    Param($Folder, $EnvironmentName)\n    \n    $Environment = $null\n    # get reference to Environment\n    if(!($Folder.Environments -eq $null) -and $Folder.Environments.Count -gt 0)\n    {\n    \t$Environment = $Folder.Environments[$EnvironmentName]\n    }\n    \n    # check to see if it's a null reference\n    if($Environment -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Environment $EnvironmentName doesn't exist, creating environment...\"\n    \n    \t# create environment\n    \t$Environment = New-Object \"$ISNamespace.EnvironmentInfo\" ($Folder, $EnvironmentName, $EnvironmentName)\n    \t$Environment.Create() \n    }\n    \n    # return the environment\n    return $Environment\n}\n#endregion\n\n#region Set-EnvironmentReference\nFunction Set-EnvironmentReference\n{\n     # define parameters\n    Param($Project, $Environment, $Folder)\n    \n    # get reference\n    $Reference = $null\n    \n    if(!($Project.References -eq $null))\n    {\n    \t$Reference = $Project.References[$Environment.Name, $Folder.Name]\n    \n    }\n    \n    # check to see if it's a null reference\n    if($Reference -eq $null)\n    {\n    \t# display\n    \tWrite-Host \"Project does not reference environment $($Environment.Name), creating reference...\"\n    \n    \t# create reference\n    \t$Project.References.Add($Environment.Name, $Folder.Name)\n    \t$Project.Alter() \n    }\n}\n#endregion\n\n#region Set-ProjectParametersToEnvironmentVariablesReference\nFunction Set-ProjectParametersToEnvironmentVariablesReference\n{\n     # define parameters\n    Param($Project, $Environment)\n    \n    $UpsertedVariables = @()\n\n    if($Project.Parameters -eq $null)\n    {\n        Write-Host \"No project parameters exist\"\n        return\n    }\n\n    # loop through project parameters\n    foreach($Parameter in $Project.Parameters)\n    {\n        # skip if the parameter is included in custom filters\n        if ($UseCustomFilter) \n        {\n            if ($Parameter.Name -match $CustomFilter)\n            {\n                Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                continue\n            }\n        }\n\n        # Add variable to list of variable\n        $UpsertedVariables += $Parameter.Name\n\n        $Variable = $null\n        if(!($Environment.Variables -eq $null))\n        {\n    \t    # get reference to variable\n    \t    $Variable = $Environment.Variables[$Parameter.Name]\n        }\n    \n    \t# check to see if variable exists\n    \tif($Variable -eq $null)\n    \t{\n    \t\t# add the environment variable\n    \t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $Parameter.Name\n    \n    \t\t# get reference to the newly created variable\n    \t\t$Variable = $Environment.Variables[$Parameter.Name]\n    \t}\n    \n    \t# set the environment variable value\n    \tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $Parameter.Name\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n    $Project.Alter()\n\n    return $UpsertedVariables\n}\n#endregion\n\nFunction Set-PackageVariablesToEnvironmentVariablesReference\n{\n    # define parameters\n    Param($Project, $Environment)\n\n    $Variables = @()\n    $UpsertedVariables = @()\n\n    # loop through packages in project in order to store a temp collection of variables\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n    \t\t# add to the temporary variable collection\n    \t\t$Variables += $Parameter.Name\n    \t}\n    }\n\n    # loop through packages in project\n    foreach($Package in $Project.Packages)\n    {\n    \t# loop through parameters of package\n    \tforeach($Parameter in $Package.Parameters)\n    \t{\n            if ($UseFullyQualifiedVariableNames)\n            {\n                # Set fully qualified variable name\n                $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n            }\n            else\n            {\n                # check if exists a variable with the same name\n                $VariableNameOccurrences = $($Variables | Where-Object { $_ -eq $Parameter.Name }).count\n                $ParameterName = $Parameter.Name\n                \n                if ($VariableNameOccurrences -gt 1)\n                {\n                    $ParameterName = $Parameter.ObjectName.Replace(\".dtsx\", \"\")+\".\"+$Parameter.Name\n                }\n            }\n            \n            if ($UseCustomFilter)\n            {\n                if ($ParameterName -match $CustomFilter)\n                {\n                    Write-Host \"- $($Parameter.Name) skipped due to CustomFilters.\"            \n                    continue\n                }\n            }\n\n            # get reference to variable\n    \t\t$Variable = $Environment.Variables[$ParameterName]\n\n            # Add variable to list of variable\n            $UpsertedVariables += $ParameterName\n\n            # check to see if the parameter exists\n    \t\tif(!$Variable)\n    \t\t{\n    \t\t\t# add the environment variable\n    \t\t\tAdd-EnvironmentVariable -Environment $Environment -Parameter $Parameter -ParameterName $ParameterName\n    \n    \t\t\t# get reference to the newly created variable\n    \t\t\t$Variable = $Environment.Variables[$ParameterName]\n    \t\t}\n    \n    \t\t# set the environment variable value\n    \t\tSet-EnvironmentVariableValue -Variable $Variable -Parameter $Parameter -ParameterName $ParameterName\n    \t}\n    \n    \t# alter the package\n    \t$Package.Alter()\n    }\n    \n    # alter the environment\n    $Environment.Alter()\n\n    return $UpsertedVariables\n}\n\nFunction Sync-EnvironmentVariables\n{\n    # define parameters\n    Param($Environment, $VariablesToPreserveInEnvironment)\n\n    foreach($VariableToEvaluate in $Environment.Variables)\n    {\n        if ($VariablesToPreserveInEnvironment -notcontains $VariableToEvaluate.Name)\n        {\n            Write-Host \"- Removing environment variable: $($VariableToEvaluate.Name)\"\n            $VariableToRemove = $Environment.Variables[$VariableToEvaluate.Name]\n            $Environment.Variables.Remove($VariableToRemove) | Out-Null\n        }\n    }\n\n    # alter the environment\n    $Environment.Alter()\n}\n\n#region Add-EnvironmentVariable\nFunction Add-EnvironmentVariable\n{\n    # define parameters\n    Param($Environment, $Parameter, $ParameterName)\n    \n    # display \n    Write-Host \"- Adding environment variable $($ParameterName)\"\n    \n    # check to see if design default value is emtpy or null\n    if([string]::IsNullOrEmpty($Parameter.DesignDefaultValue))\n    {\n    \t# give it something\n    \t$DefaultValue = \"\" # sensitive variables will not return anything so when trying to use the property of $Parameter.DesignDefaultValue, the Alter method will fail.\n    }\n    else\n    {\n    \t# take the design\n    \t$DefaultValue = $Parameter.DesignDefaultValue\n    }\n    \n    # add variable with an initial value\n    $Environment.Variables.Add($ParameterName, $Parameter.DataType, $DefaultValue, $Parameter.Sensitive, $Parameter.Description)\n}\n#endregion\n\n#region Set-EnvironmentVariableValue\nFunction Set-EnvironmentVariableValue\n{\n     # define parameters\n    Param($Variable, $Parameter, $ParameterName)\n\n    # check to make sure variable value is available\n    if($OctopusParameters -and $OctopusParameters.ContainsKey($ParameterName))\n    {\n        # display \n        Write-Host \"- Updating environment variable $($ParameterName)\"\n\n    \t# set the variable value\n    \t$Variable.Value = $OctopusParameters[\"$($ParameterName)\"]\n    }\n    else\n    {\n    \t# warning\n    \tWrite-Host \"**- OctopusParameters collection is empty or $($ParameterName) not in the collection -**\"\n    }\n    \n    # Set reference\n    $Parameter.Set([Microsoft.SqlServer.Management.IntegrationServices.ParameterInfo+ParameterValueType]::Referenced, \"$($ParameterName)\")\n}\n#endregion\n\n# Define PowerShell Modules path\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\n$env:PSModulePath = \"$LocalModules;$env:PSModulePath\"\n\n# Check to see if SqlServer module is installed\nif ((Get-SqlModuleInstalled -PowerShellModuleName \"SqlServer\") -ne $true)\n{\n\t# Display message\n    Write-Output \"PowerShell module SqlServer not present, downloading temporary copy ...\"\n\n\t#Enable TLS 1.2 as default protocol\n\t[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12\n\n    # Download and install temporary copy\n    Install-SqlServerPowerShellModule -PowerShellModuleName \"SqlServer\" -LocalModulesPath $LocalModules\n    \n\t#region Dependent assemblies\n\tLoad-SqlServerAssmblies    \n}\nelse\n{\n\t# Load the IntegrationServices Assembly\n\t[Reflection.Assembly]::LoadWithPartialName(\"Microsoft.SqlServer.Management.IntegrationServices\") | Out-Null # Out-Null supresses a message that would normally be displayed saying it loaded out of GAC\n}\n\n#endregion\n\n# Store the IntegrationServices Assembly namespace to avoid typing it every time\n$ISNamespace = \"Microsoft.SqlServer.Management.IntegrationServices\"\n\n#endregion\n\n#region Main\ntry\n{   \n    # ensure all boolean variables are true booleans\n    $EnableCLR = [System.Convert]::ToBoolean(\"$EnableCLR\")\n    $UseEnvironment = [System.Convert]::ToBoolean(\"$UseEnvironment\")\n    $ReferenceProjectParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$ReferenceProjectParametersToEnvironmentVairables\")\n    \n    $ReferencePackageParametersToEnvironmentVairables = [System.Convert]::ToBoolean(\"$ReferencePackageParametersToEnvironmentVairables\")\n    $UseFullyQualifiedVariableNames = [System.Convert]::ToBoolean(\"$UseFullyQualifiedVariableNames\")\n    $SyncEnvironment = [System.Convert]::ToBoolean(\"$SyncEnvironment\")\n    # custom names for filtering out the excluded variables by design\n    $UseCustomFilter = [System.Convert]::ToBoolean(\"$UseCustomFilter\")\n    $CustomFilter = [System.Convert]::ToString(\"$CustomFilter\")\n    # list of variables names to keep in target environment\n    $VariablesToPreserveInEnvironment = @()\n        \n\t# Get the extracted path\n\t$DeployedPath = $OctopusParameters[\"Octopus.Action.Package[$ssisPackageId].ExtractedPath\"]\n    \n\t# Get all .ispac files from the deployed path\n\t$IsPacFiles = Get-ChildItem -Recurse -Path $DeployedPath | Where {$_.Extension.ToLower() -eq \".ispac\"}\n\n\t# display number of files\n\tWrite-Host \"$($IsPacFiles.Count) .ispac file(s) found.\"\n\n\tWrite-Host \"Connecting to server ...\"\n\n\t# Create a connection to the server\n    $sqlConnectionString = \"Data Source=$ServerName;Initial Catalog=SSISDB;\"\n    \n    if (![string]::IsNullOrEmpty($sqlAccountUsername) -and ![string]::IsNullOrEmpty($sqlAccountPassword))\n    {\n    \t# Add username and password to connection string\n        $sqlConnectionString += \"User ID=$sqlAccountUsername; Password=$sqlAccountPassword;\"\n    }\n    else\n    {\n    \t# Use integrated\n        $sqlConnectionString += \"Integrated Security=SSPI;\"\n    }\n    \n    \n    # Create new connection object with connection string\n    $sqlConnection = New-Object System.Data.SqlClient.SqlConnection $sqlConnectionString\n\n\t# create integration services object\n\t$integrationServices = New-Object \"$ISNamespace.IntegrationServices\" $sqlConnection\n\n\t# get reference to the catalog\n\tWrite-Host \"Getting reference to catalog $CataLogName\"\n\t$Catalog = Get-Catalog -CatalogName $CataLogName\n\n\t# get folder reference\n\t$Folder = Get-Folder -FolderName $FolderName -Catalog $Catalog\n\n\t# loop through ispac files\n\tforeach($IsPacFile in $IsPacFiles)\n\t{\n\t\t# read project file\n\t\t$ProjectFile = [System.IO.File]::ReadAllBytes($IsPacFile.FullName)\n\n\t\t# deploy project\n\t\tWrite-Host \"Deploying project $($IsPacFile.Name)...\"\n\t\t$Folder.DeployProject($ProjectName, $ProjectFile) | Out-Null\n\n\t\t# get reference to deployed project\n\t\t$Project = $Folder.Projects[$ProjectName]\n\n\t\t# check to see if they want to use environments\n\t\tif($UseEnvironment)\n\t\t{\n\t\t\t# get environment reference\n\t\t\t$Environment = Get-Environment -Folder $Folder -EnvironmentName $EnvironmentName\n\n\t\t\t# set environment reference\n\t\t\tSet-EnvironmentReference -Project $Project -Environment $Environment -Folder $Folder\n\n\t\t\t# check to see if the user wants to convert project parameters to environment variables\n\t\t\tif($ReferenceProjectParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set environment variables\n\t\t\t\tWrite-Host \"Referencing Project Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-ProjectParametersToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n\n\t\t\t# check to see if the user wants to convert the package parameters to environment variables\n\t\t\tif($ReferencePackageParametersToEnvironmentVairables)\n\t\t\t{\n\t\t\t\t# set package variables\n\t\t\t\tWrite-Host \"Referencing Package Parameters to Environment Variables...\"\n\t\t\t\t$VariablesToPreserveInEnvironment += Set-PackageVariablesToEnvironmentVariablesReference -Project $Project -Environment $Environment\n\t\t\t}\n            \n            # Removes all unused variables from the environment\n            if ($SyncEnvironment)\n            {\n                Write-Host \"Sync package environment variables...\"\n                Sync-EnvironmentVariables -Environment $Environment -VariablesToPreserveInEnvironment $VariablesToPreserveInEnvironment\n            }\n\t\t}\n\t}\n}\n\nfinally\n{\n\t# check to make sure sqlconnection isn't null\n\tif($sqlConnection)\n\t{\n\t\t# check state of sqlconnection\n\t\tif($sqlConnection.State -eq [System.Data.ConnectionState]::Open)\n\t\t{\n\t\t\t# close the connection\n\t\t\t$sqlConnection.Close()\n\t\t}\n\n\t\t# cleanup\n\t\t$sqlConnection.Dispose()\n\t}\n}\n#endregion\n",
+      "Octopus.Action.Script.ScriptSource": "Inline"
+    },
+    "Parameters": [
+      {
+        "Id": "53aa9e3e-1292-4e75-8095-3666ebd5886b",
+        "Name": "ServerName",
+        "Label": "Database server name (\\instance)",
+        "HelpText": "Name of the SQL Server you are deploying to.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "c0605196-f184-44f6-9b3d-c043323e017c",
+        "Name": "sqlAccountUsername",
+        "Label": "SQL Authentication Username",
+        "HelpText": "(Optional) Username of the SQL Authentication account.  Use this approach when deploying to Azure Databases with SSIS configured.  If SQL Authentication Username and Password are blank, Integrated Authentication is used.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "224b913f-657c-4d1c-a3d8-0f286203c1ec",
+        "Name": "sqlAccountPassword",
+        "Label": "SQL Authentication Password",
+        "HelpText": "(Optional) Password of the SQL Authentication account.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "0abbb06c-5f98-44d8-b20d-b811b6bf18da",
+        "Name": "EnableCLR",
+        "Label": "Enable SQL CLR",
+        "HelpText": "This will reconfigure SQL Server to enable the SQL CLR.  It is highly recommended that this be previously authorized by your Database Administrator.",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "ebe9ab8b-3433-4aeb-bafb-642033a9b0a0",
+        "Name": "CatalogName",
+        "Label": "Catalog name",
+        "HelpText": "Name of the catalog to create in Integration Services Catalogs on SQL Server.  When using the GUI, this value gets hardcoded to SSISDB and cannot be changed.  It is recommended that you do not change the default value.",
+        "DefaultValue": "SSISDB",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "d111401b-504f-41f4-96de-b7667fcbf990",
+        "Name": "CatalogPwd",
+        "Label": "Catalog password",
+        "HelpText": "Password to the Integration Services Catalog.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "d2fefbf6-c68f-4a66-a5d1-3beb9e51a331",
+        "Name": "FolderName",
+        "Label": "Folder name",
+        "HelpText": "Name of the folder to use within the Integration Services Catalog",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "d6b05afa-6f7b-47cf-9b35-b92b87211dea",
+        "Name": "ProjectName",
+        "Label": "Project name",
+        "HelpText": "Name of the project within the folder of the Integration Services catalog",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "ec3589c1-360b-44fc-a19c-f2de0f57a323",
+        "Name": "UseEnvironment",
+        "Label": "Use environment",
+        "HelpText": "This will make a project reference to the defined environment.",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "718f2836-1c49-4119-a294-9b5488ead33b",
+        "Name": "EnvironmentName",
+        "Label": "Environment name",
+        "HelpText": "Name of the environment to reference the project to. If the environment doesn't exist, it will create it.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "303dd486-a389-48c2-a653-fe881c3b7d9a",
+        "Name": "ReferenceProjectParametersToEnvironmentVairables",
+        "Label": "Reference project parameters to environment variables",
+        "HelpText": "Checking this box will make Project Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects that an Octopus variable of the same name exists.",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "06079e96-3c10-4137-9c99-83da2051f8be",
+        "Name": "ReferencePackageParametersToEnvironmentVairables",
+        "Label": "Reference package parameters to environment variables",
+        "HelpText": "Checking this box will make Package Parameters reference Environment Variables.  If the Environment Variable doesn't exist, it will create it.  This expects than an Octopus variable of the same name exists.",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "8c219bf1-0715-4c21-a131-f7bfb44690cd",
+        "Name": "UseFullyQualifiedVariableNames",
+        "Label": "Use Fully Qualified Variable Names",
+        "HelpText": "When true the package variables names must be represented in `dtsx_name_without_extension.variable_name`",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "6b29c969-3928-4faf-af17-0911d777d5b1",
+        "Name": "UseCustomFilter",
+        "Label": "Use Custom Filter for connection manager properties",
+        "HelpText": "Custom filter should contain the regular expression for ignoring properties when setting will occur during the auto-mapping",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "b33575e2-7246-4c04-b4fa-cd58e2b5e516",
+        "Name": "CustomFilter",
+        "Label": "Custom Filter for connection manager properties",
+        "HelpText": "Regular expression for filtering out the connection manager properties during the auto-mapping process. This string is used when `UseCustomFilter` is set to true",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "92b546d9-abf3-45e4-a61b-0315c21455df",
+        "Name": "SyncEnvironment",
+        "Label": "Clean obsolete variables from environment",
+        "HelpText": "When `true` synchronizes the environment:\n- Removes obsolete variables\n- Removes renamed variables\n- Replaces values of valid variables (also when `false`)",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "6a1fa441-9e14-4c13-b7f3-9c932d9b4e8e",
+        "Name": "ssisPackageId",
+        "Label": "Package Id",
+        "HelpText": "Id of the package to deploy, used to support deployment with Workers.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Package"
+        }
+      }
+    ],
+    "$Meta": {
+      "ExportedAt": "2020-06-25T17:22:28.356Z",
+      "OctopusVersion": "2020.2.14",
+      "Type": "ActionTemplate"
+    },
+    "LastModifiedBy": "twerthi",
+    "Category": "sql"
+  }

--- a/step-templates/ssis-deploy-ispac-from-package-parameter.json
+++ b/step-templates/ssis-deploy-ispac-from-package-parameter.json
@@ -1,6 +1,6 @@
 {
   "Id": "27567d46-b935-4ee6-8b2d-8c165edada4e",
-  "Name": "Deploy ispac SSIS project from Referenced Package Copy",
+  "Name": "Deploy ispac SSIS project from a Package parameter",
   "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
   "ActionType": "Octopus.Script",
   "Version": 1,


### PR DESCRIPTION
---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes issue where feed-id doesn't work in existing package.
