### PR TITLE
Increase future reliability and use choco.exe to ensure Chocolatey is installed 

### DIFF
--- a/step-templates/chocolatey-ensure-installed.json
+++ b/step-templates/chocolatey-ensure-installed.json
@@ -5,15 +5,15 @@
   "ActionType": "Octopus.Script",
   "Version": 6,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\nWrite-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\cinst.exe\"\n\nif (-not $chocInstalled) {\n    Write-Output \"Chocolatey not found, installing...\"\n    \n    $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n    Invoke-Expression $installPs1\n    \n    Write-Output \"Chocolatey installation complete.\"\n} else {\n    Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n",
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\nWrite-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\choco.exe\"\n\nif (-not $chocInstalled) {\n    Write-Output \"Chocolatey not found, installing...\"\n    \n    $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n    Invoke-Expression $installPs1\n    \n    Write-Output \"Chocolatey installation complete.\"\n} else {\n    Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
   "Parameters": [],
-  "LastModifiedOn": "2014-07-08T17:25:22.284+00:00",
-  "LastModifiedBy": "joewaid",
+  "LastModifiedOn": "2020-07-28T13:42:22.284+00:00",
+  "LastModifiedBy": "pauby",
   "$Meta": {
-    "ExportedAt": "2014-07-08T17:46:00.478+00:00",
+    "ExportedAt": "2020-07-28T13:42:22.284+00:00",
     "OctopusVersion": "2.4.7.85",
     "Type": "ActionTemplate"
   },

--- a/step-templates/chocolatey-ensure-installed.json
+++ b/step-templates/chocolatey-ensure-installed.json
@@ -3,7 +3,7 @@
   "Name": "Chocolatey - Ensure Installed",
   "Description": "Ensures that the Chocolatey package manager is installed on the system. The installer is downloaded from https://chocolatey.org if required.",
   "ActionType": "Octopus.Script",
-  "Version": 6,
+  "Version": 7,
   "Properties": {
     "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\nWrite-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocInstalled = Test-Path \"$chocolateyBin\\choco.exe\"\n\nif (-not $chocInstalled) {\n    Write-Output \"Chocolatey not found, installing...\"\n    \n    $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n    Invoke-Expression $installPs1\n    \n    Write-Output \"Chocolatey installation complete.\"\n} else {\n    Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n",
     "Octopus.Action.Script.Syntax": "PowerShell"


### PR DESCRIPTION
---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

_This is amending a currently existing step template._

To detect that Chocolatey exists on the machine `cinst.exe` is being tested for. `cinst` is an alias for `choco install` and _may_ be removed in future versions. To ensure that this template can be used in the future, and to improve reliability, change detection of `cinst.exe` to `choco.exe` (which exists in the same directory).