### PR TITLE
Add the configure lambda function

### DIFF
--- a/step-templates/aws-configure-lambda.json
+++ b/step-templates/aws-configure-lambda.json
@@ -1,0 +1,264 @@
+{
+  "Id": "db4f7564-1b04-41c6-a3a6-aca911236aee",
+  "Name": "AWS - Configure Lambda Function",
+  "Description": "Creates or updates a lambda function using code from an S3 bucket or an [container image](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the Amazon ECR registry.  \n\nThis step uses the following AWS CLI commands to create or update the AWS Lambda function.  You will be required to install the AWS CLI on your server/worker for this to work.  The AWS CLI is pre-installed on the [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools) in Octopus Cloud as well as the provided docker containers for [Execution Containers](https://octopus.com/docs/deployment-process/execution-containers-for-workers).\n\n- [create-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html)\n- [get-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/get-function.html)\n- [publish-version](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/publish-version.html)\n- [tag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/tag-resource.html)\n- [untag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/untag-resource.html)\n- [update-function-code](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-code.html)\n- [update-function-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-configuration.html)\n\n## Code Options\n\nYou can specify either a .zip file hosted in S3 or a container hosted in Amazon ECR.\n\nIf you decide on S3 the key is the \"path\" to the .zip file in the S3 bucket.  For example: `#{Octopus.Release.Number}/#{Octopus.Environment.Name}/AcceptMessage.zip`\n\nIf you decide on the container, you must include the version number in the URI.  Typically, most people use `latest`.\n\n## Output Variables\n\nThis step template sets the following output variables:\n\n- `LambdaArn`: The ARN of the Lambda Function\n- `PublishedVersion`: The most recent version published (only set when Publish is set to `Yes`).",
+  "ActionType": "Octopus.AwsRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.AwsAccount.Variable": "#{AWS.Lambda.Account}",
+    "Octopus.Action.Aws.Region": "#{AWS.Lambda.Region}",
+    "Octopus.Action.Script.ScriptBody": "$functionName = $OctopusParameters[\"AWS.Lambda.FunctionName\"]\n$functionRole = $OctopusParameters[\"AWS.Lambda.FunctionRole\"]\n$functionRunTime = $OctopusParameters[\"AWS.Lambda.Runtime\"]\n$functionHandler = $OctopusParameters[\"AWS.Lambda.FunctionHandler\"]\n$functionMemorySize = $OctopusParameters[\"AWS.Lambda.MemorySize\"]\n$functionDescription = $OctopusParameters[\"AWS.Lambda.Description\"]\n$functionVPCSubnetId = $OctopusParameters[\"AWS.Lambda.VPCSubnetIds\"]\n$functionVPCSecurityGroupId = $OctopusParameters[\"AWS.Lambda.VPCSecurityGroupIds\"]\n$functionEnvironmentVariables = $OctopusParameters[\"AWS.Lambda.EnvironmentVariables\"]\n$functionEnvironmentVariablesKey = $OctopusParameters[\"AWS.Lambda.EnvironmentVariablesKey\"]\n$functionTimeout = $OctopusParameters[\"AWS.Lambda.FunctionTimeout\"]\n$functionTags = $OctopusParameters[\"AWS.Lambda.Tags\"]\n$functionFileSystemConfig = $OctopusParameters[\"AWS.Lambda.FileSystemConfig\"]\n$functionDeadLetterConfig = $OctopusParameters[\"AWS.Lambda.DeadLetterConfig\"]\n$functionTracingConfig = $OctopusParameters[\"AWS.Lambda.TracingConfig\"]\n$functionPublishOption = $OctopusParameters[\"AWS.Lambda.Publish\"]\n\n$functionReleaseNumber = $OctopusParameters[\"Octopus.Release.Number\"]\n$functionRunbookRun = $OctopusParameters[\"Octopus.RunbookRun.Id\"]\n$stepName = $OctopusParameters[\"Octopus.Step.Name\"]\n\n$regionName = $OctopusParameters[\"AWS.Lambda.Region\"]\n$functionCodeS3Bucket = $OctopusParameters[\"AWS.Lambda.Code.S3Bucket\"]\n$functionCodeS3Key = $OctopusParameters[\"AWS.Lambda.Code.S3Key\"]\n$functionCodeS3Version = $OctopusParameters[\"AWS.Lambda.Code.S3ObjectVersion\"]\n$functionCodeImageUri = $OctopusParameters[\"AWS.Lambda.Code.ImageUri\"]\n$functionCodeVersion = $OctopusParameters[\"AWS.Lambda.Code.Version\"]\n\nif ([string]::IsNullOrWhiteSpace($functionName))\n{\n\tWrite-Error \"The parameter Function Name is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionRole))\n{\n\tWrite-Error \"The parameter Role is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionCodeS3Bucket) -and [string]::IsNullOrWhiteSpace($functionCodeImageUri))\n{\n\tWrite-Error \"You must specify either a S3 Bucket or an Image URI for the lambda to run.\"\n    exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionCodeS3Bucket) -and [string]::IsNullOrWhiteSpace($functionCodeS3Key) -eq $false)\n{\n\tWrite-Error \"The S3 Key was specified but the S3 bucket was not specified, the S3 Bucket parameter is required when the key is specified.\"\n    exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionRunTime))\n{\n\tWrite-Error \"The parameter Run Time is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionHandler))\n{\n\tWrite-Error \"The parameter Handler is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionPublishOption))\n{\n\tWrite-Error \"The parameter Publish is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionReleaseNumber) -eq $false)\n{\n    $deployVersionTag = \"Octopus-Release=$functionReleaseNumber\"\n}\nelse\n{\n\t$deployVersionTag = \"Octopus-Runbook-Run=$functionRunbookRun\"\n}\n\nWrite-Host \"Function Name: $functionName\"\nWrite-Host \"Function Role: $functionRole\"\nWrite-Host \"Function Runtime: $functionRunTime\"\nWrite-Host \"Function Handler: $functionHandler\"\nWrite-Host \"Function Memory Size: $functionMemorySize\"\nWrite-Host \"Function Description: $functionDescription\"\nWrite-Host \"Function Subnet Ids: $functionVPCSubnetId\"\nWrite-Host \"Function Security Group Ids: $functionVPCSecurityGroupId\"\nWrite-Host \"Function Environment Variables: $functionEnvironmentVariables\"\nWrite-Host \"Function Environment Variables Key: $functionEnvironmentVariablesKey\"\nWrite-Host \"Function Timeout: $functionTimeout\"\nWrite-Host \"Function Tags: $functionTags\"\nWrite-Host \"Function File System Config: $functionFileSystemConfig\"\nWrite-Host \"Function Dead Letter Config: $functionDeadLetterConfig\"\nWrite-Host \"Function Tracing Config: $functionTracingConfig\"\nWrite-Host \"Function S3 Bucket: $functionCodeS3Bucket\"\nWrite-host \"Function S3 Key: $functionCodeS3Key\"\nWrite-Host \"Function S3 Object Version: $functionCodeS3Version\"\nWrite-Host \"Function Image Uri: $functionCodeImageUri\"\nWrite-Host \"Function Publish: $functionPublishOption\"\n\nWrite-Host \"Attempting to find the function $functionName in the region $regionName\"\n$hasExistingFunction = $true\ntry\n{\n\t$existingFunction = aws lambda get-function --function-name \"$functionName\"\n    \n    Write-Host \"The exit code from the lookup was $LASTEXITCODE\"\n    if ($LASTEXITCODE -eq 255 -or $LASTEXITCODE -eq 254)\n    {\n    \t$hasExistingFunction = $false\n    }   \n    \n    $existingFunction = $existingFunction | ConvertFrom-Json\n}\ncatch\n{\n\tWrite-Host \"The function was not found\"\n\t$hasExistingFunction = $false\n}\n\nWrite-Host \"Existing functions: $hasExistingFunction\"\nWrite-Host $existingFunction\n\n$aliasInformation = $null\nif ($hasExistingFunction -eq $false)\n{\n\t$functionCodeLocation = \"ImageUri=$functionCodeImageUri\"\n    if ([string]::IsNullOrWhiteSpace($functionCodeS3Bucket) -eq $false)\n    {\n    \tWrite-Host \"S3 Bucket Specified, using that as the code source.\"\n        $functionCodeLocation = \"S3Bucket=$functionCodeLocation\"\n        \n        if ([string]::IsNullOrWhiteSpace($functionCodeS3Key) -eq $false)\n        {\n        \tWrite-Host \"S3 Key Specified\"\n        \t$functionCodeLocation += \",S3Key=$functionCodeS3Key\"\n        }\n        \n        if ([string]::IsNullOrWhiteSpace($functionCodeS3Version) -eq $false)\n        {\n        \tWrite-Host \"Object Version Specified\"\n        \t$functionCodeLocation += \",S3Key=$functionCodeS3Version\"\n        }\n    }\n    \n\tWrite-Highlight \"Creating $functionName in $regionName\"    \n\t$functionInformation = aws lambda create-function --function-name \"$functionName\" --code \"$functionCodeLocation\" --handler $functionHandler --runtime $functionRuntime --role $functionRole --memory-size $functionMemorySize\n}\nelse\n{\n\tif ([string]::IsNullOrWhiteSpace($functionCodeS3Bucket) -eq $false)\n    {\n    \tWrite-Host \"S3 Bucket specified, updating the function $functionName to use that.\"\n        \n    \tif ([string]::IsNullOrWhiteSpace($functionCodeS3Key) -eq $false -and [string]::IsNullOrWhiteSpace($functionCodeS3Version) -eq $false)\n        {\n        \tWrite-host \"Both the S3 Key and the Object Version specified\"            \n\t\t    $updatedConfig = aws lambda update-function-code --function-name \"$functionName\" --s3-bucket \"$functionCodeS3Bucket\" --s3-key \"$functionCodeS3Key\" --s3-object-version \"$functionCodeS3Version\"\n        }\n        elseif ([string]::IsNullOrWhiteSpace($functionCodeS3Key) -eq $false -and [string]::IsNullOrWhiteSpace($functionCodeS3Version) -eq $true)\n        {\n        \tWrite-host \"Only the S3 key was specified\"            \n\t\t    $updatedConfig = aws lambda update-function-code --function-name \"$functionName\" --s3-bucket \"$functionCodeS3Bucket\" --s3-key \"$functionCodeS3Key\"\n        }\n        else\n        {\n        \tWrite-host \"Only the Object Version was specified\"            \n\t\t    $updatedConfig = aws lambda update-function-code --function-name \"$functionName\" --s3-bucket \"$functionCodeS3Bucket\" --s3-object-version \"$functionCodeS3Version\"\n        }\n    }\n    else\n    {\n    \tWrite-Host \"Image URI specified, updating the function $functionName to use that.\"           \n\t    $updatedConfig = aws lambda update-function-code --function-name \"$functionName\" --image-uri \"$functionCodeImageUri\"\n    }\n    \n    Write-Highlight \"Updating the $functionName base configuration\"    \n    $functionInformation = aws lambda update-function-configuration --function-name \"$functionName\" --role $functionRole --handler $functionHandler --runtime $functionRuntime --memory-size $functionMemorySize\n}\n\n$functionInformation = $functionInformation | ConvertFrom-JSON\n$functionArn = $functionInformation.FunctionArn\n\nWrite-Host \"Function ARN: $functionArn\"\n\nif ([string]::IsNullOrWhiteSpace($functionEnvironmentVariables) -eq $false)\n{\n\tWrite-Highlight \"Environment variables specified, updating environment variables configuration for $functionName\"\n\t$environmentVariables = \"Variables={$functionEnvironmentVariables}\"\n    \n    if ([string]::IsNullOrWhiteSpace($functionEnvironmentVariablesKey) -eq $true)\n    {\n    \t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --environment \"$environmentVariables\"\n    }\n    else\n    {\n    \t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --environment \"$environmentVariables\" --kms-key-arn \"$functionEnvironmentVariablesKey\"\n    }\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTimeout) -eq $false)\n{\n\tWrite-Highlight \"Timeout specified, updating timeout configuration for $functionName\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --timeout \"$functionTimeout\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTags) -eq $false)\n{\n\tWrite-Highlight \"Tags specified, updating tags configuration for $functionName\"\n\t$updatedConfig = aws lambda tag-resource --resource \"$functionArn\" --tags \"$functionTags\"\n}\n\nif ([string]::IsNullOrWhiteSpace($deployVersionTag) -eq $false)\n{\n\tWrite-Highlight \"Deploy version tag found with value of $deployVersionTag, updating tags configuration for $functionName\"\n    aws lambda untag-resource --resource \"$functionArn\" --tag-keys \"Octopus-Release\" \"Octopus-Runbook-Run\"\n\t$updatedConfig = aws lambda tag-resource --resource \"$functionArn\" --tags \"$deployVersionTag\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionVPCSubnetId) -eq $false -and [string]::IsNullOrWhiteSpace($functionVPCSecurityGroupId) -eq $false)\n{\n\tWrite-Highlight \"VPC subnets and security group specified, updating vpc configuration for $functionName\"\n\t$vpcConfig = \"SubnetIds=$functionVPCSubnetId,SecurityGroupIds=$functionVPCSecurityGroupId\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --vpc-config \"$vpcConfig\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionDescription) -eq $false)\n{\n\tWrite-Highlight \"Description specified, updating description configuration for $functionName\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --description \"$functionDescription\"\t\n}\n\nif ([string]::IsNullOrWhiteSpace($functionFileSystemConfig) -eq $false)\n{\n\tWrite-Highlight \"File System Config specified, updating file system configuration for $functionName\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --file-system-configs \"$functionFileSystemConfig\"\t\n}\n\nif ([string]::IsNullOrWhiteSpace($functionDeadLetterConfig) -eq $false)\n{\n\tWrite-Highlight \"Dead Letter specified, updating dead letter configuration for $functionName\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --dead-letter-config \"$functionDeadLetterConfig\"\t\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTracingConfig) -eq $false)\n{\n\tWrite-Highlight \"Tracing config specified, updating tracing configuration for $functionName\"\n\t$updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --tracing-config \"$functionTracingConfig\"\t\n}\n\nWrite-Host $updatedConfig | ConvertFrom-JSON\n\nif ($functionPublishOption -eq \"Yes\")\n{\n\t$functionVersionNumber = $functionCodeVersion\n\tif ([string]::IsNullOrWhiteSpace($functionCodeVersion) -eq $true)\n    {\n    \t$functionVersionNumber = $functionReleaseNumber\n    }\n    \n\tWrite-Highlight \"Publishing the function with the description $functionVersionNumber to create a snapshot of the current code and configuration of this function in AWS.\"\n\t$publishedVersion = aws lambda publish-version --function-name \"$functionArn\" --description \"$functionVersionNumber\"\n    \n    $publishedVersion = $publishedVersion | ConvertFrom-JSON\n    \n    Write-Highlight \"Setting the output variable 'Octopus.Action[$($stepName)].Output.PublishedVersion' to $($publishedVersion.Version)\"\n    Set-OctopusVariable -name \"PublishedVersion\" -value \"$($publishedVersion.Version)\"    \n}\n\nWrite-Highlight \"Setting the output variable 'Octopus.Action[$($stepName)].Output.LambdaArn' to $functionArn\"\nSet-OctopusVariable -name \"LambdaArn\" -value \"$functionArn\"\n\nWrite-Highlight \"AWS Lambda $functionName successfully deployed.\"",
+    "Octopus.Action.SubstituteInFiles.Enabled": "True",
+    "Octopus.Action.SubstituteInFiles.OutputEncoding": "utf-8",
+    "OctopusUseBundledTooling": "False"
+  },
+  "Parameters": [
+    {
+      "Id": "bf72bc3e-3ce6-4b63-b23f-1171b5cc72dd",
+      "Name": "AWS.Lambda.FunctionName",
+      "Label": "Function Name",
+      "HelpText": "Required.\n\nThe name of the function to create or update.  See [documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html#options)\n\nExamples:\n- Function name - my-function .\n- Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function .\n- Partial ARN - 123456789012:function:my-function .\n\nThe length constraint applies only to the full ARN. If you specify only the function name, it is limited to 64 characters in length.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "13dcec09-00f8-4af0-80e4-23bcb47eaf17",
+      "Name": "AWS.Lambda.Account",
+      "Label": "AWS Account",
+      "HelpText": "Required.\n\nThe AWS Account with permissions to create / update AWS Lambdas.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    },
+    {
+      "Id": "8fd7ff24-7557-4f96-a809-ce611c473b13",
+      "Name": "AWS.Lambda.Region",
+      "Label": "Region",
+      "HelpText": "Required.\n\nThe region where the function will live.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "us-east-2|US East (Ohio)\nus-east-1|US East (N. Virginia)\nus-west-1|US West (N. California)\nus-west-2|US West (Oregon)\naf-south-1|Africa (Cape Town)\nap-east-1|Asia Pacific (Hong Kong)\nap-south-1|Asia Pacific (Mumbai)\nap-northeast-3|Asia Pacific (Osaka-Local)\nap-northeast-2|Asia Pacific (Seoul)\nap-southeast-1|Asia Pacific (Singapore)\nap-southeast-2|Asia Pacific (Sydney)\nap-northeast-1|Asia Pacific (Tokyo)\nca-central-1|Canada (Central)\neu-central-1|Europe (Frankfurt)\neu-west-1|Europe (Ireland)\neu-west-2|Europe (London)\neu-south-1|Europe (Milan)\neu-west-3|Europe (Paris)\neu-north-1|Europe (Stockholm)\nme-south-1|Middle East (Bahrain)\nsa-east-1|South America (São Paulo)"
+      }
+    },
+    {
+      "Id": "d45499b4-5f4a-4bae-a4b9-336e97a75cdc",
+      "Name": "AWS.Lambda.FunctionRole",
+      "Label": "Function Role",
+      "HelpText": "Required.\n\nThe Amazon Resource Name (ARN) of the function’s execution role.  This role must exist prior to this step is run.  See [documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) for more detail on creating an execution role.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e4426d6c-2814-451c-9575-d2d216ac2778",
+      "Name": "AWS.Lambda.Code.S3Bucket",
+      "Label": "S3 Bucket",
+      "HelpText": "Optional.\n\nThe S3 bucket where the code is stored. The bucket can be in a different Amazon Web Services account.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "bc282ee2-2341-4b36-a1fc-181dbf72692f",
+      "Name": "AWS.Lambda.Code.S3Key",
+      "Label": "S3 Key",
+      "HelpText": "Optional.\n\nThe Amazon S3 key of the deployment package. You must upload the function as a .zip file.  The key must be the path to the .zip file.\n\nFor example: `#{Octopus.Release.Number}/#{Octopus.Environment.Name}/AcceptMessage.zip`\n\n**Please note**: If this is specified then the `S3 Bucket` is required.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "49002ff9-f4f4-4114-a363-2eeedd62f1a7",
+      "Name": "AWS.Lambda.Code.S3ObjectVersion",
+      "Label": "S3 Object Version",
+      "HelpText": "Optional.\n\nFor versioned objects, the version of the deployment package object to use.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "02f25886-8101-4fe2-b9e4-844ea3498522",
+      "Name": "AWS.Lambda.Code.ImageUri",
+      "Label": "Image URI",
+      "HelpText": "Optional.\n\nURI of a [container image](https://docs.aws.amazon.com/lambda/latest/dg/lambda-images.html) in the Amazon ECR registry.\n\nYou must include the version number in the URI, or `latest` to use the latest image.\n\n**Please note**: You can either run the lambda from an S3 bucket OR an image URI.  If the S3 bucket parameter is specified this value will be ignored.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "5d930ed5-1e7e-4b5c-8bc4-26ab5e0aeff5",
+      "Name": "AWS.Lambda.Code.Version",
+      "Label": "Code Version",
+      "HelpText": "Optional.\n\nThe version of the package being uploaded to S3 or Amazon ECR in this deployment.  If you are publishing the function with this deployment, this will be what is added to the description.\n\n**Please Note**: If this is left blank the release number will be used in the published description.\n\nYou can use a variable to reference the package version from a previous step.\n\n`#{Octopus.Action[_name_].Package.PackageVersion}`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "926b93c6-a47a-4899-9865-e7329b93b4b8",
+      "Name": "AWS.Lambda.Runtime",
+      "Label": "Runtime",
+      "HelpText": "Required.\n\nThe runtime of the AWS Lambda.  See [documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html#options) for more details on what runtimes are supported.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "nodejs|nodejs\nnodejs4.3|nodejs4.3\nnodejs4.3-edge|nodejs4.3-edge\nnodejs6.10|nodejs6.10\nnodejs8.10|nodejs8.10\nnodejs10.x|nodejs10.x\nnodejs12.x|nodejs12.x\nnodejs14.x|nodejs14.x\njava8|java8\njava8.al2|java8.al2\njava11|java11\npython2.7|python2.7\npython3.6|python3.6\npython3.7|python3.7\npython3.8|python3.8\npython3.9|python3.9\ndotnetcore1.0|dotnetcore1.0\ndotnetcore2.0|dotnetcore2.0\ndotnetcore2.1|dotnetcore2.1\ndotnetcore3.1|dotnetcore3.1\nnodejs4.3-edge|nodejs4.3-edge\ngo1.x|go1.x\nruby2.5|ruby2.5\nruby2.7|ruby2.7\nprovided|provided\nprovided.al2|provided.al2"
+      }
+    },
+    {
+      "Id": "1b8bfb82-3736-4d9a-8b05-a39319eb5735",
+      "Name": "AWS.Lambda.FunctionHandler",
+      "Label": "Handler",
+      "HelpText": "Required.\n\nThe name of the method within your code that Lambda calls to execute your function. The format includes the file name. It can also include namespaces and other qualifiers, depending on the runtime. For more information, see [Programming Model](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-features.html)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "68428e8e-abc3-4f29-a5bb-fe635281d073",
+      "Name": "AWS.Lambda.MemorySize",
+      "Label": "Memory Size",
+      "HelpText": "Required.\n\nThe amount of memory that your function has access to. Increasing the function’s memory also increases its CPU allocation. The default value is 128 MB. The value must be a multiple of 64 MB.",
+      "DefaultValue": "128",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "948280bb-50af-495b-9d1d-2f7567a0b0cc",
+      "Name": "AWS.Lambda.Description",
+      "Label": "Description",
+      "HelpText": "Optional.\n\nA description of the function.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ed2ab9bb-d8a3-4ab4-a576-36b6c0a8f75d",
+      "Name": "AWS.Lambda.VPCSubnetIds",
+      "Label": "VPC Subnet Ids",
+      "HelpText": "Optional.\n\nFormat: `SubnetId1,SubnetId2`\n\nFor network connectivity to AWS resources in a VPC, specify a list of security groups and subnets in the VPC. When you connect a function to a VPC, it can only access resources and the internet through that VPC. For more information, see [VPC Settings](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8c2793a7-1a88-40a2-be28-3a38c7b40658",
+      "Name": "AWS.Lambda.VPCSecurityGroupIds",
+      "Label": "VPC Security Group Ids",
+      "HelpText": "Optional.\n\nFormat: `SecurityGroupId1,SecurityGroupId2`\n\nFor network connectivity to AWS resources in a VPC, specify a list of security groups and subnets in the VPC. When you connect a function to a VPC, it can only access resources and the internet through that VPC. For more information, see [VPC Settings](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ba3edded-1e19-47c4-990a-ebdf4eb0bcca",
+      "Name": "AWS.Lambda.EnvironmentVariables",
+      "Label": "Environment Variables",
+      "HelpText": "Optional.\n\nFormat: `KeyName1=string,KeyName2=string`\n\nEnvironment variables that are accessible from function code during execution.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "58d76440-e4f5-46fb-a095-84aedd904a18",
+      "Name": "AWS.Lambda.EnvironmentVariablesKey",
+      "Label": "Environment Variables Encryption Key",
+      "HelpText": "Optional.\n\nThe ARN of the AWS Key Management Service (AWS KMS) key that’s used to encrypt your function’s environment variables. If it’s not provided, AWS Lambda uses a default service key.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "5b9b3111-5349-49e6-ab0d-f386a53bdd7c",
+      "Name": "AWS.Lambda.FunctionTimeout",
+      "Label": "Timeout",
+      "HelpText": "Optional.\n\nThe amount of time that Lambda allows a function to run before stopping it. The default is 3 seconds. The maximum allowed value is 900 seconds.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "567f5eeb-e174-4c8f-8b17-36bd9457ea29",
+      "Name": "AWS.Lambda.Tags",
+      "Label": "Tags",
+      "HelpText": "Optional.\n\nFormat: `KeyName1=string,KeyName2=string`\n\nA list of tags to apply to the function.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "297f4f8e-3837-43a3-b844-a0e0d02e9d5b",
+      "Name": "AWS.Lambda.FileSystemConfig",
+      "Label": "File System Config",
+      "HelpText": "Optional.\n\nFormat: `Arn=string,LocalMountPath=string`\n\nConnection settings for an Amazon EFS file system.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "c720a63a-7b77-4a13-b6ed-6d44126e9372",
+      "Name": "AWS.Lambda.TracingConfig",
+      "Label": "Tracing Config",
+      "HelpText": "Optional.\n\nFormat: `Mode=string`\n\nSet Mode to Active to sample and trace a subset of incoming requests with AWS X-Ray.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "92fd8a1f-e681-4e1c-b382-3df1de12194e",
+      "Name": "AWS.Lambda.DeadLetterConfig",
+      "Label": "Dead Letter Config",
+      "HelpText": "Optional.\n\nFormat: `TargetArn=string`\n\nA dead letter queue configuration that specifies the queue or topic where Lambda sends asynchronous events when they fail processing. For more information, see [Dead Letter Queues](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq).\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "67f8da1a-08f1-4cde-a60f-238d1fb08c98",
+      "Name": "AWS.Lambda.Publish",
+      "Label": "Publish",
+      "HelpText": "Required.\n\nCreates a [version](https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html) from the current code and configuration of a function. Use versions to create a snapshot of your function code and configuration that doesn’t change.\n\n**Important**: Lambda doesn’t publish a version if the function’s configuration and code haven’t changed since the last version. Use UpdateFunctionCode or UpdateFunctionConfiguration to update the function before publishing a version.",
+      "DefaultValue": "Yes",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "Yes|Yes\nNo|No"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.AwsRunScript",
+  "$Meta": {
+    "ExportedAt": "2021-11-04T14:40:20.783Z",
+    "OctopusVersion": "2021.3.7807",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "bobjwalker",
+  "Category": "aws"
+}


### PR DESCRIPTION
Creates a new step template to allow users to create or update an existing lambda function using code hosted in S3 or as a container hosted in Amazon ECR.

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it