### PR TITLE
Add support for putting annotations on namespaces

### DIFF
--- a/step-templates/k8s-create-serviceaccount-and-target.json
+++ b/step-templates/k8s-create-serviceaccount-and-target.json
@@ -3,14 +3,13 @@
   "Name": "Kubernetes - Create Service Account and Target",
   "Description": "Create a service account with a role granting full access to everything in the namespace, and create a Kubernetes target with the new account in Octopus",
   "ActionType": "Octopus.KubernetesRunScript",
-  "Version": 12,
+  "Version": 13,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "if ([string]::IsNullOrWhitespace($CreateK8sTargetNamespace)) {\n\tWrite-Error \"The namespace variable must be defined\"\n    exit 1\n}\n\nif ([string]::IsNullOrWhitespace($CreateK8sTargetRole)) {\n\tWrite-Error \"The role variable must be defined\"\n    exit 1\n}\n\n$target = if ([string]::IsNullOrEmpty($CreateK8sTargetName)) {\"$($CreateK8sTargetNamespace)-k8s\"} else {$CreateK8sTargetName}\n$serviceaccount = \"$($CreateK8sTargetNamespace)-deployer\"\n$rolename = \"$($CreateK8sTargetNamespace)-deployer-role\"\n$binding = \"$($CreateK8sTargetNamespace)-deployer-binding\"\n\n$count = (kubectl get namespaces -o json |\n\tConvertFrom-JSON |\n    Select-Object -ExpandProperty items |\n    ? {$_.metadata.name -eq $CreateK8sTargetNamespace}).Count\n    \nif ($count -eq 0) {\n  Set-Content -Path namespace.yaml -Value @\"\n  apiVersion: v1\n  kind: Namespace\n  metadata:\n     name: $CreateK8sTargetNamespace\n\"@\n\n  kubectl apply -f namespace.yaml\n}\n\nSet-Content -Path serviceaccount.yaml -Value @\"\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: $serviceaccount\n  namespace: $CreateK8sTargetNamespace \n---\nkind: Role\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  namespace: $CreateK8sTargetNamespace \n  name: $rolename\nrules:\n- apiGroups: [\"*\"]\n  resources: [\"*\"]\n  verbs: [\"*\"]\n---\nkind: RoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: $binding\n  namespace: $CreateK8sTargetNamespace \nsubjects:\n- kind: ServiceAccount\n  name: $serviceaccount\n  apiGroup: \"\"\nroleRef:\n  kind: Role\n  name: $rolename\n  apiGroup: \"\"\n\"@\n\nkubectl apply -f serviceaccount.yaml\n  \n$data = kubectl get secret $(kubectl get serviceaccount $serviceaccount -o jsonpath=\"{.secrets[0].name}\" --namespace=$CreateK8sTargetNamespace) -o jsonpath=\"{.data.token}\"  --namespace=$CreateK8sTargetNamespace \n$token = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($data))\n$url = (kubectl config view -o json | ConvertFrom-Json).clusters[0].cluster.server\n\nNew-OctopusTokenAccount -Name $target -token $token -updateIfExisting\n\nif ([string]::IsNullOrEmpty(\"#{Octopus.Action.Kubernetes.CertificateAuthority}\") -or \"#{Octopus.Action.Kubernetes.AksAdminLogin}\" -ieq \"True\") {\n\tNew-OctopusKubernetesTarget `\n\t\t-name $target `\n\t\t-clusterUrl $url `\n\t\t-octopusRoles $CreateK8sTargetRole `\n\t\t-octopusAccountIdOrName $target `\n\t\t-namespace $CreateK8sTargetNamespace `\n\t\t-updateIfExisting `\n\t\t-skipTlsVerification True `\n\t\t-octopusDefaultWorkerPoolIdOrName \"#{Octopus.WorkerPool.Id}\" `\n        -healthCheckContainerImageFeedIdOrName \"$CreateK8sTargetContainerImageFeed\" `\n    \t-healthCheckContainerImage \"$CreateK8sTargetContainerImage\"\n} else {\n\tNew-OctopusKubernetesTarget `\n\t\t-name $target `\n\t\t-clusterUrl $url `\n\t\t-octopusRoles $CreateK8sTargetRole `\n\t\t-octopusAccountIdOrName $target `\n\t\t-namespace $CreateK8sTargetNamespace `\n\t\t-updateIfExisting `\n        -octopusServerCertificateIdOrName \"#{Octopus.Action.Kubernetes.CertificateAuthority}\" `\n\t\t-octopusDefaultWorkerPoolIdOrName \"#{Octopus.WorkerPool.Id}\" `\n        -healthCheckContainerImageFeedIdOrName \"$CreateK8sTargetContainerImageFeed\" `\n    \t-healthCheckContainerImage \"$CreateK8sTargetContainerImage\"\n}",
-    "Octopus.Action.KubernetesContainers.Namespace": ""
+    "Octopus.Action.Script.ScriptBody": "if ([string]::IsNullOrWhitespace($CreateK8sTargetNamespace)) {\n\tWrite-Error \"The namespace variable must be defined\"\n    exit 1\n}\n\nif ([string]::IsNullOrWhitespace($CreateK8sTargetRole)) {\n\tWrite-Error \"The role variable must be defined\"\n    exit 1\n}\n\n$target = if ([string]::IsNullOrEmpty($CreateK8sTargetName)) {\"$($CreateK8sTargetNamespace)-k8s\"} else {$CreateK8sTargetName}\n$serviceaccount = \"$($CreateK8sTargetNamespace)-deployer\"\n$rolename = \"$($CreateK8sTargetNamespace)-deployer-role\"\n$binding = \"$($CreateK8sTargetNamespace)-deployer-binding\"\n\n$count = (kubectl get namespaces -o json |\n\tConvertFrom-JSON |\n    Select-Object -ExpandProperty items |\n    ? {$_.metadata.name -eq $CreateK8sTargetNamespace}).Count\n    \nif ($count -eq 0) {\n  Set-Content -Path namespace.yaml -Value @\"\n  apiVersion: v1\n  kind: Namespace\n  metadata:\n    name: $CreateK8sTargetNamespace\n\"@\n\n  if (![string]::IsNullOrWhitespace($CreateK8sTargetNamespaceAnnotations)) {\n  \tAdd-Content -Path namespace.yaml -Value @\"\n    annotations:\n\"@\n\t$annotations = ($CreateK8sTargetNamespaceAnnotations -split '\\r?\\n').Trim()\n    foreach ($annotation in $annotations) {\n        Add-Content -Path namespace.yaml -Value @\"\n      $annotation\n\"@\n    }\n  }\n\n  kubectl apply -f namespace.yaml\n}\n\nSet-Content -Path serviceaccount.yaml -Value @\"\napiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: $serviceaccount\n  namespace: $CreateK8sTargetNamespace \n---\nkind: Role\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  namespace: $CreateK8sTargetNamespace \n  name: $rolename\nrules:\n- apiGroups: [\"*\"]\n  resources: [\"*\"]\n  verbs: [\"*\"]\n---\nkind: RoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: $binding\n  namespace: $CreateK8sTargetNamespace \nsubjects:\n- kind: ServiceAccount\n  name: $serviceaccount\n  apiGroup: \"\"\nroleRef:\n  kind: Role\n  name: $rolename\n  apiGroup: \"\"\n\"@\n\nkubectl apply -f serviceaccount.yaml\n  \n$data = kubectl get secret $(kubectl get serviceaccount $serviceaccount -o jsonpath=\"{.secrets[0].name}\" --namespace=$CreateK8sTargetNamespace) -o jsonpath=\"{.data.token}\"  --namespace=$CreateK8sTargetNamespace \n$token = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($data))\n$url = (kubectl config view -o json | ConvertFrom-Json).clusters[0].cluster.server\n\nNew-OctopusTokenAccount -Name $target -token $token -updateIfExisting\n\nif ([string]::IsNullOrEmpty(\"#{Octopus.Action.Kubernetes.CertificateAuthority}\") -or \"#{Octopus.Action.Kubernetes.AksAdminLogin}\" -ieq \"True\") {\n\tNew-OctopusKubernetesTarget `\n\t\t-name $target `\n\t\t-clusterUrl $url `\n\t\t-octopusRoles $CreateK8sTargetRole `\n\t\t-octopusAccountIdOrName $target `\n\t\t-namespace $CreateK8sTargetNamespace `\n\t\t-updateIfExisting `\n\t\t-skipTlsVerification True `\n\t\t-octopusDefaultWorkerPoolIdOrName \"#{Octopus.WorkerPool.Id}\" `\n        -healthCheckContainerImageFeedIdOrName \"$CreateK8sTargetContainerImageFeed\" `\n    \t-healthCheckContainerImage \"$CreateK8sTargetContainerImage\"\n} else {\n\tNew-OctopusKubernetesTarget `\n\t\t-name $target `\n\t\t-clusterUrl $url `\n\t\t-octopusRoles $CreateK8sTargetRole `\n\t\t-octopusAccountIdOrName $target `\n\t\t-namespace $CreateK8sTargetNamespace `\n\t\t-updateIfExisting `\n        -octopusServerCertificateIdOrName \"#{Octopus.Action.Kubernetes.CertificateAuthority}\" `\n\t\t-octopusDefaultWorkerPoolIdOrName \"#{Octopus.WorkerPool.Id}\" `\n        -healthCheckContainerImageFeedIdOrName \"$CreateK8sTargetContainerImageFeed\" `\n    \t-healthCheckContainerImage \"$CreateK8sTargetContainerImage\"\n}"
   },
   "Parameters": [
     {
@@ -44,6 +43,16 @@
       }
     },
     {
+      "Id": "34a94173-611f-4cbf-b30a-66fb9456d1cf",
+      "Name": "CreateK8sTargetNamespaceAnnotations",
+      "Label": "Namespace annotations",
+      "HelpText": "An optional list of annotations to apply to the namespace",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
       "Id": "f14880f9-5a57-4469-85d7-5e68e090ed43",
       "Name": "CreateK8sTargetContainerImageFeed",
       "Label": "Container Image Feed",
@@ -65,10 +74,10 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2020-08-02T23:50:06.800Z",
-    "OctopusVersion": "2020.3.2",
+    "ExportedAt": "2021-07-22T11:26:30.753Z",
+    "OctopusVersion": "2021.1.7508",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "mcasperson",
+  "LastModifiedBy": "jmezach",
   "Category": "k8s"
 }


### PR DESCRIPTION

---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

As discussed in #1140 I had a need for adding annotations on the namespaces created by the Create Service Account and Target step template. While it was discussed to use Kustomize to facilitate this I ended up feeling that might be overkill for what I'm trying to achieve here. Honestly I don't think there's much more you would want to customize for a Kubernetes namespace except for annotations since it is fairly simple object.

Fixes #1140 


