### PR TITLE
Loosen CSP headers to keep site working

### DIFF
--- a/web.config
+++ b/web.config
@@ -59,10 +59,10 @@
     <!-- Add all the nice security headers -->
     <httpProtocol>
       <customHeaders>
-        <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />
-        <add name="Content-Security-Policy" value="default-src https:" />
+        <add name="Content-Security-Policy" value="default-src https:; img-src https: data:; script-src https: 'unsafe-inline'; style-src https: 'unsafe-inline';" />
+        <add name="Permissions-Policy" value="accelerometer=(), camera=(), cross-origin-isolated=(), display-capture=(), encrypted-media=(), geolocation=(), gyroscope=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()" />
         <add name="Referrer-Policy" value="no-referrer" />
-        <add name="Permissions-Policy" value="microphone ‘none’; camera ‘none’ https://library.octopus.com" />
+        <add name="Strict-Transport-Security" value="max-age=31536000; includeSubDomains" />        
         <add name="X-Frame-Options" value="SAMEORIGIN" />
         <add name="X-Content-Type-Options" value="nosniff" />
       </customHeaders>


### PR DESCRIPTION
This backs off the previously introduced CSP header and makes the values permissive 
enough to work with the current application code and page structure of the Library 
app. However, usage of `'unsafe-inline'` and `data:` are explicitly discouraged by the CSP
spec, because they are so permissive that it's like not having a CSP header at all.

We should do further analysis of the changes required to tighten up the CSP header
at a later date.

Also fixes the `Permissions-Policy` header to be in the right format, and disable almost
all known browser permissions - none should be relevant for our very simple Library app.