### PR TITLE
Allow SecurityProtocol TLS, TLS 1.1 and TLS 1.2 for Invoke-WebRequest

### DIFF
--- a/step-templates/epplus-register-dll-gac.json
+++ b/step-templates/epplus-register-dll-gac.json
@@ -3,13 +3,13 @@
     "Name": "Register EPPlus DLL in the GAC",
     "Description": "This script registers EPPlus dll to the GAC",
     "ActionType": "Octopus.Script",
-    "Version": 1,
+    "Version": 2,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
       "Octopus.Action.Script.ScriptSource": "Inline",
       "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::Load(\"System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\")\n\nfunction Expand-ZIPFile($file, $destination)\n{\n    $shell = new-object -com shell.application\n    $zip = $shell.NameSpace($file)\n    foreach($item in $zip.items())\n    {\n        $shell.Namespace($destination).copyhere($item)\n    }\n}\n\n$TempFolder = \"\\TempNupkg\"\n$ExpandedFolder = \"\\expanded\"\n\n$FileDestinationPath = $RegisteringDllFolderPath + \"\\\" + $DllName \n$FileSourcePath = $RegisteringDllFolderPath + $TempFolder + $ExpandedFolder + $DllPathInExpanded + \"\\\" + $DllName\n\n$TempPath = $RegisteringDllFolderPath + $TempFolder\n$NupkgPath = $RegisteringDllFolderPath + $TempFolder + \"\\temp.zip\"\n$ExpandedTempPath = $RegisteringDllFolderPath + $TempFolder + $ExpandedFolder\n\n$DllUrl = \"https://www.nuget.org/api/v2/package/\"+ $PackageName +\"/\" + $PackageVersion\n\nif (!(Test-Path $ExpandedTempPath -PathType Container)) {\n    New-Item -ItemType Directory -Force -Path $ExpandedTempPath\n}\n\nWrite-Host \"Dowloading package ...\"\nInvoke-WebRequest -Uri $DllUrl -OutFile $NupkgPath\n\nWrite-Host \"Expanding Archive ...\"\nExpand-ZIPFile –File $NupkgPath –Destination $ExpandedTempPath\n\nWrite-Host \"Copying to destination folder ...\"\nCopy-Item $FileSourcePath -Destination $FileDestinationPath\n\nRemove-Item -Recurse -Force $TempPath\nWrite-Host \"Deleteing temp folders ...\"\n\nWrite-Host \"Library Found\"\n\n#Note that you should be running PowerShell as an Administrator\nWrite-Host \"Installing to GAC ...\"\n$publish = New-Object System.EnterpriseServices.Internal.Publish\n$publish.GacInstall($fileDestinationPath)\nWrite-Host \"Installed to GAC\""
+      "Octopus.Action.Script.ScriptBody": "[System.Reflection.Assembly]::Load(\"System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a\")\n\nfunction Expand-ZIPFile($file, $destination)\n{\n    $shell = new-object -com shell.application\n    $zip = $shell.NameSpace($file)\n    foreach($item in $zip.items())\n    {\n        $shell.Namespace($destination).copyhere($item)\n    }\n}\n\n$TempFolder = \"\\TempNupkg\"\n$ExpandedFolder = \"\\expanded\"\n\n$FileDestinationPath = $RegisteringDllFolderPath + \"\\\" + $DllName \n$FileSourcePath = $RegisteringDllFolderPath + $TempFolder + $ExpandedFolder + $DllPathInExpanded + \"\\\" + $DllName\n\n$TempPath = $RegisteringDllFolderPath + $TempFolder\n$NupkgPath = $RegisteringDllFolderPath + $TempFolder + \"\\temp.zip\"\n$ExpandedTempPath = $RegisteringDllFolderPath + $TempFolder + $ExpandedFolder\n\n$DllUrl = \"https://www.nuget.org/api/v2/package/\"+ $PackageName +\"/\" + $PackageVersion\n\nif (!(Test-Path $ExpandedTempPath -PathType Container)) {\n    New-Item -ItemType Directory -Force -Path $ExpandedTempPath\n}\n\nWrite-Host \"Allow SecurityProtocol TLS, TLS 1.1 and TLS 1.2 ...\"\n[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls -bor [Net.SecurityProtocolType]::Tls11 -bor [Net.SecurityProtocolType]::Tls12\nWrite-Host \"Dowloading package ...\"\nInvoke-WebRequest -Uri $DllUrl -OutFile $NupkgPath\n\nWrite-Host \"Expanding Archive ...\"\nExpand-ZIPFile –File $NupkgPath –Destination $ExpandedTempPath\n\nWrite-Host \"Copying to destination folder ...\"\nCopy-Item $FileSourcePath -Destination $FileDestinationPath\n\nRemove-Item -Recurse -Force $TempPath\nWrite-Host \"Deleteing temp folders ...\"\n\nWrite-Host \"Library Found\"\n\n#Note that you should be running PowerShell as an Administrator\nWrite-Host \"Installing to GAC ...\"\n$publish = New-Object System.EnterpriseServices.Internal.Publish\n$publish.GacInstall($fileDestinationPath)\nWrite-Host \"Installed to GAC\""
     },
     "Parameters": [
       {
@@ -63,10 +63,10 @@
         }
       }
     ],
-    "LastModifiedBy": "suxstellino",
+    "LastModifiedBy": "fabiozanella",
     "$Meta": {
-        "ExportedAt": "2019-04-18T14:08:10.232Z",
-        "OctopusVersion": "2018.10.5",
+        "ExportedAt": "2020-11-03T09:07:40.202Z",
+        "OctopusVersion": "2020.4.5",
         "Type": "ActionTemplate"
       },
     "Category": "dll"    


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it


