### PR TITLE
Flyway execution containers

### DIFF
--- a/step-templates/flyway-database-migrations.json
+++ b/step-templates/flyway-database-migrations.json
@@ -1,160 +1,221 @@
 {
-    "Id": "80def6d7-7e38-4e34-8461-689da6842150",
-    "Name": "Flyway Database Migrations",
-    "Description": "Step template to leverage Flyway to deploy migration scripts.  This is the latest and greatest flyway step template that leverages all the newest features of both Flyway and Octopus Deploy.\n\n- You can include the flyway executables in your package, if you include the flyway or flyway.cmd in the root of the package this step template will automatically find them.\n- You can use this with an execution container, negating the need to include flyway in the package. If flyway isn't found in the package it will attempt to find /flyway/flyway and use that.\n- Support for migrate, info, repair, validate and undo commands\n- Support for flyway teams edition.  The info command will generate a .SQL file for the dry run, rather than JSON file.  Undo command only works with the flyway teams edition.\n\nPlease note this requires Octopus Deploy **2019.10.0** or newer along with PowerShell Core installed on the machines running this step.",
-    "ActionType": "Octopus.Script",
-    "Version": 1,
-    "CommunityActionTemplateId": null,
-    "Packages": [
-      {
-        "Name": "Flyway.Package.Value",
-        "Id": "0c0d333c-d794-4a16-a3a2-4bbba4550763",
-        "PackageId": null,
-        "FeedId": "Feeds-1141",
-        "AcquisitionLocation": "Server",
-        "Properties": {
-          "Extract": "True",
-          "SelectionMode": "deferred",
-          "PackageParameterName": "Flyway.Package.Value"
-        }
+  "Id": "ccebac39-79a8-4ab4-b55f-19ea570d9ebc",
+  "Name": "Flyway Database Migrations",
+  "Description": "Step template to leverage Flyway to deploy migration scripts.  This is the latest and greatest Flyway step template that leverages all the newest features of both Flyway and Octopus Deploy.\n\n- You can include the flyway executables in your package, if you include the `flyway` (Linux) or `flyway.cmd` (Windows) in the root of the package this step template will automatically find them.\n- You can use this with an execution container, negating the need to include Flyway in the package. If Flyway isn't found in the package it will attempt to find `/flyway/flyway` (when using Linux containers) or `flyway` in the environment path and use that.\n- Support for all Flyway commands, including the `undo` command.\n- Support for flyway community, teams, enterprise, and pro editions.  \n\nPlease note this requires Octopus Deploy **2019.10.0** or newer along with PowerShell Core installed on the machines running this step.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,  
+  "Packages": [
+    {
+      "Name": "Flyway.Package.Value",
+      "Id": "0c0d333c-d794-4a16-a3a2-4bbba4550763",
+      "PackageId": null,
+      "FeedId": "Feeds-1141",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "Flyway.Package.Value"
       }
-    ],
-    "Properties": {
-      "Octopus.Action.Script.ScriptSource": "Inline",
-      "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\nfunction Get-FlywayExecutablePath\n{\n\tparam (\n    \t$providedPath\n    )\n    \n    if ([string]::IsNullOrWhiteSpace($providedPath) -eq $false)\n    {\n    \tWrite-Host \"The executable path was provided, testing to see if it is absolute or relative\"\n\t\tif ([IO.Path]::IsPathRooted($providedPath))\n        {\n        \tWrite-Host \"The provided path is absolute, using that\"\n            \n        \treturn $providedPath\n        }\n        \n        Write-Host \"The provided path was relative, combining $(Get-Location) with $providedPath\"\n        return Join-Path $(Get-Location) $providedPath\n    }\n    \n    Write-Host \"Checking to see if we are currently running on Linux\"\n    if ($IsLinux)    \n    {\n    \tWrite-Host \"Currently running on Linux\"\n    \tWrite-Host \"Checking to see if flyway was included with the package\"\n    \tif (Test-Path \"./flyway\")\n        {\n        \tWrite-Host \"It was, using that version of flyway\"\n        \treturn \"flyway\"\n        }\n        \n        Write-Host \"Testing to see if we are on an execution container with /flyway/flyway as the path\"\n    \tif (Test-Path \"/flyway/flyway\")\n        {\n        \tWrite-Host \"We are, using /flyway/flyway\"\n        \treturn \"/flyway/flyway\"\n        }               \n    }\n    \n    Write-Host \"Currently running on Windows\"\n    \n    Write-Host \"Testing to see if flyway.cmd was included with the package\"\n    if (Test-Path \".\\flyway.cmd\")\n    {\n    \tWrite-Host \"It was, using that version.\"\n    \treturn \".\\flyway.cmd\"\n    }\n    \n    Write-Host \"Testing to see if flyway can be found in the env path\"\n    if ((Get-Command \"flyway\" -ErrorAction SilentlyContinue) -ne $null)\n    {\n    \tWrite-Host \"The flyway folder is part of the environment path\"\n        return \"flyway\"\n    }\n    \n    Fail-Step \"Unable to find flyway executable.  Please include it as part of the package, or provide the path to it.\"\n}\n\n# Declaring the path to the NuGet package\n$flywayPackagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway.Package.Value].ExtractedPath\"]\n$flywayUrl = $OctopusParameters[\"Flyway.Target.Url\"]\n$flywayUser = $OctopusParameters[\"Flyway.Database.User\"]\n$flywayUserPassword = $OctopusParameters[\"Flyway.Database.User.Password\"]\n$flywayCommand = $OctopusParameters[\"Flyway.Command.Value\"]\n$flywayLicenseKey = $OctopusParameters[\"Flyway.License.Key\"]\n$flywayExecutablePath = $OctopusParameters[\"Flyway.Executable.Path\"]\n$flywaySchemas = $OctopusParameters[\"Flyway.Command.Schemas\"]\n$flywayTarget = $OctopusParameters[\"Flyway.Command.Target\"]\n$flywayInfoSinceDate = $OctopusParameters[\"Flyway.Command.InfoSinceDate\"]\n$flywayInfoSinceVersion = $OctopusParameters[\"Flyway.Command.InfoSinceVersion\"]\n$flywayLicensedEdition = $OctopusParameters[\"Flyway.License.Version\"]\n\nif ([string]::IsNullOrWhiteSpace($flywayLicenseKey) -eq $false -and $flywayLicensedEdition -eq \"community\")\n{\n\tWrite-Warning \"License key was specified with the Licensed Edition specified as community.  Changing to teams.  To stop this warning update the Licensed Edition parameter to be something other than community.\"\n\t$flywayLicensedEdition = \"teams\"\n}\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"PackagePath: $flywayPackagePath\"\nWrite-Host \"Flyway Executable Path: $flywayExecutablePath\"\nWrite-Host \"Flyway Command: $flywayCommand\"\nWrite-Host \"Flyway Licensed Edition: $flywayLicensedEdition\"\nWrite-Host \"-url: $flywayUrl\"\nWrite-Host \"-user: $flywayUser\"\nWrite-Host \"-schemas: $flywaySchemas\"\nWrite-Host \"-target: $flywayTarget\"\nWrite-Host \"-infoSinceDate: $flywayInfoSinceDate\"\nWrite-Host \"-infoSinceVersion: $flywayInfoSinceVersion\"\nWrite-Host \"*******************************************\"\n\nWrite-Host \"Setting execution location to: $flywayPackagePath\"\nSet-Location $flywayPackagePath\n\n$flywayCmd = Get-FlywayExecutablePath -providedPath $flywayExecutablePath\n\n$commandToUse = $flywayCommand\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$commandToUse = \"migrate\"\n}\n\n$arguments = @(\n\t$commandToUse,\n    \"-url=`\"$flywayUrl`\"\"\n)\n\nif ([string]::IsNullOrWhiteSpace($flywayUser) -eq $false)\n{\n\tWrite-Host \"User provided, adding user and password command line argument\"\n\t$arguments += \"-user=`\"$flywayUser`\"\"\n    $arguments += \"-password=`\"$flywayUserPassword`\"\"\n}\n\nif ([string]::IsNullOrWhiteSpace($flywaySchemas) -eq $false)\n{\n\tWrite-Host \"Schemas provided, adding schemas command line argument\"\n\t$arguments += \"-schemas=`\"$flywaySchemas`\"\"    \n}\n\nif ([string]::IsNullOrWhiteSpace($flywayTarget) -eq $false)\n{\n\tWrite-Host \"Target provided, adding target command line argument\"\n    \n    if ($flywayTarget.ToLower().Trim() -eq \"latest\" -and $flywayCommand -eq \"undo\")\n    {\n    \tWrite-Host \"The current target is latest, but the command is undo, changing the target to be current\"\n    \t$flywayTarget = \"current\"\n    }\n    \n\t$arguments += \"-target=`\"$flywayTarget`\"\"    \n}\n\nif ([string]::IsNullOrWhiteSpace($flywayLicenseKey) -eq $false)\n{\n\tWrite-Host \"License key provided, changing the edition to $flywayLicensedEdition\"\n\t$arguments += \"-licenseKey=`\"$flywayLicenseKey`\"\"    \n    $arguments += \"-$flywayLicensedEdition\"\n    \n    if ([string]::IsNullOrWhiteSpace($flywayInfoSinceDate) -eq $false -and $flywayCommand -eq \"info\")\n    {\n    \t$arguments += \"-infoSinceDate=`\"$flywayInfoSinceDate`\"\"\n    }\n    \n    if ([string]::IsNullOrWhiteSpace($flywayInfoSinceVersion) -eq $false -and $flywayCommand -eq \"info\")\n    {\n    \t$arguments += \"-infoSinceVersion=`\"$flywayInfoSinceVersion`\"\"\n    }       \n}\n\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$dryRunOutputFile = Join-Path $(Get-Location) \"dryRunOutput.sql\"\n    $arguments += \"-dryRunOutput=`\"$dryRunOutputFile`\"\"\n    \n    Write-Host \"Executing the following command: & $flywayCmd $arguments\"\n    & $flywayCmd $arguments\n    \n    $currentDate = Get-Date\n\t$currentDateFormatted = $currentDate.ToString(\"yyyyMMdd_HHmmss\")\n    $urlFormatted = $flywayUrl.SubString($flywayUrl.IndexOf(\"//\") + 2)\n    \n    New-OctopusArtifact -Path $dryRunOutputFile -Name \"$($Urlformatted)_$($currentDateFormatted)_DryRunReport.sql\"\n}\nelse\n{\n\tWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\t& $flywayCmd $arguments\n}",
-      "Octopus.Action.PowerShell.Edition": "Core",
-      "Octopus.Action.EnabledFeatures": "Octopus.Features.SelectPowerShellEditionForWindows"
-    },
-    "Parameters": [
-      {
-        "Id": "a4ba9557-61d3-4d93-99d9-9937abaded9c",
-        "Name": "Flyway.Package.Value",
-        "Label": "Flyway Package",
-        "HelpText": "**Required**\n\nThe package containing the migration scripts you want Flyway to run.  Please refer to [documentation](https://flywaydb.org/documentation/concepts/migrations) for core concepts and naming conventions.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Package"
-        }
-      },
-      {
-        "Id": "02d50d4c-02f9-44c2-8ee0-3fc69a21a165",
-        "Name": "Flyway.Executable.Path",
-        "Label": "Flyway Executable Path",
-        "HelpText": "**Optional**\n\nThe path of the flyway executable.  Can either be a relative path or an absolute path.\n\nWhen not provided, this step template will test for the following:\n\n- /flyway/flyway: when this is run in an execution container\n- flyway: the package being deployed includes flyway and is running on Linux\n- flyway.cmd: the package being deployed includes flyway and is running on Windows",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "6e6e98ae-7e57-4bf7-a280-7c4a6bc57760",
-        "Name": "Flyway.Command.Value",
-        "Label": "Flyway Command",
-        "HelpText": "**Required**\n\nThe [flyway command](https://flywaydb.org/documentation/usage/commandline/) you wish to run.\n\n- `Migrate`: Migrates the schema to the latest version\n- `Migrate Dry Run`: Does a migration dry run and saves the results to an artifact.  Must provide a Flyway Teams license for this to work.\n- `Info`: Prints the details and status information about all migrations.  \n- `Validate`: Validates applied migrations against resolved ones (on the filesystem or classpath) to detect accidental changes that may prevent the schema(s) from being recreated exactly.\n- `Undo`: Undoes the most recently applied versioned migration.  Must provide a Flyway Teams license key for this to work.\n- `Repair`: Repairs the Flyway schema history table by removing any failed migrations and realigning the checksums, descriptions and types of the applied migrations with the ones of the available migrations\n",
-        "DefaultValue": "migrate",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "migrate|Migrate\nmigrate dry run|Migrate Dry Run\ninfo|Info\nvalidate|Validate\nundo|Undo\nrepair|Repair"
-        }
-      },
-      {
-        "Id": "e648821f-221c-4b8b-85fb-654f0d7379c5",
-        "Name": "Flyway.License.Key",
-        "Label": "License Key",
-        "HelpText": "**Optional**\n\nThe [Flyway Teams](https://flywaydb.org/download) license key will enable undo functionality as well as the ability to dry run a migration.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "658a18d4-c0e0-432e-bc27-76efa56c4983",
-        "Name": "Flyway.License.Version",
-        "Label": "Licensed Edition",
-        "HelpText": "The edition of Flyway you are licensed for.  The default is `Community`.  If you provide a license key with `Community` set as the value it will switch over to `Teams`.",
-        "DefaultValue": "community",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "community|Community\npro|Pro\nenterprise|Enterprise\nteams|Teams"
-        }
-      },
-      {
-        "Id": "bb9d99ac-96b4-4d46-ae8f-87e5a7214278",
-        "Name": "Flyway.Target.Url",
-        "Label": "-Url",
-        "HelpText": "**Required**\n\nThe [URL](https://flywaydb.org/documentation/configuration/parameters/url) parameter used in Flyway.  This is the URL of the database to run the migration scripts on in the format specified in the default flyway.conf file.\n\nExamples:\n- SQL Server: `jdbc:sqlserver://host:port;databaseName=database`\n- Oracle: `jdbc:oracle:thin:@//host:port/service` or `jdbc:oracle:thin:@tns_entry`\n- MySQL: `jdbc:mysql://host:port/database`\n- PostgreSQL: `jdbc:postgresql://host:port/database`\n- SQLite: `jdbc:sqlite:database`\n\nPlease refer to [documentation](https://flywaydb.org/documentation/database/sqlserver) for further examples.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "e1cb49a8-b965-4827-9f8e-01724d263541",
-        "Name": "Flyway.Database.User",
-        "Label": "-User",
-        "HelpText": "**Optional**\n\nThe [user](https://flywaydb.org/documentation/configuration/parameters/user) used to connect to the database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "51fab335-82b2-4e58-8d4a-e2640ba66296",
-        "Name": "Flyway.Database.User.Password",
-        "Label": "-Password",
-        "HelpText": "**Optional**\n\nThe [password](https://flywaydb.org/documentation/configuration/parameters/password) used to connect to the database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "f8787222-c404-47ca-9f0f-32fad6c656e7",
-        "Name": "Flyway.Command.Schemas",
-        "Label": "-Schemas",
-        "HelpText": "**Optional**\n\nComma-separated case-sensitive list of [schemas](https://flywaydb.org/documentation/configuration/parameters/schemas) managed by Flyway. \n\nExample: `schema1,schema2`\n\nFlyway will attempt to create these schemas if they do not already exist and will clean them in the order of this list. If Flyway created them, then the schemas themselves will be dropped when cleaning.\n\nThe first schema in the list will act as the default schema.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "27a4fafe-8e8b-4d6d-b25a-0953535ef2c9",
-        "Name": "Flyway.Command.Target",
-        "Label": "-Target",
-        "HelpText": "**Required**\n\nThe [target version](https://flywaydb.org/documentation/configuration/parameters/target) up to which Flyway should consider migrations. If set to a value other than current or latest, this must be a valid migration version (e.g. `2.1`).\n\nWhen migrating forwards, Flyway will apply all migrations up to and including the target version. Migrations with a higher version number will be ignored. If the target is `current`, then no versioned migrations will be applied but repeatable migrations will be, together with any callbacks.\n\nWhen undoing migrations, Flyway will apply all undo scripts up to and including the target version. Undo scripts with a lower version number will be ignored. Specifying a target version should be done with care, as undo scripts typically destroy database objects.\n\nSpecial Values:\n- `current`: designates the current version of the schema\n- `latest`: the latest version of the schema, as defined by the migration with the highest version\n\nDefault is: `latest`.  When running the `undo` command, this will switch to `current` if `latest` is supplied.",
-        "DefaultValue": "latest",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "3703d1da-1750-4c4f-89ba-04f5297ba0b9",
-        "Name": "Flyway.Command.InfoSinceDate",
-        "Label": "-InfoSinceDate",
-        "HelpText": "**Optional**\n\nOnly works with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  \n\nLimits info to show only migrations applied after this date, and any unapplied migrations. Must be in the format `dd/MM/yyyy HH:mm` (e.g. `01/12/2020 13:00`)",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "0bfecdcd-ad27-4908-949c-a54745aa85f0",
-        "Name": "Flyway.Command.InfoSinceVersion",
-        "Label": "-InfoSinceVersion",
-        "HelpText": "**Optional**\n\nOnly works with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  \n\nLimits info to show only migrations greater than or equal to this version, and any repeatable migrations. (e.g `1.1`)",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\nfunction Get-FlywayExecutablePath\n{\n\tparam (\n    \t$providedPath\n    )\n    \n    if ([string]::IsNullOrWhiteSpace($providedPath) -eq $false)\n    {\n    \tWrite-Host \"The executable path was provided, testing to see if it is absolute or relative\"\n\t\tif ([IO.Path]::IsPathRooted($providedPath))\n        {\n        \tWrite-Host \"The provided path is absolute, using that\"\n            \n        \treturn $providedPath\n        }\n        \n        Write-Host \"The provided path was relative, combining $(Get-Location) with $providedPath\"\n        return Join-Path $(Get-Location) $providedPath\n    }\n    \n    Write-Host \"Checking to see if we are currently running on Linux\"\n    if ($IsLinux)    \n    {\n    \tWrite-Host \"Currently running on Linux\"\n    \tWrite-Host \"Checking to see if flyway was included with the package\"\n    \tif (Test-Path \"./flyway\")\n        {\n        \tWrite-Host \"It was, using that version of flyway\"\n        \treturn \"flyway\"\n        }\n        \n        Write-Host \"Testing to see if we are on an execution container with /flyway/flyway as the path\"\n    \tif (Test-Path \"/flyway/flyway\")\n        {\n        \tWrite-Host \"We are, using /flyway/flyway\"\n        \treturn \"/flyway/flyway\"\n        }               \n    }\n    \n    Write-Host \"Currently running on Windows\"\n    \n    Write-Host \"Testing to see if flyway.cmd was included with the package\"\n    if (Test-Path \".\\flyway.cmd\")\n    {\n    \tWrite-Host \"It was, using that version.\"\n    \treturn \".\\flyway.cmd\"\n    }\n    \n    Write-Host \"Testing to see if flyway can be found in the env path\"\n    if ((Get-Command \"flyway\" -ErrorAction SilentlyContinue) -ne $null)\n    {\n    \tWrite-Host \"The flyway folder is part of the environment path\"\n        return \"flyway\"\n    }\n    \n    Fail-Step \"Unable to find flyway executable.  Please include it as part of the package, or provide the path to it.\"\n}\n\nfunction Test-AddParameterToCommandline\n{\n\tparam (\n    \t$acceptedCommands,\n        $selectedCommand,\n        $parameterValue,\n        $defaultValue,\n        $parameterName\n    )\n    \n    if ([string]::IsNullOrWhiteSpace($parameterValue) -eq $true)\n    {    \t\n    \tWrite-Verbose \"$parameterName is empty, returning false\"\n    \treturn $false\n    }\n    \n    if ([string]::IsNullOrWhiteSpace($defaultValue) -eq $false -and $parameterValue.ToLower().Trim() -eq $defaultValue.ToLower().Trim())\n    {\n    \tWrite-Verbose \"$parameterName is matches the default value, returning false\"\n    \treturn $false\n    }\n    \n    if ([string]::IsNullOrWhiteSpace($acceptedCommands) -eq $true -or $acceptedCommands -eq \"any\")\n    {\n    \tWrite-Verbose \"$parameterName has a value and this is for any command, returning true\"\n    \treturn $true\n    }\n    \n    $acceptedCommandArray = $acceptedCommands -split \",\"\n    foreach ($command in $acceptedCommandArray)\n    {\n    \tif ($command.ToLower().Trim() -eq $selectedCommand.ToLower().Trim())\n        {\n        \tWrite-Verbose \"$parameterName has a value and the current command $selectedCommand matches the accepted command $command, returning true\"\n        \treturn $true\n        }\n    }\n    \n    Write-Verbose \"$parameterName has a value but is not accepted in the current command, returning false\"\n    return $false\n}\n\n# Declaring the path to the NuGet package\n$flywayPackagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway.Package.Value].ExtractedPath\"]\n$flywayUrl = $OctopusParameters[\"Flyway.Target.Url\"]\n$flywayUser = $OctopusParameters[\"Flyway.Database.User\"]\n$flywayUserPassword = $OctopusParameters[\"Flyway.Database.User.Password\"]\n$flywayCommand = $OctopusParameters[\"Flyway.Command.Value\"]\n$flywayLicenseKey = $OctopusParameters[\"Flyway.License.Key\"]\n$flywayExecutablePath = $OctopusParameters[\"Flyway.Executable.Path\"]\n$flywaySchemas = $OctopusParameters[\"Flyway.Command.Schemas\"]\n$flywayTarget = $OctopusParameters[\"Flyway.Command.Target\"]\n$flywayInfoSinceDate = $OctopusParameters[\"Flyway.Command.InfoSinceDate\"]\n$flywayInfoSinceVersion = $OctopusParameters[\"Flyway.Command.InfoSinceVersion\"]\n$flywayLicensedEdition = $OctopusParameters[\"Flyway.License.Version\"]\n$flywayCherryPick = $OctopusParameters[\"Flyway.Command.CherryPick\"]\n$flywayOutOfOrder = $OctopusParameters[\"Flyway.Command.OutOfOrder\"]\n$flywaySkipExecutingMigrations = $OctopusParameters[\"Flyway.Command.SkipExecutingMigrations\"]\n$flywayPlaceHolders = $OctopusParameters[\"Flyway.Command.PlaceHolders\"]\n$flywayBaseLineVersion = $OctopusParameters[\"Flyway.Command.BaselineVersion\"]\n$flywayBaselineDescription = $OctopusParameters[\"Flyway.Command.BaselineDescription\"]\n\nif ([string]::IsNullOrWhiteSpace($flywayLicenseKey) -eq $false -and $flywayLicensedEdition -eq \"community\")\n{\n\tWrite-Warning \"License key was specified with the Licensed Edition specified as community.  Changing to teams.  To stop this warning update the Licensed Edition parameter to be something other than community.\"\n\t$flywayLicensedEdition = \"teams\"\n}\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"PackagePath: $flywayPackagePath\"\nWrite-Host \"Flyway Executable Path: $flywayExecutablePath\"\nWrite-Host \"Flyway Command: $flywayCommand\"\nWrite-Host \"Flyway Licensed Edition: $flywayLicensedEdition\"\nWrite-Host \"-url: $flywayUrl\"\nWrite-Host \"-user: $flywayUser\"\nWrite-Host \"-schemas: $flywaySchemas\"\nWrite-Host \"-target: $flywayTarget\"\nWrite-Host \"-cherryPick: $flywayCherryPick\"\nWrite-Host \"-outOfOrder: $flywayOutOfOrder\"\nWrite-Host \"-skipExecutingMigrations: $flywaySkipExecutingMigrations\"\nWrite-Host \"-infoSinceDate: $flywayInfoSinceDate\"\nWrite-Host \"-infoSinceVersion: $flywayInfoSinceVersion\"\nWrite-Host \"-baselineVersion: $flywayBaselineVersion\"\nWrite-Host \"-baselineDescription: $flywayBaselineDescription\"\nWrite-Host \"placeHolders: $flywayPlaceHolders\"\nWrite-Host \"*******************************************\"\n\nWrite-Host \"Setting execution location to: $flywayPackagePath\"\nSet-Location $flywayPackagePath\n\n$flywayCmd = Get-FlywayExecutablePath -providedPath $flywayExecutablePath\n\n$commandToUse = $flywayCommand\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$commandToUse = \"migrate\"\n}\n\n$arguments = @(\n\t$commandToUse,\n    \"-url=`\"$flywayUrl`\"\"\n)\n\nWrite-Host \"Testing for parameters that can be applied to any command\"\nif (Test-AddParameterToCommandline -parameterValue $flywayUser -acceptedCommands \"any\" -selectedCommand $flywayCommand -parameterName \"-user\")\n{\n\tWrite-Host \"User provided, adding user and password command line argument\"\n\t$arguments += \"-user=`\"$flywayUser`\"\"\n    $arguments += \"-password=`\"$flywayUserPassword`\"\"\n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywaySchemas -acceptedCommands \"any\" -selectedCommand $flywayCommand -parameterName \"-schemas\")\n{\n\tWrite-Host \"Schemas provided, adding schemas command line argument\"\n\t$arguments += \"-schemas=`\"$flywaySchemas`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayLicenseKey -acceptedCommands \"any\" -selectedCommand $flywayCommand -parameterName \"-licenseKey\")\n{\n\tWrite-Host \"License key provided, changing the edition to $flywayLicensedEdition\"\n\t$arguments += \"-licenseKey=`\"$flywayLicenseKey`\"\"    \n    $arguments += \"-$flywayLicensedEdition\"              \n}\nWrite-Host \"Finished testing for parameters that can be applied to any command, moving onto command specific parameters\"\n\nif (Test-AddParameterToCommandline -parameterValue $flywayCherryPick -acceptedCommands \"migrate,info,validate\" -selectedCommand $flywayCommand -parameterName \"-cherryPick\")\n{\n\tWrite-Host \"Cherry pick provided, adding cherry pick command line argument\"\n\t$arguments += \"-cherryPick=`\"$flywayCherryPick`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayOutOfOrder -defaultValue \"false\" -acceptedCommands \"migrate,info,validate\" -selectedCommand $flywayCommand -parameterName \"-outOfOrder\")\n{\n\tWrite-Host \"Out of order is not false, adding out of order command line argument\"\n\t$arguments += \"-outOfOrder=`\"$flywayOutOfOrder`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayPlaceHolders -acceptedCommands \"migrate,info,validate,undo,repair\" -selectedCommand $flywayCommand -parameterName \"-placeHolders\")\n{\n\tWrite-Host \"Placeholder parameter provided, adding them to the command line arguments\"\n    \n    $placeHolderValueList = @(($flywayPlaceHolders -Split \"`n\").Trim())\n    foreach ($placeHolder in $placeHolderValueList)\n    {\n    \t$placeHolderSplit = $placeHolder -Split \"::\"\n        $placeHolderKey = $placeHolderSplit[0]\n        $placeHolderValue = $placeHolderSplit[1]\n        Write-Host \"Adding -placeHolders.$placeHolderKey = $placeHolderValue to the argument list\"\n        \n        $arguments += \"-placeholders.$placeHolderKey=`\"$placeHolderValue`\"\"    \n    }   \t\n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayTarget -acceptedCommands \"migrate,info,validate,undo\" -selectedCommand $flywayCommand -parameterName \"-target\")\n{\n\tWrite-Host \"Target provided, adding target command line argument\"\n\n\tif ($flywayTarget.ToLower().Trim() -eq \"latest\" -and $flywayCommand -eq \"undo\")\n\t{\n\t\tWrite-Host \"The current target is latest, but the command is undo, changing the target to be current\"\n\t\t$flywayTarget = \"current\"\n\t}\n\n\t$arguments += \"-target=`\"$flywayTarget`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywaySkipExecutingMigrations -defaultValue \"false\" -acceptedCommands \"migrate\" -selectedCommand $flywayCommand -parameterName \"-skipExecutingMigrations\")\n{\n\tWrite-Host \"Skip executing migrations is not false, adding skip executing migrations command line argument\"\n\t$arguments += \"-skipExecutingMigrations=`\"$flywaySkipExecutingMigrations`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayBaselineVersion -acceptedCommands \"baseline\" -selectedCommand $flywayCommand -parameterName \"-baselineVersion\")\n{\n\tWrite-Host \"Doing a baseline, adding baseline version and description\"\n\t$arguments += \"-baselineVersion=`\"$flywayBaselineVersion`\"\"    \n    $arguments += \"-baselineDescription=`\"$flywayBaselineDescription`\"\"    \n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayInfoSinceDate -acceptedCommands \"info\" -selectedCommand $flywayCommand -parameterName \"-infoSinceDate\")\n{\n\tWrite-Host \"Info since date has been provided, adding that to the command line arguments\"\n\t$arguments += \"-infoSinceDate=`\"$flywayInfoSinceDate`\"\"\n}\n\nif (Test-AddParameterToCommandline -parameterValue $flywayInfoSinceVersion -acceptedCommands \"info\" -selectedCommand $flywayCommand -parameterName \"-infoSinceVersion\")\n{\n\tWrite-Host \"Info since version has been provided, adding that to the command line arguments\"\n\t$arguments += \"-infoSinceVersion=`\"$flywayInfoSinceVersion`\"\"\n} \n\n\nWrite-Host \"Finished checking for command specific parameters, moving onto execution\"\n\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$dryRunOutputFile = Join-Path $(Get-Location) \"dryRunOutput.sql\"\n    $arguments += \"-dryRunOutput=`\"$dryRunOutputFile`\"\"\n    \n    Write-Host \"Executing the following command: & $flywayCmd $arguments\"\n    & $flywayCmd $arguments\n    \n    $currentDate = Get-Date\n\t$currentDateFormatted = $currentDate.ToString(\"yyyyMMdd_HHmmss\")\n    $urlFormatted = $flywayUrl.SubString($flywayUrl.IndexOf(\"//\") + 2)\n    \n    New-OctopusArtifact -Path $dryRunOutputFile -Name \"$($Urlformatted)_$($currentDateFormatted)_DryRunReport.sql\"\n}\nelse\n{\n\tWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\t& $flywayCmd $arguments\n}",
+    "Octopus.Action.PowerShell.Edition": "Core",
+    "Octopus.Action.EnabledFeatures": "Octopus.Features.SelectPowerShellEditionForWindows"
+  },
+  "Parameters": [
+    {
+      "Id": "a4ba9557-61d3-4d93-99d9-9937abaded9c",
+      "Name": "Flyway.Package.Value",
+      "Label": "Flyway Package",
+      "HelpText": "**Required**\n\nThe package containing the migration scripts you want Flyway to run.  Please refer to [documentation](https://flywaydb.org/documentation/concepts/migrations) for core concepts and naming conventions.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
       }
-    ],
-    "$Meta": {
-      "ExportedAt": "2021-03-26T22:41:21.266Z",
-      "OctopusVersion": "2020.6.4688",
-      "Type": "ActionTemplate"
     },
-    "LastModifiedBy": "octopusbob",
-    "Category": "flyway"
-  }
+    {
+      "Id": "02d50d4c-02f9-44c2-8ee0-3fc69a21a165",
+      "Name": "Flyway.Executable.Path",
+      "Label": "Flyway Executable Path",
+      "HelpText": "**Optional**\n\nThe path of the flyway executable.  Can either be a relative path or an absolute path.\n\nWhen not provided, this step template will test for the following.  The step template places precedence on the version of flyway included in the package. If Flyway is NOT found in the package it will attempt to see if it is installed on the server by checking common paths.\n\nRunning on `Linux`:\n- `.flyway`: the package being deployed includes flyway and is running on Linux\n- `/flyway/flyway`: The default path for the Linux execution container.\n\nRunning on Windows:\n- `\\.flyway.cmd`: the package being deployed includes flyway and is running on Windows\n- `flyway`: the package is in the path on the Windows VM or Windows Execution container.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6e6e98ae-7e57-4bf7-a280-7c4a6bc57760",
+      "Name": "Flyway.Command.Value",
+      "Label": "Flyway Command",
+      "HelpText": "**Required**\n\nThe [flyway command](https://flywaydb.org/documentation/usage/commandline/) you wish to run.\n\n- `Migrate`: Migrates the schema to the latest version\n- `Migrate Dry Run`: Does a migration dry run and saves the results to an artifact.  Must provide a Flyway Teams license for this to work.\n- `Info`: Prints the details and status information about all migrations.  \n- `Validate`: Validates applied migrations against resolved ones (on the filesystem or classpath) to detect accidental changes that may prevent the schema(s) from being recreated exactly.\n- `Undo`: Undoes the most recently applied versioned migration.  Must provide a Flyway Teams license key for this to work.\n- `Repair`: Repairs the Flyway schema history table by removing any failed migrations and realigning the checksums, descriptions and types of the applied migrations with the ones of the available migrations\n- `Clean`: It will effectively give you a fresh start, by wiping your configured schemas completely clean. All objects (tables, views, procedures, …) will be dropped.  **DO NOT USE AGAINST A PRODUCTION DB!!!**\n- `Baseline`:  Introducing Flyway to existing databases by baselining them at a specific version. This will cause Migrate to ignore all migrations up to and including the baseline version. Newer migrations will then be applied as usual.\n",
+      "DefaultValue": "migrate",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "migrate|Migrate\nmigrate dry run|Migrate Dry Run\ninfo|Info\nvalidate|Validate\nundo|Undo\nrepair|Repair\nclean|Clean\nbaseline|Baseline"
+      }
+    },
+    {
+      "Id": "658a18d4-c0e0-432e-bc27-76efa56c4983",
+      "Name": "Flyway.License.Version",
+      "Label": "Licensed Edition",
+      "HelpText": "**Required**\n\nThe edition of Flyway you are licensed for.  If you provide a license key with `Community` set as the value it will switch over to `Teams`.\n\nThe default is `Community`. ",
+      "DefaultValue": "community",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "community|Community\npro|Pro\nenterprise|Enterprise\nteams|Teams"
+      }
+    },
+    {
+      "Id": "e648821f-221c-4b8b-85fb-654f0d7379c5",
+      "Name": "Flyway.License.Key",
+      "Label": "License Key",
+      "HelpText": "**Optional**\n\nThe [Flyway Teams](https://flywaydb.org/download) license key will enable undo functionality as well as the ability to dry run a migration.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "bb9d99ac-96b4-4d46-ae8f-87e5a7214278",
+      "Name": "Flyway.Target.Url",
+      "Label": "-Url",
+      "HelpText": "**Required**\n\nThe [URL](https://flywaydb.org/documentation/configuration/parameters/url) parameter used in Flyway.  This is the URL of the database to run the migration scripts on in the format specified in the default flyway.conf file.\n\nExamples:\n- SQL Server: `jdbc:sqlserver://host:port;databaseName=database`\n- Oracle: `jdbc:oracle:thin:@//host:port/service` or `jdbc:oracle:thin:@tns_entry`\n- MySQL: `jdbc:mysql://host:port/database`\n- PostgreSQL: `jdbc:postgresql://host:port/database`\n- SQLite: `jdbc:sqlite:database`\n\nPlease refer to [documentation](https://flywaydb.org/documentation/database/sqlserver) for further examples.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e1cb49a8-b965-4827-9f8e-01724d263541",
+      "Name": "Flyway.Database.User",
+      "Label": "-User",
+      "HelpText": "**Optional**\n\nThe [user](https://flywaydb.org/documentation/configuration/parameters/user) used to connect to the database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "51fab335-82b2-4e58-8d4a-e2640ba66296",
+      "Name": "Flyway.Database.User.Password",
+      "Label": "-Password",
+      "HelpText": "**Optional**\n\nThe [password](https://flywaydb.org/documentation/configuration/parameters/password) used to connect to the database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "f8787222-c404-47ca-9f0f-32fad6c656e7",
+      "Name": "Flyway.Command.Schemas",
+      "Label": "-Schemas",
+      "HelpText": "**Optional**\n\nComma-separated case-sensitive list of [schemas](https://flywaydb.org/documentation/configuration/parameters/schemas) managed by Flyway. \n\nExample: `schema1,schema2`\n\nFlyway will attempt to create these schemas if they do not already exist and will clean them in the order of this list. If Flyway created them, then the schemas themselves will be dropped when cleaning.\n\nThe first schema in the list will act as the default schema.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "27a4fafe-8e8b-4d6d-b25a-0953535ef2c9",
+      "Name": "Flyway.Command.Target",
+      "Label": "-Target",
+      "HelpText": "**Optional** for `migrate`, `info`, `validate`, and `undo`.  **Ignored** for all other commands\n\nThe [target version](https://flywaydb.org/documentation/configuration/parameters/target) up to which Flyway should consider migrations. If set to a value other than current or latest, this must be a valid migration version (e.g. `2.1`).\n\nWhen migrating forwards, Flyway will apply all migrations up to and including the target version. Migrations with a higher version number will be ignored. If the target is `current`, then no versioned migrations will be applied but repeatable migrations will be, together with any callbacks.\n\nWhen undoing migrations, Flyway will apply all undo scripts up to and including the target version. Undo scripts with a lower version number will be ignored. Specifying a target version should be done with care, as undo scripts typically destroy database objects.\n\nSpecial Values:\n- `current`: designates the current version of the schema\n- `latest`: the latest version of the schema, as defined by the migration with the highest version\n\nDefault is: `latest`.  When running the `undo` command, this will switch to `current` if `latest` is supplied.",
+      "DefaultValue": "latest",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1b0b700e-6686-4474-a630-8a89aea9b1d5",
+      "Name": "Flyway.Command.CherryPick",
+      "Label": "-CherryPick",
+      "HelpText": "**Optional** for `migrate`, `info`, and `validate`.  **Ignored** for all other commands.\n\nA Comma separated list of migrations that Flyway should consider when migrating, undoing, or repairing. Migrations are considered in the order that they are supplied, overriding the default ordering. Leave blank to consider all discovered migrations.\n\nEach item in the list must either be a valid migration version (e.g `2.1`) or a valid migration description (e.g. `create_table`).\n\nSee [documentation](https://flywaydb.org/documentation/configuration/parameters/cherryPick) for more details.\n\nThe default is an empty string, meaning this command-line argument will be skipped.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "79a5ed66-eae8-4b0b-89fa-5da10850bb8d",
+      "Name": "Flyway.Command.OutOfOrder",
+      "Label": "-OutOfOrder",
+      "HelpText": "**Optional** for `migrate`, `info`, and `validate`.  **Ignored** for all other commands.\n\nAllows migrations to be run “out of order”.\n\nIf you already have versions `1.0` and `3.0` applied, and now a version `2.0` is found, it will be applied too instead of being ignored.\n\nSee [documentation](https://flywaydb.org/documentation/configuration/parameters/outOfOrder) for more details.\n\nThe default is `False`.",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "true|True\nfalse|False"
+      }
+    },
+    {
+      "Id": "1d234d38-35d7-4b5e-a3fb-7ed81fa41d46",
+      "Name": "Flyway.Command.SkipExecutingMigrations",
+      "Label": "-SkipExecutingMigrations",
+      "HelpText": "**Optional** for `migrate`.  **Ignored** for all other commands.\n\nWhether Flyway should skip migration execution. The remainder of the operation will run as normal - including updating the schema history table, callbacks, and so on.\n\n`skipExecutingMigrations` essentially allows you to mimic a migration being executed, because the schema history table is still updated as normal.\n\n`skipExecutingMigrations` can be used to bring an out-of-process change into Flyway’s change control process. For instance, a script run against the database outside of Flyway (like a hotfix) can be turned into a migration. The hotfix migration can be deployed with Flyway with `skipExecutingMigrations=true`. The schema history table will be updated with the new migration, but the script itself won’t be executed again.\n\n`skipExecutingMigrations` can be used with cherryPick to skip specific migrations.\n\nSee [documentation](https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations) for more details.\n\nThe default value is `False`.",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "true|True\nfalse|False"
+      }
+    },
+    {
+      "Id": "7e00397a-e18e-44b8-bb4d-e89b7c70d760",
+      "Name": "Flyway.Command.PlaceHolders",
+      "Label": "-PlaceHolders",
+      "HelpText": "**Optional** for `migrate`, `info`, `validate`, `undo`, and `repair`.  **Ignored** for all other commands.\n\n[Placeholders](https://flywaydb.org/documentation/configuration/placeholder) to replace in SQL migrations.\n\nEach new line represents a new placeholder.  This will only work with string variable types, text and sensitive values.    \n\nImagine this SQL Script\n\n```\nINSERT INTO ${Key1} (name) VALUES ('Mr. T')\nGRANT SELECT ON SCHEMA ${flyway:defaultSchema} TO ${Key2}\n```\n\nUse the format **Name::Value**  for example:\n\n```\nKey1::My Super Awesome Value\n\nKey2::Other Super Awesome Value\n```\n\nThis will replace `${Key1}` with `My Super Awesome Value` and `${Key2}` with `Other Super Awesome Value`.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "3703d1da-1750-4c4f-89ba-04f5297ba0b9",
+      "Name": "Flyway.Command.InfoSinceDate",
+      "Label": "-InfoSinceDate",
+      "HelpText": "**Optional** with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  **Ignored** for all other commands.\n\nLimits info to show only migrations applied after this date, and any unapplied migrations. Must be in the format `dd/MM/yyyy HH:mm` (e.g. `01/12/2020 13:00`)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "0bfecdcd-ad27-4908-949c-a54745aa85f0",
+      "Name": "Flyway.Command.InfoSinceVersion",
+      "Label": "-InfoSinceVersion",
+      "HelpText": "**Optional** with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  **Ignored** for all other commands.\n\nLimits info to show only migrations greater than or equal to this version, and any repeatable migrations. (e.g `1.1`)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f7e23a32-73a8-4118-8996-354d48f176cb",
+      "Name": "Flyway.Command.BaselineVersion",
+      "Label": "-baselineVersion",
+      "HelpText": "**Required** when using `Baseline`.  **Ignored** for all other commands.\n\nThe version to tag an existing schema with when executing [baseline](https://flywaydb.org/documentation/command/baseline).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "c8a118ef-bdc4-4e2f-966b-596662321d1c",
+      "Name": "Flyway.Command.BaselineDescription",
+      "Label": "-baseLineDescription",
+      "HelpText": "**Required** when using `Baseline`.  **Ignored** for all other commands.\n\nThe Description to tag an existing schema with when executing [baseline](https://flywaydb.org/documentation/command/baseline).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2021-03-29T18:58:52.934Z",
+    "OctopusVersion": "2020.6.4688",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "OctopusBob",
+  "Category": "flyway"
+}

