### PR TITLE
Added missing DisplaySettings for querystring parameter.

### DIFF
--- a/step-templates/liquibase-run-command.json
+++ b/step-templates/liquibase-run-command.json
@@ -3,7 +3,7 @@
     "Name": "Liquibase - Run command",
     "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.  ",
     "ActionType": "Octopus.Script",
-    "Version": 1,
+    "Version": 2,
     "Author": "twerthi",
     "Packages": [
       {
@@ -143,7 +143,9 @@
         "Label": "Connection query string parameters",
         "HelpText": "Add additional parameters to the connection string URL. Example: ?useUnicode=true",
         "DefaultValue": "",
-        "DisplaySettings": {}
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
       },
       {
         "Id": "8f1c2bc5-6b39-4c95-8eb0-bd97b0fe62f0",


### PR DESCRIPTION

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes bug where you cannot install template because of missing DisplaySettings for liquibaseQuerystringParameters
