### PR TITLE
(feat) Update Chocolatey Install step template with new parameters

### DIFF
--- a/step-templates/chocolatey-install-package.json
+++ b/step-templates/chocolatey-install-package.json
@@ -1,44 +1,74 @@
 {
   "Id": "b2385b12-e5b5-440f-bed8-6598c29b2528",
   "Name": "Chocolatey - Install Package",
-  "Description": "Installs a package using the Chocolatey package manager.",
+  "Description": "Installs or upgrades a package using the Chocolatey package manager.",
   "ActionType": "Octopus.Script",
-  "Version": 4,
+  "Version": 5,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$cinst = \"$chocolateyBin\\cinst.exe\"\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $cinst) -or -not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\n$chocoArgs = @()\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --confirm to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"-y\", \"\")\n}\n\nif (![String]::IsNullOrEmpty($ChocolateyCacheLocation))\n{\n\t# Use specified location\n    $chocoArgs += @(\"-c\", \"$ChocolateyCacheLocation\")\n}\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId $($chocoArgs)\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    & $cinst $ChocolateyPackageId -Version $ChocolateyPackageVersion $($chocoArgs)\n}\n\nif ($global:LASTEXITCODE -eq 3010) { #ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
-    "Octopus.Action.Script.Syntax": "PowerShell"
+    "Octopus.Action.Script.ScriptBody": "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\nif(-not (Test-Path $chocolateyBin)) {\n    Write-Output \"Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables...\"\n    $chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"User\") + \"\\bin\"\n}\n\n$choco = \"$chocolateyBin\\choco.exe\"\n\nif (-not (Test-Path $choco)) {\n    throw \"Chocolatey was not found at $chocolateyBin.\"\n}\n\n$chocoArgs = @('install')\nif (-not $ChocolateyPackageId) {\n    throw \"Please specify the ID of an application package to install.\"\n}\nelse {\n    $chocoArgs += $ChocolateyPackageId -split ' '\n}\n\n$chocoVersion = & $choco --version\nWrite-Output \"Running Chocolatey version $chocoVersion\"\n\nif (-not $ChocolateyPackageVersion) {\n    Write-Output \"Installing package(s) $ChocolateyPackageId from the Chocolatey package repository...\"\n} else {\n    Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n    $chocoArgs += @('--version', $ChocolateyPackageVersion)\n}\n\nif([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.9.8.33\")) {\n    Write-Output \"Adding --yes to arguments passed to Chocolatey\"\n    $chocoArgs += @(\"--yes\")\n}\n\nif (![String]::IsNullOrEmpty($ChocolateyCacheLocation)) {\n    Write-Output \"Using --cache-location $ChocolateyCacheLocation\"\n    $chocoArgs += @(\"--cache-location\", \"`\"'$ChocolateyCacheLocation'`\"\")\n}\n\nif (![String]::IsNullOrEmpty($ChocolateySource)) {\n    Write-Output \"Using package --source $ChocolateySource\"\n    $chocoArgs += @('--source', \"`\"'$ChocolateySource'`\"\")\n}\n\nif (($ChocolateyNoProgress -eq 'True') -and ([System.Version]::Parse($chocoVersion) -ge [System.Version]::Parse(\"0.10.4\"))) {\n    Write-Output \"Disabling download progress with --no-progress\"\n    $chocoArgs += @('--no-progress')\n}\n\nif (![String]::IsNullOrEmpty($ChocolateyOtherParameters)) {\n\t$chocoArgs += $ChocolateyOtherParameters -split ' '\n}\n\n# execute the command line\nWrite-Output \"Running the command: $choco $chocoArgs\"\n& $choco $chocoArgs\n\nif ($global:LASTEXITCODE -eq 3010) { \n\t# ignore reboot required exit code\n    Write-Output \"A restart may be required for the package to work\"\n    $global:LASTEXITCODE = 0\n}",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.EnabledFeatures": ""
   },
   "Parameters": [
     {
+      "Id": "449e25a9-2984-4cb7-b190-ae5114cfbb19",
       "Name": "ChocolateyPackageId",
-      "Label": "Chocolatey package",
-      "HelpText": "The ID of an application package in the https://chocolatey.org repository. Required. Example: _Git_.",
+      "Label": "(Required) Package Name",
+      "HelpText": "The name of the Chocolatey package to install. Install multiple packages by separating them with a space.\n\nExamples:\n\n* _git_\n* _git_ _vscode_ _notepadplusplus_\n",
       "DefaultValue": "",
       "DisplaySettings": {}
     },
     {
+      "Id": "17ff15ac-f925-493c-9330-64180687f44c",
       "Name": "ChocolateyPackageVersion",
-      "Label": "Version",
+      "Label": "(Optional) Version",
       "HelpText": "If a specific version of the Chocolatey package is required enter it here. Otherwise, leave this field blank to use the latest version. Example: _2.3.4_.",
       "DefaultValue": "",
       "DisplaySettings": {}
     },
     {
-      "Id": "e2f4f855-722c-4529-9d8c-c9b95f8e092a",
+      "Id": "8bad47c8-9537-4e8d-8ff4-0508df29ed67",
       "Name": "ChocolateyCacheLocation",
       "Label": "(Optional) Cache Location",
-      "HelpText": "Use a specific folder to download the Chocolatey package.",
+      "HelpText": "Use a specific folder to cache the Chocolatey package.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
+    },
+    {
+      "Id": "e4251d60-1a9c-4ee4-aa49-bd2ecfd5d64e",
+      "Name": "ChocolateySource",
+      "Label": "(Optional) Package Source",
+      "HelpText": "Use a package source to install Chocolatey packages from. This can be a http or https URL, a local folder or file share. When using URL's don't forget the trailing `/` at the end.\n\nFor example: \n\n* _https://chocolatey.org/api/v2/_\n* _c:\\choco-packages_\n* _\\\\business.server.local\\chocolatey-packages_",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "7790d99f-9fb2-4cfb-bdcb-74b4d254dba7",
+      "Name": "ChocolateyNoProgress",
+      "Label": "(Optional) Disable Download Progress",
+      "HelpText": "Disables the download progress percentage being displayed as this can generate a lot of output for the logs.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "e994f28e-f306-4af9-90da-0ad68ec8f30c",
+      "Name": "ChocolateyOtherParameters",
+      "Label": "(Optional) Other Parameters",
+      "HelpText": "Add additional Chocolatey parameters here, separated by spaces, and they will be prefixed to the end of the Chocolatey command being executed. Examples:\n\n* _--ignorepackagecodes_\n* _--ignorepackagecodes --requirechecksum --allow-downgrade_",
+      "DefaultValue": "",
+      "DisplaySettings": {}
     }
   ],
-  "LastModifiedOn": "2020-07-24T20:54:58.543Z",
-  "LastModifiedBy": "twerthi",
+  "LastModifiedOn": "2020-08-10T16:10:34.100Z",
+  "LastModifiedBy": "pauby",
   "$Meta": {
-    "ExportedAt": "2020-07-24T20:54:58.543Z",
-    "OctopusVersion": "2020.3.1",
+    "ExportedAt": "2020-08-10T15:59:10.300Z",
+    "OctopusVersion": "2020.3.2",
     "Type": "ActionTemplate"
   },
   "Category": "chocolatey"


### PR DESCRIPTION
* Added a `ChocolateySource` parameter to allow setting custom sources. This will help people set an internal source to get packages from;
* Add a `ChocolateyNoProgress` parameter. The step template currently has `choco` running and displaying the full download progress which can added hundreds / thousands of lines to the log. This allows that to be turned off (default is as per the previous version and turned on by default);
* Add a `ChocolateyOtherParameters` parameter which allows additional `choco` parameters to be added to the command line. `choco` has many parameters so this allows those to be used and the more popular ones specified as separate named parameters in the template.

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes #953 
