### PR TITLE
Updated StatusCake step template to include help text

### DIFF
--- a/step-templates/statuscake-maintenance-window.json
+++ b/step-templates/statuscake-maintenance-window.json
@@ -3,7 +3,7 @@
   "Name": "StatusCake Maintenance Window",
   "Description": "Creates a maintenance window in Status Cake for a given set of tests.",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
@@ -38,7 +38,7 @@
       "Id": "e210df57-ac9a-41bb-8f95-51b2595b190d",
       "Name": "StatusCake.Name",
       "Label": "Name",
-      "HelpText": null,
+      "HelpText": "Description to be shown in StatusCake for the maintenance window.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -48,15 +48,17 @@
       "Id": "3a9c7c6b-e07a-471c-91b4-ad827581a770",
       "Name": "StatusCake.TestIds",
       "Label": "Test IDs",
-      "HelpText": null,
+      "HelpText": "Comma separated list of StatusCake Test IDs.",
       "DefaultValue": "",
-      "DisplaySettings": {}
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
     {
       "Id": "e6c36ebb-73c4-4eda-95f6-cee06d93baad",
       "Name": "StatusCake.Timezone",
       "Label": "Timezone",
-      "HelpText": null,
+      "HelpText": "Timezone the maintenance window is defined in.",
       "DefaultValue": "UTC",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
@@ -67,7 +69,7 @@
       "Id": "e6b909fa-80f5-440c-9c9e-6851455dd3ff",
       "Name": "StatusCake.Length",
       "Label": "Length",
-      "HelpText": null,
+      "HelpText": "Amount of time in minutes that the maintenance window should remain active.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -75,8 +77,8 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2021-01-04T04:32:53.345Z",
-    "OctopusVersion": "2020.5.3",
+    "ExportedAt": "2021-03-15T06:00:28.045Z",
+    "OctopusVersion": "2020.6.4688",
     "Type": "ActionTemplate"
   },
   "LastModifiedBy": "svenkle",


### PR DESCRIPTION
### Step template checklist

- [ X ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ X ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ X ] Parameter names should not start with `$`
- [ X ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ X ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ X ] If a new `Category` has been created:
   - [ X ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ X ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it