### PR TITLE
Adding report deployment step template.

### DIFF
--- a/step-templates/testery-create-test-run.json
+++ b/step-templates/testery-create-test-run.json
@@ -1,5 +1,5 @@
 {
-  "Id": "ed901ef2-9799-4f29-90c0-e1a8e6d92a2c",
+  "Id": "9aa25d78-a90a-425e-a25d-b1e9f1bf08be",
   "Name": "Testery - Create Test Run",
   "Description": "Run tests in the Testery platform. For more information, visit https://testery.io/.",
   "ActionType": "Octopus.Script",

--- a/step-templates/testery-create-test-run.json
+++ b/step-templates/testery-create-test-run.json
@@ -1,101 +1,37 @@
 {
-  "Id": "9aa25d78-a90a-425e-a25d-b1e9f1bf08be",
+  "Id": "ed901ef2-9799-4f29-90c0-e1a8e6d92a2c",
   "Name": "Testery - Create Test Run",
   "Description": "Run tests in the Testery platform. For more information, visit https://testery.io/.",
   "ActionType": "Octopus.Script",
-  "Version": 22,
+  "Version": 23,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "echo \"Performing test run in Testery...\"\necho \"  Git Owner: ${TesteryGitOwner}\"\necho \"  Git Repo: ${TesteryGitRepo}\"\necho \"  Git Ref: ${TesteryGitReference}\"\necho \"  Testery User: ${TesteryApiUser}\"\necho \"  Testery API URL: ${TesteryApiUrl}\"\necho \"  Testery Feature Path: ${TesteryFeaturePath}\"\necho \"  Testery Environment: ${TesteryEnvironment}\"\n\n# Parameters\n$baseUrl = $TesteryApiUrl\n\n# Authenticate\n$pair = \"${TesteryApiUser}:${TesteryApiPassword}\"\n$bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)\n$base64 = [System.Convert]::ToBase64String($bytes)\n$basicAuthValue = \"Basic $base64\"\n\n$jsonHeaders = @{ \n  Authorization = $basicAuthValue;\n  \"accept\"=\"application/json\";\n}\n    \n# Create a test run.\n$request = \"{`\"owner`\":`\"${TesteryGitOwner}`\",`\"repository`\":`\"${TesteryGitRepo}`\",`\"ref`\":`\"${TesteryGitReference}`\",`\"project`\":`\"${TesteryProjectName}`\",`\"environment`\":`\"${TesteryEnvironment}`\",`\"buildId`\":`\"${TesteryBuildId}`\"}\"\necho $request\n$testRun = Invoke-WebRequest `\n\t-UseBasicParsing `\n\t-Uri \"${baseUrl}/test-run-requests-build\" `\n\t-Method \"POST\" `\n\t-Headers $jsonHeaders `\n\t-ContentType \"application/json\" `\n\t-Body ${request} | ConvertFrom-Json\n\n$testRunId = $testRun.id\n\necho \"Started test run: ${testRunId}\"\n$status = $testRun.status\nwrite-output \"Status: ${status}\";\n\n# Wait for results.\n$testRun = Invoke-WebRequest -Headers $jsonHeaders -UseBasicParsing \"${baseUrl}/test-run-results/${testRunId}\" | ConvertFrom-Json\n\nwhile(!(($testRun.status -eq \"PASS\") -or ($testRun.status -eq \"FAIL\"))) \n{\n\tsleep 5\n\twrite-output \"Polling ${baseUrl}/test-run-results/${testRunId}\"\n\t$testRun = Invoke-WebRequest -Headers $jsonHeaders -UseBasicParsing \"${baseUrl}/test-run-results/${testRunId}\" | ConvertFrom-Json\n\twrite-output $testRun.status\n}\n\nwrite-output \"Test run complete.\""
+    "Octopus.Action.Script.ScriptBody": "try {$pipCmd = get-command pip} catch {}\nif (!($pipCmd)) {\n\tFail-Step \"This step template requires Python 3.6 or greater and pip to be installed. Python is available at https://www.python.org/downloads/\"\n}\n\npip install testery --upgrade\n\nif (\"${TesteryIncludeTags}\" -eq \"\") {\n\techo testery create-test-run --git-ref \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectName}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\" --include-all-tags\n    testery create-test-run --git-ref \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectName}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\" --include-all-tags\n} else {\n\techo testery create-test-run --git-ref \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectName}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\" --include-tags \"${TesteryIncludeTags}\"\n    testery create-test-run --git-ref \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectName}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\" --include-tags \"${TesteryIncludeTags}\"\n}\n\n"
   },
   "Parameters": [
     {
-      "Id": "9dabee3c-67ad-4648-97a5-0b900bdc7e35",
-      "Name": "TesteryApiUrl",
-      "Label": "Testery API URL",
-      "HelpText": null,
-      "DefaultValue": "https://api.testery.io/api",
-      "DisplaySettings": {}
-    },
-    {
-      "Id": "c96fb499-d651-4c08-b2ce-7e180bd38514",
-      "Name": "TesteryApiUser",
-      "Label": "Testery API User",
-      "HelpText": null,
-      "DefaultValue": "",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "8092ec9b-1d4a-45b9-85a1-9f7dcf895b29",
-      "Name": "TesteryApiPassword",
-      "Label": "Testery API Password",
-      "HelpText": null,
+      "Id": "db36b837-9fe6-480f-b4f1-05cfc68bd08b",
+      "Name": "TesteryToken",
+      "Label": "Testery Token",
+      "HelpText": "Your Testery API token (found in Testery -> Settings -> Integrations -> Show API Token)",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "Sensitive"
       }
     },
     {
-      "Id": "5571493d-e508-4178-bf9f-dfdb42449903",
-      "Name": "TesteryGitOwner",
-      "Label": "Git Organization",
-      "HelpText": "The organization for the Git repository that stores the tests.",
-      "DefaultValue": "",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "af859f05-7183-42d9-8a84-2e3cbf613069",
-      "Name": "TesteryGitRepo",
-      "Label": "Git Repository",
-      "HelpText": "The repository that stores the tests.",
-      "DefaultValue": "",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "8ea41e40-0fff-4125-9222-69887771b34c",
-      "Name": "TesteryGitReference",
-      "Label": "Git Refererence",
-      "HelpText": "This is the git reference to the tests you want to run. For example, you can specify a commit hash or a branch like \"master\" or \"release/#.#.#\". It's a common pattern to reference a project variable here (e.g. #{CommitHash}).",
-      "DefaultValue": "",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "94fa0e0b-511f-4a99-a46a-84853c0ec94c",
-      "Name": "TesteryFeaturePath",
-      "Label": "Testery Feature Path",
-      "HelpText": "Path to the directory in git that has the feature files.",
-      "DefaultValue": "",
-      "DisplaySettings": {}
-    },
-    {
-      "Id": "1689c2a5-97fc-4215-b9d6-47bdd23447bd",
+      "Id": "54de434f-0fa8-4351-b59c-a790845a0f14",
       "Name": "TesteryProjectName",
-      "Label": "",
+      "Label": "Testery Project Name",
       "HelpText": "The project name for this build.",
       "DefaultValue": "",
       "DisplaySettings": {}
     },
     {
-      "Id": "7188d11b-a118-4a74-8d17-2719ff34174f",
-      "Name": "TesteryBuildId",
-      "Label": "Build ID",
-      "HelpText": "Your build id for this build.",
-      "DefaultValue": "",
-      "DisplaySettings": {}
-    },
-    {
-      "Id": "3c6c2989-282d-4922-9e2b-085217bc5964",
+      "Id": "352f0cf8-da46-4651-b7d0-3c5413d7f3e0",
       "Name": "TesteryEnvironment",
       "Label": "Testery Environment",
       "HelpText": "The environment (defined in Testery) where the tests should be run. It can be convenient to have these line up with tenant names.",
@@ -103,14 +39,47 @@
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
+    },
+    {
+      "Id": "9a9d2a9f-cd24-40a2-96b7-c6f42e489e7e",
+      "Name": "TesteryIncludeTags",
+      "Label": "Testery Include Tags",
+      "HelpText": "Comma separated list of tags for tests that should be included in the test run.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "b9d78e94-20fb-4fa5-9a9a-34cf173c8911",
+      "Name": "TesteryBuildId",
+      "Label": "Build ID",
+      "HelpText": "The build id of the project being tested, typically coming from your CI/CD. If uploading test artifacts to Testery, this build id must match.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "96cec59e-cf55-4867-87ec-bb4af80a86e3",
+      "Name": "TesteryGitReference",
+      "Label": "Git Refererence",
+      "HelpText": "This is the git reference to the tests you want to run. This value can be extracted from the packages when build info is reported to Octopus.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ae843e0f-a189-411e-94e8-cc8d92c7373a",
+      "Name": "TesteryApiUrl",
+      "Label": "Testery API URL",
+      "HelpText": "Override the default API URL for development and testing purposes. Most users of this step template will not need to modify this parameter.",
+      "DefaultValue": "https://api.testery.io/api",
+      "DisplaySettings": {}
     }
   ],
