### PR TITLE
Include tenant name in message title for tenanted deployments

### DIFF
--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -26,7 +26,7 @@
       "Name": "Title",
       "Label": "Message title",
       "HelpText": "The title of the message that will be posted to your Microsoft Teams channel.",
-      "DefaultValue": "#{Octopus.Project.Name} #{Octopus.Release.Number} deployed to #{Octopus.Environment.Name}",
+      "DefaultValue": "#{Octopus.Project.Name} #{Octopus.Release.Number} deployed to #{Octopus.Environment.Name}#{if Octopus.Deployment.Tenant.Id} for #{Octopus.Deployment.Tenant.Name}#{/if}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       },

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -66,10 +66,10 @@
       "Links": {}
     }
   ],
-  "LastModifiedBy": "KennethBates",
+  "LastModifiedBy": "jakobehn",
   "$Meta": {
-    "ExportedAt": "2017-04-10T19:26:28.092Z",
-    "OctopusVersion": "3.12.1",
+    "ExportedAt": "2020-10-15T08:14:40.030Z",
+    "OctopusVersion": "2020.4.0",
     "Type": "ActionTemplate"
   },
   "Category": "microsoft-teams"

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -3,7 +3,7 @@
   "Name": "Microsoft Teams - Post a message",
   "Description": "Posts a message to Microsoft Teams using a general webhook.",
   "ActionType": "Octopus.Script",
-  "Version": 15,
+  "Version": 16,
   "Properties": {
     "Octopus.Action.Script.ScriptBody": "[int]$timeoutSec = $null\nif(-not [int]::TryParse($OctopusParameters['Timeout'], [ref]$timeoutSec)) { $timeoutSec = 60 }\n\n$payload = @{\n    title = $OctopusParameters['Title']\n    text = $OctopusParameters['Body'];\n    themeColor = $OctopusParameters['Color'];\n}\n\nInvoke-RestMethod -Method POST -Uri $OctopusParameters['HookUrl'] -Body ($payload | ConvertTo-Json -Depth 4) -ContentType 'application/json; charset=utf-8' -TimeoutSec $timeoutSec",
     "Octopus.Action.Script.Syntax": "PowerShell",


### PR DESCRIPTION
When deploying to multiple tenants, all notifications are identical. This change adds the name of the tenant to the title of the notification, if it's a tenanted deployment.

Sample title (for a tenanted deployment):
Project 1,2,3 deployed to Production for Tenant
