### PR TITLE
corrected parameter name used

### DIFF
--- a/step-templates/azure-web-app-slot-swap.json
+++ b/step-templates/azure-web-app-slot-swap.json
@@ -3,13 +3,13 @@
     "Name": "Azure Web App - Slot Swap",
     "Description": "Swaps an azure web app slot. Defaults to the deployment slot defined in the web app target.\n<hr />\n\n*<p>Note This template is designed to run against an azure web app octopus target </p>*\n*<p>Depends on Azure CLI and powershell to be installed on the running machine</p>*",
     "ActionType": "Octopus.AzurePowerShell",
-    "Version": 1,
+    "Version": 2,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
       "Octopus.Action.Script.ScriptSource": "Inline",
       "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "$rg = $OctopusParameters[\"Octopus.Action.Azure.ResourceGroupName\"]\n$webAppName = $OctopusParameters[\"Octopus.Action.Azure.WebAppName\"]\n$destinationSlot = $OctopusParameters[\"azWebAppSwap.destinationSlot\"]\n$sourceSlot = $OctopusParameters[\"azWebAppSwap.sourceSlot\"]\n\nif([string]::IsNullOrEmpty($sourceSlot))\n{\n\tthrow \"value for source slot must be provided\"\n}\n\n$cmdArgs = \"-g $rg -n $webAppName -s $sourceSlot\"\n\nif(![string]::IsNullOrEmpty($destinationSlot)) {$cmdArgs += \" --target-slot $destinationSlot\"}\n\n$cmd = \"az webapp deployment slot swap $cmdArgs\"\n\nwrite-verbose \"command being invoked: $cmd\"\n\nInvoke-Expression $cmd",
+      "Octopus.Action.Script.ScriptBody": "$rg = $OctopusParameters[\"Octopus.Action.Azure.ResourceGroupName\"]\n$webAppName = $OctopusParameters[\"Octopus.Action.Azure.WebAppName\"]\n$destinationSlot = $OctopusParameters[\"azWebAppSwap.targetSlot\"]\n$sourceSlot = $OctopusParameters[\"azWebAppSwap.sourceSlot\"]\n\nif([string]::IsNullOrEmpty($sourceSlot))\n{\n\tthrow \"value for source slot must be provided\"\n}\n\n$cmdArgs = \"-g $rg -n $webAppName -s $sourceSlot\"\n\nif(![string]::IsNullOrEmpty($destinationSlot)) {$cmdArgs += \" --target-slot $destinationSlot\"}\n\n$cmd = \"az webapp deployment slot swap $cmdArgs\"\n\nwrite-verbose \"command being invoked: $cmd\"\n\nInvoke-Expression $cmd",
       "Octopus.Action.Azure.AccountId": "#{azureWebAppSwap.AzAccount}"
     },
     "Parameters": [


### PR DESCRIPTION
### Step template checklist

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author


Raised in comment found here: https://github.com/OctopusDeploy/Library/commit/c913f40e158f8d7261e5b3003f8e923760657500#commitcomment-41639347