-  "SpaceId": "Spaces-1",
-  "LastModifiedBy": "harbertc",
   "$Meta": {
-    "ExportedAt": "2019-04-17T14:55:22.438Z",
-    "OctopusVersion": "2019.2.8",
+    "ExportedAt": "2020-09-29T12:34:40.540Z",
+    "OctopusVersion": "2020.4.2",
     "Type": "ActionTemplate"
   },
+  "LastModifiedBy": "harbertc",
   "Category": "testery"
 }

--- a/step-templates/testery-report-deployment.json
+++ b/step-templates/testery-report-deployment.json
@@ -1,16 +1,16 @@
 {
-  "Id": "1c32cf55-ae40-49b7-bf6f-caab01489eb8",
+  "Id": "9c85f96e-09d3-4814-948a-aef8708740b5",
   "Name": "Testery - Report Deployment",
-  "Description": "Trigger a post-deployment test run in Testery. For more info, visit https://testery.io/.",
+  "Description": "Created from step 'Testery - Report Deployment' in project 'Sample Deploy'",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.RunOnServer": "true",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "pip install testery --upgrade\ntestery create-deploy --commit \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectKey}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\"\n"
+    "Octopus.Action.Script.ScriptBody": "try {$pipCmd = get-command pip} catch {}\nif (!($pipCmd)) {\n\tFail-Step \"This step template requires Python 3.6 or greater and pip to be installed. Python is available at https://www.python.org/downloads/\"\n}\n\npip install testery --upgrade\n\necho \"Reporting deployment info to Testery...\"\ntestery create-deploy --commit \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectName}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\"\n"
   },
   "Parameters": [
     {
@@ -33,9 +33,9 @@
     },
     {
       "Id": "4873b6f2-694a-463f-928a-9845b044bc8b",
-      "Name": "TesteryProjectKey",
-      "Label": "Testery Project Key",
-      "HelpText": "The key of the test project in the Testery platform.",
+      "Name": "TesteryProjectName",
+      "Label": "Testery Project Name",
+      "HelpText": "The name of the test project in the Testery platform.",
       "DefaultValue": "",
       "DisplaySettings": {}
     },
@@ -43,7 +43,7 @@
       "Id": "811352ba-a3e4-4092-99c2-b48499b9a880",
       "Name": "TesteryEnvironment",
       "Label": "Testery Environment",
-      "HelpText": "The name of the environment defined in Testery where you want the tests to run. It may be useful to set this to Octopus.Deployment.Tenant.Name or Octopus.Environment.Name.",
+      "HelpText": "The name of the environment defined in Testery where you want the tests to run. It may be useful to set this to Octopus.Deployment.Tenant.Name.",
       "DefaultValue": "",
       "DisplaySettings": {}
     },
