### PR TITLE
Added version field to better control how to name the version

### DIFF
--- a/step-templates/elmahio-notify-deployment.json
+++ b/step-templates/elmahio-notify-deployment.json
@@ -3,12 +3,12 @@
   "Name": "elmah.io - Register Deployment",
   "Description": "Step template for notifying elmah.io about deployments on Octopus.",
   "ActionType": "Octopus.Script",
-  "Version": 5,
+  "Version": 6,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
-    "Octopus.Action.Script.ScriptBody": "$version = $OctopusReleaseNumber\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nTry {\n[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls\n  Invoke-RestMethod -Method Post -Uri $url -Body $body\n}\nCatch {\n  Write-Error $_.Exception.Message -ErrorAction Continue\n}",
+    "Octopus.Action.Script.ScriptBody": "$version = $OctopusParameters['Version']\n$url = 'https://api.elmah.io/v3/deployments?api_key=' + $OctopusParameters['ApiKey']\n$body = @{\n  version = $version\n  description = $OctopusReleaseNotes\n  userName = $OctopusParameters['Octopus.Deployment.CreatedBy.Username']\n  userEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n  logId = $OctopusParameters['LogId']\n}\nTry {\n[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12, [Net.SecurityProtocolType]::Tls11, [Net.SecurityProtocolType]::Tls\n  Invoke-RestMethod -Method Post -Uri $url -Body $body\n}\nCatch {\n  Write-Error $_.Exception.Message -ErrorAction Continue\n}",
     "Octopus.Action.Script.ScriptFileName": null,
     "Octopus.Action.Package.FeedId": null,
     "Octopus.Action.Package.PackageId": null
@@ -33,12 +33,22 @@
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
+    },
+    {
+      "Id": "a75169a0-f829-4ad5-ab4b-c108cf2231e5",
+      "Name": "Version",
+      "Label": "Version",
+      "HelpText": "Required: Let you input a version string to use when creating the deployment on elmah.io.",
+      "DefaultValue": "#{Octopus.Release.Number}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
   "LastModifiedBy": "thomasardal",
   "$Meta": {
-    "ExportedAt": "2017-02-08T11:36:00.000+00:00",
-    "OctopusVersion": "3.4.13",
+    "ExportedAt": "2021-09-03T08:34:01.363Z",
+    "OctopusVersion": "2021.2.7428",
     "Type": "ActionTemplate"
   },
   "Category": "elmah"


### PR DESCRIPTION
This is a minor addition to the existing step template to better control how to name the version when creating the deployment on elmah.io.