### PR TITLE
Add certificate variable as a parameter to the template

### DIFF
--- a/step-templates/ssl-write-certificate-pem-and-key.json
+++ b/step-templates/ssl-write-certificate-pem-and-key.json
@@ -1,22 +1,22 @@
 {
-    "Id": "9e7f1836-c7c5-4d52-bd9e-0948114b2a0e",
+    "Id": "ActionTemplates-313",
     "Name": "SSL - Write Certificate Pem and Key to the Filesystem",
     "Description": "Export the PEM and Key from an SSL certificate to the File System. This is useful in Linux for securing websites or Docker containers",
     "ActionType": "Octopus.Script",
-    "Version": 3,
+    "Version": 6,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
       "Octopus.Action.RunOnServer": "false",
       "Octopus.Action.Script.ScriptSource": "Inline",
       "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "\n$CertName = $OctopusParameters[\"SSLCert.Name\"] \nWrite-Host \"Writing PEM and Key files for $Certname\"\n\nNew-Item -ItemType directory $sslExportPath -Force -Verbose\n\n\"Certificate Pem:\"\n$pemPath = join-path $sslExportPath $sslPemFile\n$OctopusParameters[\"SSLCert.CertificatePem\"] | out-file $pemPath -Force -Verbose\n\n\"-\" * 30\n\n\"Certificate Key: \"\n$keypath = join-path $sslExportPath $sslKeyFile\n$OctopusParameters[\"SSLCert.PrivateKeyPem\"] | out-file $keyPath -Force -Verbose\n"
+      "Octopus.Action.Script.ScriptBody": "\n$CertName = $OctopusParameters[\"sslCertificate.Name\"] \nWrite-Host \"Writing PEM and Key files for $Certname\"\n\nNew-Item -ItemType directory $sslExportPath -Force -Verbose\n\n\"Certificate Pem:\"\n$pemPath = join-path $sslExportPath $sslPemFile\n$OctopusParameters[\"sslCertificate.CertificatePem\"] | out-file $pemPath -Force -Verbose\n\n\"-\" * 30\n\n\"Certificate Key: \"\n$keypath = join-path $sslExportPath $sslKeyFile\n$OctopusParameters[\"sslCertificate.PrivateKeyPem\"] | out-file $keyPath -Force -Verbose\n"
     },
     "Parameters": [
       {
         "Id": "c9cdd622-1a9a-4e5e-9eaa-ad738b76b356",
         "Name": "sslExportPath",
-        "Label": "Root SSL Epxort Path",
+        "Label": "Root SSL Export Path",
         "HelpText": "The base directory the key and pem file will be saved to",
         "DefaultValue": "",
         "DisplaySettings": {}
@@ -36,9 +36,19 @@
         "HelpText": "The filename to write the Key to",
         "DefaultValue": "",
         "DisplaySettings": {}
+      },
+      {
+        "Id": "65d6687e-badf-4772-ac14-70bd2790cd4d",
+        "Name": "sslCertificate",
+        "Label": "SSL Certificate Variable",
+        "HelpText": "The name of the SSL certificate Variable",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Certificate"
+        }
       }
     ],
-    "LastModifiedOn": "2020-08-13T08:51:39.574+00:00",
+    "LastModifiedOn": "2020-08-13T10:14:19.000+00:00",
     "LastModifiedBy": "jfeld",
     "$Meta": {
       "ExportedAt": "2020-08-13T07:41:35.949Z",

--- a/step-templates/ssl-write-certificate-pem-and-key.json
+++ b/step-templates/ssl-write-certificate-pem-and-key.json
@@ -1,5 +1,5 @@
 {
-    "Id": "ActionTemplates-313",
+    "Id": "9e7f1836-c7c5-4d52-bd9e-0948114b2a0e",
     "Name": "SSL - Write Certificate Pem and Key to the Filesystem",
     "Description": "Export the PEM and Key from an SSL certificate to the File System. This is useful in Linux for securing websites or Docker containers",
     "ActionType": "Octopus.Script",


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
