### PR TITLE
Add LetsEncrypt - DNSimple step template

### DIFF
--- a/step-templates/letsencrypt-dnsimple.json
+++ b/step-templates/letsencrypt-dnsimple.json
@@ -1,0 +1,106 @@
+{
+    "Id": "21583723-1283-46aa-bb7b-121d365837cb",
+    "Name": "Lets Encrypt - DNSimple",
+    "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [DNSimple](https://dnsimple.com/) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [
+        
+    ],
+    "Properties":{
+        "Octopus.Action.Script.ScriptSource": "Inline",
+        "Octopus.Action.Script.Syntax": "PowerShell",
+        "Octopus.Action.Script.ScriptBody": "###############################################################################\n# TLS 1.2\n###############################################################################\n[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12\n\n###############################################################################\n# Required Modules\n###############################################################################\nWrite-Host \"Checking for required modules.\"\n\n$required_posh_acme_version = 3.12.0\n$module_check = Get-Module -ListAvailable -Name Posh-Acme | Where-Object { $_.Version -ge $required_posh_acme_version }\n\nif (-not ($module_check)) {\n    Write-Host \"Installing Posh-ACME.\"\n    Install-Module -Name Posh-ACME -MinimumVersion 3.12.0 -Scope CurrentUser -Force\n}\n\nImport-Module Posh-ACME\n\n###############################################################################\n# DebugOutput\n###############################################################################\nif ($OctopusParameters[\"LE_DNSimple_Debug_Output\"] -eq $True) {\n\tWrite-Host \"Setting DebugPreference to Continue\"\n    $DebugPreference = 'Continue'\n}\n\n###############################################################################\n# Constants\n###############################################################################\n$LE_DNSimple_Certificate_Name = \"Lets Encrypt - $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"])\"\n$LE_DNSimple_Fake_Issuer = \"Fake LE Intermediate X1\"\n$LE_DNSimple_Issuer = \"Let's Encrypt Authority X3\"\n\n###############################################################################\n# Helpers\n###############################################################################\nfunction Get-WebRequestErrorBody {\n    param (\n        $RequestError\n    )\n\n    # Powershell < 6 you can read the Exception\n    if ($PSVersionTable.PSVersion.Major -lt 6) {\n        if ($RequestError.Exception.Response) {\n            $reader = New-Object System.IO.StreamReader($RequestError.Exception.Response.GetResponseStream())\n            $reader.BaseStream.Position = 0\n            $reader.DiscardBufferedData()\n            $response = $reader.ReadToEnd()\n\n            return $response | ConvertFrom-Json\n        }\n    }\n    else {\n        return $RequestError.ErrorDetails.Message\n    }\n}\n\n###############################################################################\n# Functions\n###############################################################################\nfunction Get-LetsEncryptCertificate {\n    Write-Debug \"Entering: Get-LetsEncryptCertificate\"\n\n    if ($OctopusParameters[\"LE_DNSimple_Use_Staging\"] -eq $True) {\n        Write-Host \"Using Lets Encrypt Server: Staging\"\n        Set-PAServer LE_STAGE;\n    }\n    else {\n        Write-Host \"Using Lets Encrypt Server: Production\"\n        Set-PAServer LE_PROD;\n    }\n\n    # Clobber account if it exists.\n    $le_account = Get-PAAccount\n    if ($le_account) {\n        Remove-PAAccount $le_account.Id -Force\n    }\n\n\t$dnsimple_args = @{}\n    # DNSimple requires a token. If it's windows, Secure-String is supported.\n    if ($IsWindows -and 'Desktop' -eq $PSEdition) {\n        $token = ConvertTo-SecureString -String $OctopusParameters[\"LE_DNSimple_Token\"] -AsPlainText -Force\n    \t$dnsimple_args = @{\n        \tDSToken = $token\n    \t}\n    }\n    else {\n    \t$token = $OctopusParameters[\"LE_DNSimple_Token\"]\n    \t$dnsimple_args = @{\n        \tDSTokenInsecure = $token\n    \t}\n    }\n       \n    try {\n        return New-PACertificate -Domain $OctopusParameters[\"LE_DNSimple_CertificateDomain\"] -AcceptTOS -Contact $OctopusParameters[\"LE_DNSimple_ContactEmailAddress\"] -DnsPlugin DNSimple -PluginArgs $dnsimple_args -PfxPass $OctopusParameters[\"LE_DNSimple_PfxPassword\"] -Force\n    }\n    catch {\n        Write-Host \"Failed to Create Certificate. Error Message: $($_.Exception.Message). See Debug output for details.\"\n        Write-Debug (Get-WebRequestErrorBody -RequestError $_)\n        exit 1\n    }\n}\n\nfunction Get-OctopusCertificates {\n    Write-Debug \"Entering: Get-OctopusCertificates\"\n\n    $octopus_uri = $OctopusParameters[\"Octopus.Web.ServerUri\"]\n    $octopus_space_id = $OctopusParameters[\"Octopus.Space.Id\"]\n    $octopus_headers = @{ \"X-Octopus-ApiKey\" = $OctopusParameters[\"LE_DNSimple_Octopus_APIKey\"] }\n    $octopus_certificates_uri = \"$octopus_uri/api/$octopus_space_id/certificates?search=$($OctopusParameters[\"LE_DNSimple_CertificateDomain\"])\"\n\n    try {\n        # Get a list of certificates that match our domain search criteria.\n        $certificates_search = Invoke-WebRequest -Uri $octopus_certificates_uri -Method Get -Headers $octopus_headers -UseBasicParsing -ErrorAction Stop | ConvertFrom-Json | Select-Object -ExpandProperty Items\n\n        # We don't want to confuse Production and Staging Lets Encrypt Certificates.\n        $issuer = $LE_DNSimple_Issuer\n        if ($OctopusParameters[\"LE_DNSimple_Use_Staging\"] -eq $True) {\n            $issuer = $LE_DNSimple_Fake_Issuer\n        }\n\n        return $certificates_search | Where-Object {\n            $_.SubjectCommonName -eq $OctopusParameters[\"LE_DNSimple_CertificateDomain\"] -and\n            $_.IssuerCommonName -eq $issuer -and\n            $null -eq $_.ReplacedBy -and\n            $null -eq $_.Archived\n        }\n    }\n    catch {\n        Write-Host \"Could not retrieve certificates from Octopus Deploy. Error: $($_.Exception.Message). See Debug output for details.\"\n        Write-Debug (Get-WebRequestErrorBody -RequestError $_)\n        exit 1\n    }\n}\n\nfunction Publish-OctopusCertificate {\n    param (\n        [string] $JsonBody\n    )\n\n    Write-Debug \"Entering: Publish-OctopusCertificate\"\n\n    if (-not ($JsonBody)) {\n        Write-Host \"Existing Certificate is required.\"\n        exit 1\n    }\n\n    $octopus_uri = $OctopusParameters[\"Octopus.Web.ServerUri\"]\n    $octopus_space_id = $OctopusParameters[\"Octopus.Space.Id\"]\n    $octopus_headers = @{ \"X-Octopus-ApiKey\" = $OctopusParameters[\"LE_DNSimple_Octopus_APIKey\"] }\n    $octopus_certificates_uri = \"$octopus_uri/api/$octopus_space_id/certificates\"\n\n    try {\n        Invoke-WebRequest -Uri $octopus_certificates_uri -Method Post -Headers $octopus_headers -Body $JsonBody -UseBasicParsing\n        Write-Host \"Published $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) certificate to the Octopus Deploy Certificate Store.\"\n    }\n    catch {\n        Write-Host \"Failed to publish $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) certificate. Error: $($_.Exception.Message). See Debug output for details.\"\n        Write-Debug (Get-WebRequestErrorBody -RequestError $_)\n        exit 1\n    }\n}\n\nfunction Update-OctopusCertificate {\n    param (\n        [string]$Certificate_Id,\n        [string]$JsonBody\n    )\n\n    Write-Debug \"Entering: Update-OctopusCertificate\"\n\n    if (-not ($Certificate_Id -and $JsonBody)) {\n        Write-Host \"Existing Certificate Id and a replace Certificate are required.\"\n        exit 1\n    }\n\n    $octopus_uri = $OctopusParameters[\"Octopus.Web.ServerUri\"]\n    $octopus_space_id = $OctopusParameters[\"Octopus.Space.Id\"]\n    $octopus_headers = @{ \"X-Octopus-ApiKey\" = $OctopusParameters[\"LE_DNSimple_Octopus_APIKey\"] }\n    $octopus_certificates_uri = \"$octopus_uri/api/$octopus_space_id/certificates/$Certificate_Id/replace\"\n\n    try {\n        Invoke-WebRequest -Uri $octopus_certificates_uri -Method Post -Headers $octopus_headers -Body $JsonBody -UseBasicParsing\n        Write-Host \"Replaced $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) certificate in the Octopus Deploy Certificate Store.\"\n    }\n    catch {\n        Write-Error \"Failed to replace $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) certificate. Error: $($_.Exception.Message)\"\n        exit 1\n    }\n}\n\nfunction Get-NewCertificatePFXAsJson {\n    param (\n        $Certificate\n    )\n\n    Write-Debug \"Entering: Get-NewCertificatePFXAsJson\"\n\n    if (-not ($Certificate)) {\n        Write-Host \"Certificate is required.\"\n        Exit 1\n    }\n\n    [Byte[]]$certificate_buffer = [System.IO.File]::ReadAllBytes($Certificate.PfxFullChain)\n    $certificate_base64 = [convert]::ToBase64String($certificate_buffer)\n\n    $certificate_body = @{\n        Name            = \"$LE_DNSimple_Certificate_Name\";\n        Notes           = \"\";\n        CertificateData = @{\n            HasValue = $true;\n            NewValue = $certificate_base64;\n        };\n        Password        = @{\n            HasValue = $true;\n            NewValue = $OctopusParameters[\"LE_DNSimple_PfxPassword\"];\n        };\n    }\n\n    return $certificate_body | ConvertTo-Json\n}\n\nfunction Get-ReplaceCertificatePFXAsJson {\n    param (\n        $Certificate\n    )\n\n    Write-Debug \"Entering: Get-ReplaceCertificatePFXAsJson\"\n\n    if (-not ($Certificate)) {\n        Write-Host \"Certificate is required.\"\n        Exit 1\n    }\n\n    [Byte[]]$certificate_buffer = [System.IO.File]::ReadAllBytes($Certificate.PfxFullChain)\n    $certificate_base64 = [convert]::ToBase64String($certificate_buffer)\n\n    $certificate_body = @{\n        CertificateData = $certificate_base64;\n        Password        = $OctopusParameters[\"LE_DNSimple_PfxPassword\"];\n    }\n\n    return $certificate_body | ConvertTo-Json\n}\n\n###############################################################################\n# DO THE THING | MAIN |\n###############################################################################\nWrite-Debug \"Do the Thing\"\n\nWrite-Host \"Checking for existing Lets Encrypt Certificates in the Octopus Deploy Certificates Store.\"\n$certificates = Get-OctopusCertificates\n\n# Check for PFX & PEM\nif ($certificates) {\n\n    # Handle weird behavior between Powershell 5 and Powershell 6+\n    $certificate_count = 1\n    if ($certificates.Count -ge 1) {\n        $certificate_count = $certificates.Count\n    }\n\n    Write-Host \"Found $certificate_count for $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]).\"\n    Write-Host \"Checking to see if any expire within $($OctopusParameters[\"LE_DNSimple_ReplaceIfExpiresInDays\"]) days.\"\n\n    # Check Expiry Dates\n    $expiring_certificates = $certificates | Where-Object { [DateTime]$_.NotAfter -lt (Get-Date).AddDays($OctopusParameters[\"LE_DNSimple_ReplaceIfExpiresInDays\"]) }\n\n    if ($expiring_certificates) {\n        Write-Host \"Found certificates that expire with $($OctopusParameters[\"LE_DNSimple_ReplaceIfExpiresInDays\"]) days. Requesting new certificates for $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) from Lets Encrypt\"\n        $le_certificate = Get-LetsEncryptCertificate\n\n        # PFX\n        $existing_certificate = $certificates | Where-Object { $_.CertificateDataFormat -eq \"Pkcs12\" } | Select-Object -First 1\n        $certificate_as_json = Get-ReplaceCertificatePFXAsJson -Certificate $le_certificate\n        Update-OctopusCertificate -Certificate_Id $existing_certificate.Id -JsonBody $certificate_as_json\n    }\n    else {\n        Write-Host \"Nothing to do here...\"\n    }\n\n    exit 0\n}\n\n# No existing Certificates - Lets get some new ones.\nWrite-Host \"No existing certificates found for $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]).\"\nWrite-Host \"Request New Certificate for $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) from Lets Encrypt\"\n\n# New Certificate..\n$le_certificate = Get-LetsEncryptCertificate\n\nWrite-Host \"Publishing: LetsEncrypt - $($OctopusParameters[\"LE_DNSimple_CertificateDomain\"]) (PFX)\"\n$certificate_as_json = Get-NewCertificatePFXAsJson -Certificate $le_certificate\nPublish-OctopusCertificate -JsonBody $certificate_as_json\n\nWrite-Host \"GREAT SUCCESS\"\n"
+    },
+    "Parameters": [
+        {
+            "Id": "d0984e44-0783-4ddc-8a57-8008997edb2a",
+            "Name": "LE_DNSimple_CertificateDomain",
+            "Label": "Certificate Domain",
+            "HelpText": "Domain (TLD, CNAME or Wildcard) to create a certificate for. ",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "c68389d4-17e4-491b-a6ce-ee6b09ae1579",
+            "Name": "LE_DNSimple_PfxPassword",
+            "Label": "PFX Password",
+            "HelpText": "Password to use when converting to / from PFX. ",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Sensitive"
+            }
+        },
+        {
+            "Id": "0bce1a67-4981-474d-8b93-873fa3b28712",
+            "Name": "LE_DNSimple_ReplaceIfExpiresInDays",
+            "Label": "Replace expiring certificate before N days",
+            "HelpText": "Replace the certificate if it expiries within N days",
+            "DefaultValue": "30",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "f1f25997-9733-4882-a546-ef6c76b7c7f1",
+            "Name": "LE_DNSimple_Token",
+            "Label": "DNSimple API Token",
+            "HelpText": "DNSimple API Token created from your [DNSimple account](https://github.com/rmbolger/Posh-ACME/blob/master/Posh-ACME/DnsPlugins/DNSimple-Readme.md#setup)",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Sensitive"
+            }
+        },
+        {
+            "Id": "1addd2e6-782d-4a1f-bd12-480a9dd964cd",
+            "Name": "LE_DNSimple_Octopus_APIKey",
+            "Label": "Octopus Deploy API key",
+            "HelpText": "A Octopus Deploy API key with access to change Certificates in the Certificate Store. ",
+            "DefaultValue": "",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Sensitive"
+            }
+        },
+        {
+            "Id": "ad07684b-93ea-4d65-b2a8-395e3bbfdaf8",
+            "Name": "LE_DNSimple_Use_Staging",
+            "Label": "Use Lets Encrypt Staging",
+            "HelpText": "Should the Certificate be generated using the Lets Encrypt Staging infrastructure?",
+            "DefaultValue": "false",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Checkbox"
+            }
+        },
+        {
+            "Id": "9a358e2e-07df-42d1-9f0a-04cbc800dacf",
+            "Name": "LE_DNSimple_ContactEmailAddress",
+            "Label": "Contact Email Address",
+            "HelpText": "Email Address",
+            "DefaultValue": "#{Octopus.Deployment.CreatedBy.EmailAddress}",
+            "DisplaySettings": {
+                "Octopus.ControlType": "SingleLineText"
+            }
+        },
+        {
+            "Id": "3a9e5773-9fbb-4dd4-a9c2-0f66a36b74a2",
+            "Name": "LE_DNSimple_Debug_Output",
+            "Label": "Debug Output",
+            "HelpText": "Tick this to provide debug information in the output",
+            "DefaultValue": "false",
+            "DisplaySettings": {
+                "Octopus.ControlType": "Checkbox"
+            }
+        }
+    ],
+    "LastModifiedAt": "2020-08-26T08:55:06.515Z",
+    "LastModifiedBy": "harrisonmeister",
+    "$Meta": {
+        "ExportedAt": "2020-08-26T08:55:06.515Z",
+        "OctopusVersion": "2020.4.0-rc0002",
+        "Type": "ActionTemplate"
+    },
+    "Category": "lets-encrypt"
+}


### PR DESCRIPTION
### Detail
Add new Step Template for Lets Enrcrypt using [DNSimple](https://dnsimple.com) Challenge for TLD, CNAME and Wildcard domains. 
### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

