### PR TITLE
[Fix] Set Feed Ids to null to prevent validation error in non-default spaces

### DIFF
--- a/spec/step-template-validation-tests.js
+++ b/spec/step-template-validation-tests.js
@@ -128,7 +128,6 @@ describe('step-templates', function() {
 
       templateFiles.forEach(function (templateFile) {
         fs.readFile(dirname + templateFile, 'utf-8', function (err, content) {
-          console.log(templateFile);
           if (err) {
             fail('error reading file ' + templateFile + ': ' + err);
           }
@@ -138,7 +137,6 @@ describe('step-templates', function() {
               return;
             } else {
                 template.Packages.forEach(function (pkg) {
-                console.log('FeedId ' + pkg.FeedId);
                 if (pkg.FeedId === null) return; // null ok
                 if (pkg.FeedId[0] === '#') return; // variables ok
                 if (pkg.FeedId !== null) {

--- a/spec/step-template-validation-tests.js
+++ b/spec/step-template-validation-tests.js
@@ -58,7 +58,6 @@ describe('step-templates', function() {
         return;
       }
 
-
       var templateFiles =  results.filter(function(file) { return file.substr(-5) === '.json'; });
       stepTemplateCount = templateFiles.length;
 
@@ -108,6 +107,57 @@ describe('step-templates', function() {
 
       var otherThings =  results.filter(function(file) { return file.substr(-5) !== '.json' && file !== 'logos' && file !== 'tests'; });
       expect(otherThings).toEqual([]);
+      done();
+    });
+  });
+
+  it('do not set a non-variable package feedId', function(done) {
+    var fs = require('fs');
+
+    var dirname = './step-templates/';
+
+    fs.readdir(dirname, function (err, results) {
+      if (err) {
+        console.log('error listing files in dir: ' + err);
+        return;
+      }
+
+      var templateFiles = results.filter(function (file) {
+        return file.substr(-5) === '.json';
+      });
+
+      templateFiles.forEach(function (templateFile) {
+        fs.readFile(dirname + templateFile, 'utf-8', function (err, content) {
+          console.log(templateFile);
+          if (err) {
+            fail('error reading file ' + templateFile + ': ' + err);
+          }
+          try {
+            var template = JSON.parse(content);
+            if (template.Packages === undefined || template.Packages.length === 0) {
+              return;
+            } else {
+                template.Packages.forEach(function (pkg) {
+                console.log('FeedId ' + pkg.FeedId);
+                if (pkg.FeedId === null) return; // null ok
+                if (pkg.FeedId[0] === '#') return; // variables ok
+                if (pkg.FeedId !== null) {
+                    fail(`Package FeedId for ${templateFile} should be null, but was: ${pkg.FeedId}`);
+                }
+              });
+            }
+          } catch (e) {
+            fail(
+              'error reading file ' +
+                dirname +
+                templateFile +
+                ': ' +
+                e +
+                ' - it might be UTF 8 with a BOM. Please resave without the BOM.'
+            );
+          }
+        });
+      });
       done();
     });
   });

--- a/step-templates/aws-deploy-lambda.json
+++ b/step-templates/aws-deploy-lambda.json
@@ -10,7 +10,7 @@
         "Id": "8dbae499-5aa8-438e-a2fe-ae29fb8f0a39",
         "Name": "AWS.Lambda.Package",
         "PackageId": null,
-        "FeedId": "feeds-builtin",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "False",

--- a/step-templates/aws-deploy-lambda.json
+++ b/step-templates/aws-deploy-lambda.json
@@ -3,7 +3,7 @@
     "Name": "AWS - Deploy Lambda Function",
     "Description": "Deploys a Zip file to an AWS Lambda function.  \n\nThis step does **not** perform variable substitution (it used to).  It takes the .zip file from the specified feed and uploads it to AWS as is.  The recommended approach to changing a lambda configuration per environment is to use [environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)  \n\nThis step uses the following AWS CLI commands to deploy the AWS Lambda.  You will be required to install the AWS CLI on your server/worker for this to work.  The AWS CLI is pre-installed on the [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools) in Octopus Cloud as well as the provided docker containers for [Execution Containers](https://octopus.com/docs/deployment-process/execution-containers-for-workers).\n\n- [create-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html)\n- [get-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/get-function.html)\n- [update-function-code](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-code.html)\n- [update-functions-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-configuration.html)\n\nThis step template is worker-friendly, you can pass in a package reference rather than having to reference a previous step which downloaded the package. This step requires **Octopus Deploy 2019.10.0** or higher.",
     "ActionType": "Octopus.AwsRunScript",
-    "Version": 3,
+    "Version": 4,
     "CommunityActionTemplateId": null,
     "Packages": [
       {

--- a/step-templates/azure-load-appsettings-from-file.json
+++ b/step-templates/azure-load-appsettings-from-file.json
@@ -10,7 +10,7 @@
       "Id": "31f79f978a2e46f9b3add02f695e672b",
       "Name": "LoadAppSettingsFromFile.Package",
       "PackageId": "#{Parameters.PackageId}",
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True"

--- a/step-templates/azure-load-appsettings-from-file.json
+++ b/step-templates/azure-load-appsettings-from-file.json
@@ -3,7 +3,7 @@
   "Name": "Azure Website - Load App Settings From File (Geta)",
   "Description": "Loads app settings from a json file (e.g. local.settings.json) which is also json-transformed to inject environment-specific values.",
   "ActionType": "Octopus.AzurePowerShell",
-  "Version": 6,
+  "Version": 7,
   "CommunityActionTemplateId": null,
   "Packages": [
     {

--- a/step-templates/firebase-deploy.json
+++ b/step-templates/firebase-deploy.json
@@ -10,7 +10,7 @@
             "Id": "343306b7-6997-429f-9ed5-4214ca4d32ac",
             "Name": "FirebaseDeploy.Package",
             "PackageId": null,
-            "FeedId": "feeds-builtin",
+            "FeedId": null,
             "AcquisitionLocation": "Server",
             "Properties": {
                 "Extract": "True",

--- a/step-templates/firebase-deploy.json
+++ b/step-templates/firebase-deploy.json
@@ -3,7 +3,7 @@
     "Name": "Firebase - Deploy",
     "Description": "Deploys the contents of a package to a Firebase project using the [Firebase CLI deploy command](https://firebase.google.com/docs/cli/#deployment).",
     "ActionType": "Octopus.Script",
-    "Version": 1,
+    "Version": 2,
     "CommunityActionTemplateId": null,
     "Packages": [
         {

--- a/step-templates/flyway-info-bash.json
+++ b/step-templates/flyway-info-bash.json
@@ -3,7 +3,7 @@
   "Name": "Flyway Info from a referenced package - Bash",
   "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/flyway-info-bash.json
+++ b/step-templates/flyway-info-bash.json
@@ -10,7 +10,7 @@
       "Id": "69db0748-ec8d-42a2-bf8f-84f6161ce571",
       "Name": "FlyWayPackage",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/flyway-info.json
+++ b/step-templates/flyway-info.json
@@ -3,7 +3,7 @@
   "Name": "Flyway Info from a referenced package",
   "Description": "Display migration state using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/flyway-info.json
+++ b/step-templates/flyway-info.json
@@ -10,7 +10,7 @@
       "Id": "78529e7d-498d-4490-92d7-1f0929bbd923",
       "Name": "FlyWayPackage",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/flyway-migrate-bash.json
+++ b/step-templates/flyway-migrate-bash.json
@@ -10,7 +10,7 @@
       "Id": "a4894287-dc06-4d8c-89d1-752635fb5328",
       "Name": "FlyWayPackage",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/flyway-migrate-bash.json
+++ b/step-templates/flyway-migrate-bash.json
@@ -3,7 +3,7 @@
   "Name": "Flyway Migrate - Bash",
   "Description": "Deploy a database using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "Author": "twerhti",
   "Packages": [
     {

--- a/step-templates/flyway-migrate-referenced-package.json
+++ b/step-templates/flyway-migrate-referenced-package.json
@@ -3,7 +3,7 @@
   "Name": "Flyway Migrate from a referenced package",
   "Description": "Deploy a database using Flyway from a referenced package.  Variable substitution for the SQL folder is built into the template",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/flyway-migrate-referenced-package.json
+++ b/step-templates/flyway-migrate-referenced-package.json
@@ -10,7 +10,7 @@
       "Id": "91fc30bd-0259-4631-950f-eff921ee910f",
       "Name": "FlyWayPackage",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/ftp-uploadfiles-package.json
+++ b/step-templates/ftp-uploadfiles-package.json
@@ -8,7 +8,7 @@
   "Packages": [
     {
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/ftp-uploadfiles-package.json
+++ b/step-templates/ftp-uploadfiles-package.json
@@ -3,7 +3,7 @@
   "Name": "Upload files by FTP from package",
   "Description": "Upload files to a remote server via File Transfer Protocol (SFTP or FTP) using WinSCP.\n\nThis step template uses the [WinSCP .NET Assembly](http://winscp.net/eng/docs/library#downloading_and_installing_the_assembly).  In the absence of WinSCP installed on the machine, it will attempt to make use of the WinSCP PowerShell module, downloading a temporary copy if not already present. \n\n# Notes on usage\n\nThis version uses a referenced package parameter and is able to be run on a Worker.\n\n## Cleaning up deployments\n\nIf you aren't deploying to an application host and don't want the deployment files to persist on the tentacle irrespective of the life cycle retention policy ensure that you set the \"Delete Previous Deployment\" to `true` and they will be removed.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/liquibase-apply-changeset.json
+++ b/step-templates/liquibase-apply-changeset.json
@@ -8,7 +8,7 @@
     "Packages": [
       {
         "PackageId": null,
-        "FeedId": "feeds-builtin",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True",
@@ -34,7 +34,7 @@
         "DisplaySettings": {
           "Octopus.ControlType": "SingleLineText"
         }
-      },  
+      },
       {
         "Id": "4477651b-2b6d-4352-a1bd-9b9e46c31c75",
         "Name": "liquibaseDatabaseType",
@@ -113,7 +113,7 @@
         "HelpText": "Add additional parameters to the connection string URL. Example: ?useUnicode=true",
         "DefaultValue": "",
         "DisplaySettings": {}
-      },      
+      },
       {
         "Id": "1d907292-d8c6-4afc-bc26-34125b1f66ec",
         "Name": "liquibaseClassPath",

--- a/step-templates/liquibase-apply-changeset.json
+++ b/step-templates/liquibase-apply-changeset.json
@@ -3,7 +3,7 @@
     "Name": "Liquibase - Apply changeset",
     "Description": "Deploy database updates using Liquibase.  You can include Liquibase in the package itself or choose Download to download it during runtime.  Use the `Report only?` option to output the SQL it will run and upload it as an Artifact.  NOTE: `Report only?` does not work with NoSQL databases such as MongoDB",
     "ActionType": "Octopus.Script",
-    "Version": 8,
+    "Version": 9,
     "Author": "twerthi",
     "Packages": [
       {

--- a/step-templates/redgate-deploy-database-release-worker-friendly.json
+++ b/step-templates/redgate-deploy-database-release-worker-friendly.json
@@ -10,7 +10,7 @@
         "Id": "cbac673c-43fb-4f6f-8204-31597bb57077",
         "Name": "DLMAutomationPackageName",
         "PackageId": null,
-        "FeedId": "Feeds-1041",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True",

--- a/step-templates/redgate-deploy-database-release-worker-friendly.json
+++ b/step-templates/redgate-deploy-database-release-worker-friendly.json
@@ -3,7 +3,7 @@
     "Name": "Redgate - Deploy from Database Release (Worker Friendly)",
     "Description": "Uses the deployment resources from the 'Redgate - Create Database Release' step to deploy the database changes using Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage).\n\nRequires SQL Change Automation version 3.0.2 or later.\n\n*Version date: 2019-07-26*\n\nThis step template is worker friendly, you can pass in a package reference rather than having to reference a previous step which downloaded the package. This step requires Octopus Deploy **2019.10.0** or higher.",
     "ActionType": "Octopus.Script",
-    "Version": 3,
+    "Version": 4,
     "Author": "octopusbob",
     "Packages": [
       {

--- a/step-templates/redgate-deploy-from-package-worker-friendly.json
+++ b/step-templates/redgate-deploy-from-package-worker-friendly.json
@@ -10,7 +10,7 @@
       "Id": "8ec6200a-24c9-4273-bdcc-5ff46ce3111f",
       "Name": "DLMAutomation.Package.Name",
       "PackageId": null,
-      "FeedId": "Feeds-1110",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/redgate-deploy-from-package-worker-friendly.json
+++ b/step-templates/redgate-deploy-from-package-worker-friendly.json
@@ -3,7 +3,7 @@
   "Name": "Redgate - Deploy from Package (Worker Friendly)",
   "Description": "Uses Redgate's [SQL Change Automation](http://www.red-gate.com/sca/productpage) to deploy a package containing a database schema to a SQL Server database, without a review step.\n\nRequires SQL Change Automation version 3.0.2 or later.\n\n*Version date: 2020-04-09*\n\nThis step template is worker friendly, you can pass in a package reference rather than having to reference a previous step which downloaded the package. This step requires Octopus Deploy **2019.10.0** or higher.\n",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "CommunityActionTemplateId": null,
   "Packages": [
     {

--- a/step-templates/roundhouse-database-migration.json
+++ b/step-templates/roundhouse-database-migration.json
@@ -10,7 +10,7 @@
         "Id": "249cd84b-2e41-4001-8222-f1a60f9a50ea",
         "Name": "roundhousePackage",
         "PackageId": null,
-        "FeedId": "feeds-builtin",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True",

--- a/step-templates/roundhouse-database-migration.json
+++ b/step-templates/roundhouse-database-migration.json
@@ -3,7 +3,7 @@
     "Name": "RoundhousE Database Migrations",
     "Description": "Database migrations using RoundhousE.",
     "ActionType": "Octopus.Script",
-    "Version": 3,
+    "Version": 4,
     "Author": "twerthi",
     "Packages": [
       {

--- a/step-templates/snowchange-deploy-scripts.json
+++ b/step-templates/snowchange-deploy-scripts.json
@@ -3,7 +3,7 @@
   "Name": "Snowchange - Deploy Scripts",
   "Description": "[Snowchange](https://github.com/jamesweakley/snowchange#overview) is a Python script that applies migration scripts to [Snowflake](https://www.snowflake.com/) systems.\n\n**Dependencies:**\nThis step is a PowerShell script which requires Python (and pip) to run.\nFor the scripts package, ensure scripts follow the [naming convention](https://github.com/jamesweakley/snowchange#script-naming) presribed by SnowChange, which uses the Flyway naming convention.\n\n**Activities:**\n* Uses pip to update itself and install `wheel` and `snowflake-connector-python`.\n* If a path to Snowchange.py is not provided, retrieves the latest version of the file from Github.\n* Generates a process-level environment variable, `SNOWSQL_PWD`, which Snowchange requires in order to function.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [
     {

--- a/step-templates/snowchange-deploy-scripts.json
+++ b/step-templates/snowchange-deploy-scripts.json
@@ -10,7 +10,7 @@
       "Id": "4d8e376e-2736-4b9d-bae5-074c07748e85",
       "Name": "SnowChangeDeploySnowflakeScriptsPackage",
       "PackageId": null,
-      "FeedId": "Feeds-1021",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/sql-deploy-dacpac-package-variable.json
+++ b/step-templates/sql-deploy-dacpac-package-variable.json
@@ -10,7 +10,7 @@
       "Id": "edff7d94-0feb-48a9-8185-48feb084a94f",
       "Name": "DACPACPackage",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/sql-deploy-dacpac-package-variable.json
+++ b/step-templates/sql-deploy-dacpac-package-variable.json
@@ -3,7 +3,7 @@
   "Name": "SQL - Deploy DACPAC from Package Parameter",
   "Description": "Calls the DacFX library to perform SSDT commands such as:\n * Deploy\n * Script\n * DeployReport\n\nBased on community step template \"SQL - Deploy DACPAC\" but now utilises the in-step package reference, so a previous package retrieval and extraction step is no longer required. \n\nRequires a second package containing the DacFX library. An existing package can be found at [https://www.nuget.org/packages/Microsoft.Data.Tools.Msbuild](https://www.nuget.org/packages/Microsoft.Data.Tools.Msbuild/).\n\nIf selected the deploy script and deploy report will be loaded back into Octopus Deploy as an artifact. This allows you to put in place a manual intervention step if required. It is also useful for auditing purposes.\n\nSqlCmd variables are now supported.  To specify SqlCmd variables, create your Octopus variable with the following naming convention: SqlCmdVariable.<Variable name> (case insensitive) and then assign it a value.  Examples:\n* SqlCmdVariable.Variable1\n* my.sqlcmdvariable.variable2\n\nNOTE: Requires version 2019.10 or above.",
   "ActionType": "Octopus.Script",
-  "Version": 3,
+  "Version": 4,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/ssis-deploy-ispac-from-package-parameter.json
+++ b/step-templates/ssis-deploy-ispac-from-package-parameter.json
@@ -3,7 +3,7 @@
   "Name": "Deploy ispac SSIS project from a Package parameter",
   "Description": "This step template will deploy SSIS ispac projects to SQL Server Integration Services Catalog.  The template uses a referenced package and is Worker compatible.\n\nThis template will install the Nuget package provider if it is not present on the machine it is running on.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Author": "twerthi",
   "Packages": [
     {

--- a/step-templates/ssis-deploy-ispac-from-package-parameter.json
+++ b/step-templates/ssis-deploy-ispac-from-package-parameter.json
@@ -10,7 +10,7 @@
       "Id": "5ce9da08-a4ed-4b69-92d1-ab88c705cf08",
       "Name": "SSIS.Template.ssisPackageId",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/ssrs-deploy-from-package-parameter.json
+++ b/step-templates/ssrs-deploy-from-package-parameter.json
@@ -3,7 +3,7 @@
     "Name": "Deploy SSRS Reports from a package parameter",
     "Description": "Uploads SSRS reports to an SSRS server from a NuGet package.\n\nThe following Datasource properties can be overidden: ConnectionString, Username and Password.  To override the property, create a Variable using the syntax of DatasourceName.PropertyName.  For example: MyDatasource.Username \n\nTo specify the Username and Password are Windows Credentials, create a variable called DatasourceName.WindowsCredentials and set the value to the string value 'true' (minus the quotes).",
     "ActionType": "Octopus.Script",
-    "Version": 2,
+    "Version": 3,
     "Author": "twerthi",
     "Packages": [
       {

--- a/step-templates/ssrs-deploy-from-package-parameter.json
+++ b/step-templates/ssrs-deploy-from-package-parameter.json
@@ -10,7 +10,7 @@
         "Name": "SSRSPackage",
         "Id": "5f4c7059-081e-44d7-bfea-6b9a90c4e77c",
         "PackageId": null,
-        "FeedId": "feeds-builtin",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True",
@@ -179,7 +179,7 @@
     ],
     "$Meta": {
       "ExportedAt": "2021-01-27T23:24:01.623Z",
-      "OctopusVersion": "2020.5.5",  
+      "OctopusVersion": "2020.5.5",
       "Type": "ActionTemplate"
     },
     "LastModifiedBy": "twerthi",


### PR DESCRIPTION
Fixes: https://github.com/OctopusDeploy/Issues/issues/6733

Summary: When a community step template defines a package feed id, if a use tries to copy this template in a non-default space, a validation error will most likely be produced since it is unlikely that the feed Id will exist in another users space. This includes using the default space default feed Id when in a non-default space.

Setting the package feed Id is not necessary, so this PR sets the package feed Ids in all templates where a variable is not used to null.