@@ -57,8 +57,8 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2020-09-22T18:49:13.693Z",
-    "OctopusVersion": "2020.4.0",
+    "ExportedAt": "2020-09-29T12:37:12.701Z",
+    "OctopusVersion": "2020.4.2",
     "Type": "ActionTemplate"
   },
   "LastModifiedBy": "harbertc",

--- a/step-templates/testery-report-deployment.json
+++ b/step-templates/testery-report-deployment.json
@@ -1,0 +1,66 @@
+{
+  "Id": "1c32cf55-ae40-49b7-bf6f-caab01489eb8",
+  "Name": "Testery - Report Deployment",
+  "Description": "Trigger a post-deployment test run in Testery. For more info, visit https://testery.io/.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "pip install testery --upgrade\ntestery create-deploy --commit \"${TesteryGitReference}\" --token \"${TesteryToken}\" --project \"${TesteryProjectKey}\" --environment \"${TesteryEnvironment}\" --build-id \"${TesteryBuildId}\"\n"
+  },
+  "Parameters": [
+    {
+      "Id": "f96b7529-7ced-4265-8176-972ec30b9bba",
+      "Name": "TesteryGitReference",
+      "Label": "Testery Git Reference",
+      "HelpText": "The git hash of the commit for the version of the tests to be run.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "f01f917a-b2c8-4038-be1c-b2355639f57e",
+      "Name": "TesteryToken",
+      "Label": "Testery Token",
+      "HelpText": "Your Testery API token (found in Testery -> Settings -> Integrations -> Show API Token)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "4873b6f2-694a-463f-928a-9845b044bc8b",
+      "Name": "TesteryProjectKey",
+      "Label": "Testery Project Key",
+      "HelpText": "The key of the test project in the Testery platform.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "811352ba-a3e4-4092-99c2-b48499b9a880",
+      "Name": "TesteryEnvironment",
+      "Label": "Testery Environment",
+      "HelpText": "The name of the environment defined in Testery where you want the tests to run. It may be useful to set this to Octopus.Deployment.Tenant.Name or Octopus.Environment.Name.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    },
+    {
+      "Id": "7a6aa01f-13a1-4fa7-a681-7f0acda63932",
+      "Name": "TesteryBuildId",
+      "Label": "Testery Build Id",
+      "HelpText": "The build ID from your CI/CD. If you have uploaded any test artifacts from your CI/CD, this build id should match the build id used when uploading artifacts.",
+      "DefaultValue": "",
+      "DisplaySettings": {}
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2020-09-22T18:49:13.693Z",
+    "OctopusVersion": "2020.4.0",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harbertc",
+  "Category": "testery"
+}


### PR DESCRIPTION
### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [N/A] If a new `Category` has been created:
   - [N/A] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [N/A] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
