### PR TITLE
Create sentry-release-tracking-token-auth.json

### DIFF
--- a/step-templates/sentry-release-tracking-token-auth.json
+++ b/step-templates/sentry-release-tracking-token-auth.json
@@ -48,6 +48,6 @@
     "OctopusVersion": "2021.2.7428",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
+  "LastModifiedBy": "shout",
   "Category": "sentry"
 }

--- a/step-templates/sentry-release-tracking-token-auth.json
+++ b/step-templates/sentry-release-tracking-token-auth.json
@@ -1,20 +1,20 @@
 {
-  "Id": "b40d5528-5de0-422d-a746-1e93cd04dea0",
+  "Id": "f957377a-6389-4ed1-87a6-3317e5676a77",
   "Name": "Sentry Release Tracking (Token Auth)",
-  "Description": "Posts a new release to Sentry, It can optionaly resolve all previous issues.\n\nIf the release already exists, it only applies the resolving.",
+  "Description": "Posts a new release to Sentry and links it to one or more sentry projects. \n\n**Updated version** which uses the newer **API Token** instead of the now depreciated API Key which is only available in legacy Sentry accounts.",
   "ActionType": "Octopus.Script",
   "Version": 1,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "$url = \"https://sentry.io/api/0/organizations/$organization/releases/\"\nWrite-Host $url\n\n$headers = New-Object \"System.Collections.Generic.Dictionary[[String],[String]]\"\n$headers.Add(\"Authorization\", \"Bearer $sentryApiKey\")\n$body = ConvertTo-Json @{ \n\t\"version\" = $OctopusParameters['Octopus.Release.Number']\n    \"projects\" = $projects.Split(\";\")\n}\n\nWrite-Host $body\nTry\n{\n\t$response = Invoke-RestMethod -Method Post -Uri \"$url\" -Body $body -Headers $headers -ContentType \"application/json\"\n\tWrite-Host $response\n}\nCatch [System.Net.WebException] \n{\n\tWrite-Host $_\n\tif($_.Exception.Response.StatusCode.Value__ -ne 400)\n\t{\n\t\tThrow\n\t}\n}\n",
+    "Octopus.Action.Script.ScriptBody": "$organization = $OctopusParameters[\"SentryReleaseTracking.organization\"]\n$projects = $OctopusParameters[\"SentryReleaseTracking.projects\"]\n$apiToken = $OctopusParameters[\"SentryReleaseTracking.apiToken\"]\n\n$url = \"https://sentry.io/api/0/organizations/$organization/releases/\"\nWrite-Host $url\n\n$headers = New-Object \"System.Collections.Generic.Dictionary[[String],[String]]\"\n$headers.Add(\"Authorization\", \"Bearer $apiToken\")\n$body = ConvertTo-Json @{ \n\t\"version\" = $OctopusParameters['Octopus.Release.Number']\n    \"projects\" = $projects.Split(\";\")\n}\n\nWrite-Host $body\nTry\n{\n\t$response = Invoke-RestMethod -Method Post -Uri \"$url\" -Body $body -Headers $headers -ContentType \"application/json\"\n\tWrite-Host $response\n}\nCatch { \n\tif($_.Exception.Response.StatusCode -ne 400)\n\t{\n  \t\tThrow $_\n    }\n}\n",
     "Octopus.Action.Script.ScriptSource": "Inline"
   },
   "Parameters": [
     {
       "Id": "84a0e54c-c914-481a-9277-4b9ab176c9d6",
-      "Name": "organization",
+      "Name": "SentryReleaseTracking.organization",
       "Label": "Organisation Slug",
       "HelpText": "The organisation-name part of the url",
       "DefaultValue": "",
@@ -24,9 +24,9 @@
     },
     {
       "Id": "7ae25fac-65b3-4830-9ade-56c3443ac63b",
-      "Name": "projects",
+      "Name": "SentryReleaseTracking.projects",
       "Label": "Project Slug",
-      "HelpText": "`;`-separated list of all your sentry api slugs for the apps, (web/api/admin) on this spesific Environment.\n\n    myapp-web-dev;myapp-api-dev\n\nprotip: Add them all to a environment-scoped variable.",
+      "HelpText": "`;`-separated list of all your sentry api slugs for the apps, (web/api/admin) on this specific Environment.\n\n    myapp-web-dev;myapp-api-dev\n\nprotip: Add them all to a environment-scoped variable.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -34,20 +34,20 @@
     },
     {
       "Id": "4d2396cc-5313-4188-91ab-18cf7b59369a",
-      "Name": "sentryApiKey",
+      "Name": "SentryReleaseTracking.apiToken",
       "Label": "Sentry token",
       "HelpText": "Your sentry token",
       "DefaultValue": "",
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+        "Octopus.ControlType": "Sensitive"
       }
     }
   ],
   "$Meta": {
-    "ExportedAt": "2021-09-09T15:37:55.946Z",
+    "ExportedAt": "2021-09-10T12:19:29.946Z",
     "OctopusVersion": "2021.2.7428",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "shout",
-  "Category": "other"
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "sentry"
 }

