### PR TITLE
Add HTTP Headers to improve security posture

### DIFF
--- a/web.config
+++ b/web.config
@@ -56,7 +56,7 @@
       </requestFiltering>
     </security>
 
-    <!-- Add all the nice security headers ->>
+    <!-- Add all the nice security headers -->
     <httpProtocol>
       <customHeaders>
         <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />

--- a/web.config
+++ b/web.config
@@ -56,6 +56,18 @@
       </requestFiltering>
     </security>
 
+    <!-- Add all the nice security headers ->>
+    <httpProtocol>
+      <customHeaders>
+        <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
+        <add name="Content-Security-Policy" value="default-src https:" />
+        <add name="Referrer-Policy" value="no-referrer" />
+        <add name="Permissions-Policy" value="microphone ‘none’; camera ‘none’ https://library.octopus.com" />
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+        <add name="X-Content-Type-Options" value="nosniff" />
+      </customHeaders>
+    </httpProtocol>
+    
     <!-- Make sure error responses are left untouched -->
     <httpErrors existingResponse="PassThrough" />
 


### PR DESCRIPTION
Working with @chrisreeves- to add HTTP Headers to library.octopus.com

Has been tested on a blank website in Azure so that we're running against a real IIS server, but not with the full `library.` node app sitting underneath it, so we'll still need to do some testing against a proper instance to ensure everything is still working nicely.