--- a/step-templates/flyway-database-migrations.json
+++ b/step-templates/flyway-database-migrations.json
@@ -1,0 +1,160 @@
+{
+    "Id": "80def6d7-7e38-4e34-8461-689da6842150",
+    "Name": "Flyway Database Migrations",
+    "Description": "Step template to leverage Flyway to deploy migration scripts.  This is the latest and greatest flyway step template that leverages all the newest features of both Flyway and Octopus Deploy.\n\n- You can include the flyway executables in your package, if you include the flyway or flyway.cmd in the root of the package this step template will automatically find them.\n- You can use this with an execution container, negating the need to include flyway in the package. If flyway isn't found in the package it will attempt to find /flyway/flyway and use that.\n- Support for migrate, info, repair, validate and undo commands\n- Support for flyway teams edition.  The info command will generate a .SQL file for the dry run, rather than JSON file.  Undo command only works with the flyway teams edition.\n\nPlease note this requires Octopus Deploy **2019.10.0** or newer along with PowerShell Core installed on the machines running this step.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [
+      {
+        "Name": "Flyway.Package.Value",
+        "Id": "0c0d333c-d794-4a16-a3a2-4bbba4550763",
+        "PackageId": null,
+        "FeedId": "Feeds-1141",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "deferred",
+          "PackageParameterName": "Flyway.Package.Value"
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "$VerboseActionPreference=\"Continue\"\n\nfunction Get-FlywayExecutablePath\n{\n\tparam (\n    \t$providedPath\n    )\n    \n    if ([string]::IsNullOrWhiteSpace($providedPath) -eq $false)\n    {\n    \tWrite-Host \"The executable path was provided, testing to see if it is absolute or relative\"\n\t\tif ([IO.Path]::IsPathRooted($providedPath))\n        {\n        \tWrite-Host \"The provided path is absolute, using that\"\n            \n        \treturn $providedPath\n        }\n        \n        Write-Host \"The provided path was relative, combining $(Get-Location) with $providedPath\"\n        return Join-Path $(Get-Location) $providedPath\n    }\n    \n    Write-Host \"Checking to see if we are currently running on Linux\"\n    if ($IsLinux)    \n    {\n    \tWrite-Host \"Currently running on Linux\"\n    \tWrite-Host \"Checking to see if flyway was included with the package\"\n    \tif (Test-Path \"./flyway\")\n        {\n        \tWrite-Host \"It was, using that version of flyway\"\n        \treturn \"flyway\"\n        }\n        \n        Write-Host \"Testing to see if we are on an execution container with /flyway/flyway as the path\"\n    \tif (Test-Path \"/flyway/flyway\")\n        {\n        \tWrite-Host \"We are, using /flyway/flyway\"\n        \treturn \"/flyway/flyway\"\n        }               \n    }\n    \n    Write-Host \"Currently running on Windows\"\n    \n    Write-Host \"Testing to see if flyway.cmd was included with the package\"\n    if (Test-Path \".\\flyway.cmd\")\n    {\n    \tWrite-Host \"It was, using that version.\"\n    \treturn \".\\flyway.cmd\"\n    }\n    \n    Write-Host \"Testing to see if flyway can be found in the env path\"\n    if ((Get-Command \"flyway\" -ErrorAction SilentlyContinue) -ne $null)\n    {\n    \tWrite-Host \"The flyway folder is part of the environment path\"\n        return \"flyway\"\n    }\n    \n    Fail-Step \"Unable to find flyway executable.  Please include it as part of the package, or provide the path to it.\"\n}\n\n# Declaring the path to the NuGet package\n$flywayPackagePath = $OctopusParameters[\"Octopus.Action.Package[Flyway.Package.Value].ExtractedPath\"]\n$flywayUrl = $OctopusParameters[\"Flyway.Target.Url\"]\n$flywayUser = $OctopusParameters[\"Flyway.Database.User\"]\n$flywayUserPassword = $OctopusParameters[\"Flyway.Database.User.Password\"]\n$flywayCommand = $OctopusParameters[\"Flyway.Command.Value\"]\n$flywayLicenseKey = $OctopusParameters[\"Flyway.License.Key\"]\n$flywayExecutablePath = $OctopusParameters[\"Flyway.Executable.Path\"]\n$flywaySchemas = $OctopusParameters[\"Flyway.Command.Schemas\"]\n$flywayTarget = $OctopusParameters[\"Flyway.Command.Target\"]\n$flywayInfoSinceDate = $OctopusParameters[\"Flyway.Command.InfoSinceDate\"]\n$flywayInfoSinceVersion = $OctopusParameters[\"Flyway.Command.InfoSinceVersion\"]\n$flywayLicensedEdition = $OctopusParameters[\"Flyway.License.Version\"]\n\nif ([string]::IsNullOrWhiteSpace($flywayLicenseKey) -eq $false -and $flywayLicensedEdition -eq \"community\")\n{\n\tWrite-Warning \"License key was specified with the Licensed Edition specified as community.  Changing to teams.  To stop this warning update the Licensed Edition parameter to be something other than community.\"\n\t$flywayLicensedEdition = \"teams\"\n}\n\n# Logging for troubleshooting\nWrite-Host \"*******************************************\"\nWrite-Host \"Logging variables:\"\nWrite-Host \" - - - - - - - - - - - - - - - - - - - - -\"\nWrite-Host \"PackagePath: $flywayPackagePath\"\nWrite-Host \"Flyway Executable Path: $flywayExecutablePath\"\nWrite-Host \"Flyway Command: $flywayCommand\"\nWrite-Host \"Flyway Licensed Edition: $flywayLicensedEdition\"\nWrite-Host \"-url: $flywayUrl\"\nWrite-Host \"-user: $flywayUser\"\nWrite-Host \"-schemas: $flywaySchemas\"\nWrite-Host \"-target: $flywayTarget\"\nWrite-Host \"-infoSinceDate: $flywayInfoSinceDate\"\nWrite-Host \"-infoSinceVersion: $flywayInfoSinceVersion\"\nWrite-Host \"*******************************************\"\n\nWrite-Host \"Setting execution location to: $flywayPackagePath\"\nSet-Location $flywayPackagePath\n\n$flywayCmd = Get-FlywayExecutablePath -providedPath $flywayExecutablePath\n\n$commandToUse = $flywayCommand\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$commandToUse = \"migrate\"\n}\n\n$arguments = @(\n\t$commandToUse,\n    \"-url=`\"$flywayUrl`\"\"\n)\n\nif ([string]::IsNullOrWhiteSpace($flywayUser) -eq $false)\n{\n\tWrite-Host \"User provided, adding user and password command line argument\"\n\t$arguments += \"-user=`\"$flywayUser`\"\"\n    $arguments += \"-password=`\"$flywayUserPassword`\"\"\n}\n\nif ([string]::IsNullOrWhiteSpace($flywaySchemas) -eq $false)\n{\n\tWrite-Host \"Schemas provided, adding schemas command line argument\"\n\t$arguments += \"-schemas=`\"$flywaySchemas`\"\"    \n}\n\nif ([string]::IsNullOrWhiteSpace($flywayTarget) -eq $false)\n{\n\tWrite-Host \"Target provided, adding target command line argument\"\n    \n    if ($flywayTarget.ToLower().Trim() -eq \"latest\" -and $flywayCommand -eq \"undo\")\n    {\n    \tWrite-Host \"The current target is latest, but the command is undo, changing the target to be current\"\n    \t$flywayTarget = \"current\"\n    }\n    \n\t$arguments += \"-target=`\"$flywayTarget`\"\"    \n}\n\nif ([string]::IsNullOrWhiteSpace($flywayLicenseKey) -eq $false)\n{\n\tWrite-Host \"License key provided, changing the edition to $flywayLicensedEdition\"\n\t$arguments += \"-licenseKey=`\"$flywayLicenseKey`\"\"    \n    $arguments += \"-$flywayLicensedEdition\"\n    \n    if ([string]::IsNullOrWhiteSpace($flywayInfoSinceDate) -eq $false -and $flywayCommand -eq \"info\")\n    {\n    \t$arguments += \"-infoSinceDate=`\"$flywayInfoSinceDate`\"\"\n    }\n    \n    if ([string]::IsNullOrWhiteSpace($flywayInfoSinceVersion) -eq $false -and $flywayCommand -eq \"info\")\n    {\n    \t$arguments += \"-infoSinceVersion=`\"$flywayInfoSinceVersion`\"\"\n    }       \n}\n\nif ($flywayCommand -eq \"migrate dry run\")\n{\n\t$dryRunOutputFile = Join-Path $(Get-Location) \"dryRunOutput.sql\"\n    $arguments += \"-dryRunOutput=`\"$dryRunOutputFile`\"\"\n    \n    Write-Host \"Executing the following command: & $flywayCmd $arguments\"\n    & $flywayCmd $arguments\n    \n    $currentDate = Get-Date\n\t$currentDateFormatted = $currentDate.ToString(\"yyyyMMdd_HHmmss\")\n    $urlFormatted = $flywayUrl.SubString($flywayUrl.IndexOf(\"//\") + 2)\n    \n    New-OctopusArtifact -Path $dryRunOutputFile -Name \"$($Urlformatted)_$($currentDateFormatted)_DryRunReport.sql\"\n}\nelse\n{\n\tWrite-Host \"Executing the following command: & $flywayCmd $arguments\"\n\t& $flywayCmd $arguments\n}",
+      "Octopus.Action.PowerShell.Edition": "Core",
+      "Octopus.Action.EnabledFeatures": "Octopus.Features.SelectPowerShellEditionForWindows"
+    },
+    "Parameters": [
+      {
+        "Id": "a4ba9557-61d3-4d93-99d9-9937abaded9c",
+        "Name": "Flyway.Package.Value",
+        "Label": "Flyway Package",
+        "HelpText": "**Required**\n\nThe package containing the migration scripts you want Flyway to run.  Please refer to [documentation](https://flywaydb.org/documentation/concepts/migrations) for core concepts and naming conventions.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Package"
+        }
+      },
+      {
+        "Id": "02d50d4c-02f9-44c2-8ee0-3fc69a21a165",
+        "Name": "Flyway.Executable.Path",
+        "Label": "Flyway Executable Path",
+        "HelpText": "**Optional**\n\nThe path of the flyway executable.  Can either be a relative path or an absolute path.\n\nWhen not provided, this step template will test for the following:\n\n- /flyway/flyway: when this is run in an execution container\n- flyway: the package being deployed includes flyway and is running on Linux\n- flyway.cmd: the package being deployed includes flyway and is running on Windows",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "6e6e98ae-7e57-4bf7-a280-7c4a6bc57760",
+        "Name": "Flyway.Command.Value",
+        "Label": "Flyway Command",
+        "HelpText": "**Required**\n\nThe [flyway command](https://flywaydb.org/documentation/usage/commandline/) you wish to run.\n\n- `Migrate`: Migrates the schema to the latest version\n- `Migrate Dry Run`: Does a migration dry run and saves the results to an artifact.  Must provide a Flyway Teams license for this to work.\n- `Info`: Prints the details and status information about all migrations.  \n- `Validate`: Validates applied migrations against resolved ones (on the filesystem or classpath) to detect accidental changes that may prevent the schema(s) from being recreated exactly.\n- `Undo`: Undoes the most recently applied versioned migration.  Must provide a Flyway Teams license key for this to work.\n- `Repair`: Repairs the Flyway schema history table by removing any failed migrations and realigning the checksums, descriptions and types of the applied migrations with the ones of the available migrations\n",
+        "DefaultValue": "migrate",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Select",
+          "Octopus.SelectOptions": "migrate|Migrate\nmigrate dry run|Migrate Dry Run\ninfo|Info\nvalidate|Validate\nundo|Undo\nrepair|Repair"
+        }
+      },
+      {
+        "Id": "e648821f-221c-4b8b-85fb-654f0d7379c5",
+        "Name": "Flyway.License.Key",
+        "Label": "License Key",
+        "HelpText": "**Optional**\n\nThe [Flyway Teams](https://flywaydb.org/download) license key will enable undo functionality as well as the ability to dry run a migration.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "658a18d4-c0e0-432e-bc27-76efa56c4983",
+        "Name": "Flyway.License.Version",
+        "Label": "Licensed Edition",
+        "HelpText": "The edition of Flyway you are licensed for.  The default is `Community`.  If you provide a license key with `Community` set as the value it will switch over to `Teams`.",
+        "DefaultValue": "community",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Select",
+          "Octopus.SelectOptions": "community|Community\npro|Pro\nenterprise|Enterprise\nteams|Teams"
+        }
+      },
+      {
+        "Id": "bb9d99ac-96b4-4d46-ae8f-87e5a7214278",
+        "Name": "Flyway.Target.Url",
+        "Label": "-Url",
+        "HelpText": "**Required**\n\nThe [URL](https://flywaydb.org/documentation/configuration/parameters/url) parameter used in Flyway.  This is the URL of the database to run the migration scripts on in the format specified in the default flyway.conf file.\n\nExamples:\n- SQL Server: `jdbc:sqlserver://host:port;databaseName=database`\n- Oracle: `jdbc:oracle:thin:@//host:port/service` or `jdbc:oracle:thin:@tns_entry`\n- MySQL: `jdbc:mysql://host:port/database`\n- PostgreSQL: `jdbc:postgresql://host:port/database`\n- SQLite: `jdbc:sqlite:database`\n\nPlease refer to [documentation](https://flywaydb.org/documentation/database/sqlserver) for further examples.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "e1cb49a8-b965-4827-9f8e-01724d263541",
+        "Name": "Flyway.Database.User",
+        "Label": "-User",
+        "HelpText": "**Optional**\n\nThe [user](https://flywaydb.org/documentation/configuration/parameters/user) used to connect to the database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "51fab335-82b2-4e58-8d4a-e2640ba66296",
+        "Name": "Flyway.Database.User.Password",
+        "Label": "-Password",
+        "HelpText": "**Optional**\n\nThe [password](https://flywaydb.org/documentation/configuration/parameters/password) used to connect to the database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "f8787222-c404-47ca-9f0f-32fad6c656e7",
+        "Name": "Flyway.Command.Schemas",
+        "Label": "-Schemas",
+        "HelpText": "**Optional**\n\nComma-separated case-sensitive list of [schemas](https://flywaydb.org/documentation/configuration/parameters/schemas) managed by Flyway. \n\nExample: `schema1,schema2`\n\nFlyway will attempt to create these schemas if they do not already exist and will clean them in the order of this list. If Flyway created them, then the schemas themselves will be dropped when cleaning.\n\nThe first schema in the list will act as the default schema.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "27a4fafe-8e8b-4d6d-b25a-0953535ef2c9",
+        "Name": "Flyway.Command.Target",
+        "Label": "-Target",
+        "HelpText": "**Required**\n\nThe [target version](https://flywaydb.org/documentation/configuration/parameters/target) up to which Flyway should consider migrations. If set to a value other than current or latest, this must be a valid migration version (e.g. `2.1`).\n\nWhen migrating forwards, Flyway will apply all migrations up to and including the target version. Migrations with a higher version number will be ignored. If the target is `current`, then no versioned migrations will be applied but repeatable migrations will be, together with any callbacks.\n\nWhen undoing migrations, Flyway will apply all undo scripts up to and including the target version. Undo scripts with a lower version number will be ignored. Specifying a target version should be done with care, as undo scripts typically destroy database objects.\n\nSpecial Values:\n- `current`: designates the current version of the schema\n- `latest`: the latest version of the schema, as defined by the migration with the highest version\n\nDefault is: `latest`.  When running the `undo` command, this will switch to `current` if `latest` is supplied.",
+        "DefaultValue": "latest",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "3703d1da-1750-4c4f-89ba-04f5297ba0b9",
+        "Name": "Flyway.Command.InfoSinceDate",
+        "Label": "-InfoSinceDate",
+        "HelpText": "**Optional**\n\nOnly works with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  \n\nLimits info to show only migrations applied after this date, and any unapplied migrations. Must be in the format `dd/MM/yyyy HH:mm` (e.g. `01/12/2020 13:00`)",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "0bfecdcd-ad27-4908-949c-a54745aa85f0",
+        "Name": "Flyway.Command.InfoSinceVersion",
+        "Label": "-InfoSinceVersion",
+        "HelpText": "**Optional**\n\nOnly works with the `info` command and [Flyway Teams](https://flywaydb.org/documentation/usage/commandline/info#filtering-output) edition.  \n\nLimits info to show only migrations greater than or equal to this version, and any repeatable migrations. (e.g `1.1`)",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      }
+    ],
+    "$Meta": {
+      "ExportedAt": "2021-03-26T22:41:21.266Z",
+      "OctopusVersion": "2020.6.4688",
+      "Type": "ActionTemplate"
+    },
+    "LastModifiedBy": "octopusbob",
+    "Category": "flyway"
+  }

--- a/step-templates/flyway-database-migrations.json
+++ b/step-templates/flyway-database-migrations.json
@@ -9,7 +9,7 @@
       "Name": "Flyway.Package.Value",
       "Id": "0c0d333c-d794-4a16-a3a2-4bbba4550763",
       "PackageId": null,
-      "FeedId": "Feeds-1141",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