--- a/step-templates/sentry-release-tracking-token-auth.json
+++ b/step-templates/sentry-release-tracking-token-auth.json
@@ -1,0 +1,53 @@
+{
+  "Id": "b40d5528-5de0-422d-a746-1e93cd04dea0",
+  "Name": "Sentry Release Tracking (Token Auth)",
+  "Description": "Posts a new release to Sentry, It can optionaly resolve all previous issues.\n\nIf the release already exists, it only applies the resolving.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "$url = \"https://sentry.io/api/0/organizations/$organization/releases/\"\nWrite-Host $url\n\n$headers = New-Object \"System.Collections.Generic.Dictionary[[String],[String]]\"\n$headers.Add(\"Authorization\", \"Bearer $sentryApiKey\")\n$body = ConvertTo-Json @{ \n\t\"version\" = $OctopusParameters['Octopus.Release.Number']\n    \"projects\" = $projects.Split(\";\")\n}\n\nWrite-Host $body\nTry\n{\n\t$response = Invoke-RestMethod -Method Post -Uri \"$url\" -Body $body -Headers $headers -ContentType \"application/json\"\n\tWrite-Host $response\n}\nCatch [System.Net.WebException] \n{\n\tWrite-Host $_\n\tif($_.Exception.Response.StatusCode.Value__ -ne 400)\n\t{\n\t\tThrow\n\t}\n}\n",
+    "Octopus.Action.Script.ScriptSource": "Inline"
+  },
+  "Parameters": [
+    {
+      "Id": "84a0e54c-c914-481a-9277-4b9ab176c9d6",
+      "Name": "organization",
+      "Label": "Organisation Slug",
+      "HelpText": "The organisation-name part of the url",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "7ae25fac-65b3-4830-9ade-56c3443ac63b",
+      "Name": "projects",
+      "Label": "Project Slug",
+      "HelpText": "`;`-separated list of all your sentry api slugs for the apps, (web/api/admin) on this spesific Environment.\n\n    myapp-web-dev;myapp-api-dev\n\nprotip: Add them all to a environment-scoped variable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4d2396cc-5313-4188-91ab-18cf7b59369a",
+      "Name": "sentryApiKey",
+      "Label": "Sentry token",
+      "HelpText": "Your sentry token",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2021-09-09T15:37:55.946Z",
+    "OctopusVersion": "2021.2.7428",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "shout",
+  "Category": "other"
+}


### PR DESCRIPTION
The previous sentry-release-tracking script is outdated and does not work for new sentry accounts which cannot generate the legacy api key.
This version uses the new sentry api token instead and passes each project through as a single request rather than using a request loop.
I have left the old version as I wasn't sure if this would create compatibility issues for existing users.  The old version should probably be removed and replaced with this if not though.

---

### Step template checklist

- [ x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ x] Parameter names should not start with `$`
- [ x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
