### PR TITLE
Bug chocolatey

### DIFF
--- a/step-templates/chocolatey-install-package.json
+++ b/step-templates/chocolatey-install-package.json
@@ -5,7 +5,7 @@
   "ActionType": "Octopus.Script",
   "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$cinst = \"$chocolateyBin\\cinst.exe\"\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $cinst) -or -not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\n$chocoArgs = @()\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --confirm to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"-y\", \"\")\n    $chocoArgs += @(\"-c\", (Get-Location))\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId $($chocoArgs)\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId -Version $ChocolateyPackageVersion $($chocoArgs)\n}\n\nif ($global:LASTEXITCODE -eq 3010) { #ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$cinst = \"$chocolateyBin\\cinst.exe\"\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $cinst) -or -not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\n$chocoArgs = @()\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --confirm to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"-y\", \"\")\n}\n\nif (![String]::IsNullOrEmpty($ChocolateyCacheLocation))\n{\n\t# Use specified location\n    $chocoArgs += @(\"-c\", \"$ChocolateyCacheLocation\")\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId $($chocoArgs)\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId -Version $ChocolateyPackageVersion $($chocoArgs)\n}\n\nif ($global:LASTEXITCODE -eq 3010) { #ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "Parameters": [
@@ -22,6 +22,16 @@
       "HelpText": "If a specific version of the Chocolatey package is required enter it here. Otherwise, leave this field blank to use the latest version. Example: _2.3.4_.",
       "DefaultValue": "",
       "DisplaySettings": {}
+    },
+    {
+      "Id": "e2f4f855-722c-4529-9d8c-c9b95f8e092a",
+      "Name": "ChocolateyCacheLocation",
+      "Label": "(Optional) Cache Location",
+      "HelpText": "Use a specific folder to download the Chocolatey package.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
   "LastModifiedOn": "2020-07-24T20:54:58.543Z",

--- a/step-templates/chocolatey-install-package.json
+++ b/step-templates/chocolatey-install-package.json
@@ -3,9 +3,9 @@
   "Name": "Chocolatey - Install Package",
   "Description": "Installs a package using the Chocolatey package manager.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$cinst = \"$chocolateyBin\\cinst.exe\"\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $cinst) -or -not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\n$chocoArgs = @()\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --confirm to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"-y\", \"\")\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId $($chocoArgs)\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId -Version $ChocolateyPackageVersion $($chocoArgs)\n}\n\nif ($global:LASTEXITCODE -eq 3010) { #ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$cinst = \"$chocolateyBin\\cinst.exe\"\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $cinst) -or -not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\n$chocoArgs = @()\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --confirm to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"-y\", \"\")\n    $chocoArgs += @(\"-c\", (Get-Location))\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId $($chocoArgs)\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId -Version $ChocolateyPackageVersion $($chocoArgs)\n}\n\nif ($global:LASTEXITCODE -eq 3010) { #ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "Parameters": [
@@ -24,11 +24,11 @@
       "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2020-07-13T00:33:24.952Z",
-  "LastModifiedBy": "bigbearzhu",
+  "LastModifiedOn": "2020-07-24T20:54:58.543Z",
+  "LastModifiedBy": "twerthi",
   "$Meta": {
-    "ExportedAt": "2020-07-13T00:33:24.952Z",
-    "OctopusVersion": "2019.6.7",
+    "ExportedAt": "2020-07-24T20:54:58.543Z",
+    "OctopusVersion": "2020.3.1",
     "Type": "ActionTemplate"
   },
   "Category": "chocolatey"


### PR DESCRIPTION


---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes issue where attempts to install a package would fail claiming it couldn't extract the package to a system folder.
