### PR TITLE
(WIP) Update NewRelic Deployment Marker step template with polling checks

### DIFF
--- a/step-templates/newrelic-complete-deployment.json
+++ b/step-templates/newrelic-complete-deployment.json
@@ -3,9 +3,9 @@
   "Name": "New Relic - Complete Deployment",
   "Description": "Notifies [New Relic](https://newrelic.com) of a deployment.\nSends the revision/version number, deployer, etc from the Octopus deployment.",
   "ActionType": "Octopus.Script",
-  "Version": 26,
+  "Version": 27,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "# Minimum PowerShell version for ConvertTo-Json is 3\n\nAdd-Type -AssemblyName System.Web\n\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12\n\n$apiKey = $OctopusParameters['ApiKey']\n$user = $OctopusParameters['User']\n$appId = $OctopusParameters['AppId']\n\n#https://octopus.com/docs/deployment-process/variables/system-variables\n$releaseNumber = $OctopusParameters['Octopus.Release.Number']\n$releaseNotes = $OctopusParameters['Octopus.Release.Notes']\n$machineName = $OctopusParameters['Octopus.Machine.Name']\n$projectName = $OctopusParameters['Octopus.Project.Name']\n$deploymentLink = $OctopusParameters['Octopus.Web.DeploymentLink']\n\n## --------------------------------------------------------------------------------------\n## Helpers\n## --------------------------------------------------------------------------------------\n# Helper for validating input parameters\nfunction Validate-Parameter([string]$foo, [string[]]$validInput, $parameterName) {\n    Write-Host \"${parameterName}: $foo\"\n    if (! $foo) {\n        throw \"No value was set for $parameterName, and it cannot be empty\"\n    }\n    \n    if ($validInput) {\n        if (! $validInput -contains $foo) {\n            throw \"'$input' is not a valid input for '$parameterName'\"\n        }\n    }\n}\n\n## --------------------------------------------------------------------------------------\n## Configuration\n## --------------------------------------------------------------------------------------\nValidate-Parameter $apiKey -parameterName \"Api Key\"\n\nif (!$appId) {\n    Write-Host \"NewRelic Deploy - AppId has not been set yet. Skipping call to API.\"\n    exit 0\n}\n\nif ($appId -eq 0) {\n    Write-Host \"NewRelic Deploy - AppId has been set to zero. Skipping call to API.\"\n    exit 0\n}\n\n$userText = $((\" by user $user\", \"\")[!$user])\nWrite-Host (\"NewRelic Deploy - Notify deployment{0} - App {1} - Revision {2}\" -f $userText, $appId, $revision)\n\n        \n# https://rpm.newrelic.com/api/explore/application_deployments/create?application_id=1127348\n$deployment = New-Object -TypeName PSObject\n$deployment | Add-Member -MemberType NoteProperty -Name \"user\" -Value $user\n$deployment | Add-Member -MemberType NoteProperty -Name \"revision\" -Value $releaseNumber\n$deployment | Add-Member -MemberType NoteProperty -Name \"changelog\" -Value $releaseNotes\n$deployment | Add-Member -MemberType NoteProperty -Name \"description\" -Value \"Octopus deployment of $projectName to $machineName. ($deploymentLink)\"\n\n$deploymentContainer = New-Object -TypeName PSObject\n$deploymentContainer | Add-Member -MemberType NoteProperty -Name \"deployment\" -Value $deployment\n\n$post = $deploymentContainer | ConvertTo-Json\nWrite-Debug $post\n\n# in production, we need to\n#Create a URI instance since the HttpWebRequest.Create Method will escape the URL by default.\n$URL = \"https://api.newrelic.com/v2/applications/$appId/deployments.json\"\n$URI = New-Object System.Uri($URL,$true)\n\n#Create a request object using the URI\n$request = [System.Net.HttpWebRequest]::Create($URI)\n$request.Method = \"POST\"\n$request.Headers.Add(\"X-Api-Key\",\"$apiKey\");\n$request.ContentType = \"application/json\"\n\n#Build up a nice User Agent\n$request.UserAgent = $(\n    \"{0} (PowerShell {1}; .NET CLR {2}; {3})\" -f $UserAgent, \n    $(if($Host.Version){$Host.Version}else{\"1.0\"}),\n    [Environment]::Version,\n    [Environment]::OSVersion.ToString().Replace(\"Microsoft Windows \", \"Win\")\n)\n\ntry {\n    Write-Host \"Posting data to $URL\"\n    #Create a new stream writer to write the xml to the request stream.\n    $stream = New-Object IO.StreamWriter $request.GetRequestStream()\n    $stream.AutoFlush = $True\n    $PostStr = [System.Text.Encoding]::UTF8.GetBytes($Post)\n    $stream.Write($PostStr, 0,$PostStr.length)\n    $stream.Close()\n \n    #Make the request and get the response\n    $response = $request.GetResponse()    \n    $response.Close()\n\n    if ([int]$response.StatusCode -eq 201) {\n        Write-Host \"NewRelic Deploy - API called succeeded - HTTP $($response.StatusCode).\"\n    } else {\n        Write-Host \"NewRelic Deploy - API called failed - HTTP $($response.StatusCode).\"\n        exit 1\n    }\n} catch [System.Net.WebException] {\n    $ErrorMessage = $_.Exception.Message\n    $res = $_.Exception.Response\n    Write-Host \"NewRelic Deploy - API called failed - $ErrorMessage\" \n    exit 1\n}",
+    "Octopus.Action.Script.ScriptBody": "Add-Type -AssemblyName System.Web\n\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12\n\n$apiKey = $OctopusParameters['ApiKey']\n$user = $OctopusParameters['User']\n$applicationName = $OctopusParameters['ApplicationName']\n$checkInterval = $OctopusParameters['CheckInterval']\n$maxChecks = $OctopusParameters['MaxChecks']\n\n#https://octopus.com/docs/deployment-process/variables/system-variables\n$releaseNumber = $OctopusParameters['Octopus.Release.Number']\n$releaseNotes = $OctopusParameters['Octopus.Release.Notes']\n$machineName = $OctopusParameters['Octopus.Machine.Name']\n$projectName = $OctopusParameters['Octopus.Project.Name']\n$deploymentLink = $OctopusParameters['Octopus.Web.ServerUri'] + $OctopusParameters['Octopus.Web.DeploymentLink']\n\nfunction GetNewRelicApplication\n{\n    param([string]$applicationName, [string]$apiKey, [int]$maxChecks, [int]$checkInterval)\n    $urlEncodedApplicationName = [System.Web.HttpUtility]::UrlEncode($applicationName)\n    $applicationResponse = Invoke-RestMethod -Method Get -Uri \"https://api.newrelic.com/v2/applications.json?filter[name]=$urlEncodedApplicationName\" -Headers @{\"Api-Key\"=$apiKey}\n    $targetApplication = $applicationResponse.applications | Select-Object -First 1\n\n\n    if ($targetApplication -ne $null)\n    {\n        return $targetApplication\n    }\n\n    $checkCount = 0\n\n    Write-Host \"Waiting for newrelic application named $applicationName to show up\"\n    Write-Host \"Maximum Checks: $maxChecks\"\n    Write-Host \"Check Interval: $checkInterval\"\n\n    while ($targetApplication -eq $null -and $checkCount -le $maxChecks)\n    {\t\n\t    $checkCount += 1\n\t\n\t    Write-Host \"Waiting for $checkInterval seconds for newrelic application named $applicationName to show up\"\n\t    Start-Sleep -Seconds $checkInterval\n\t\n\t    if ($checkCount -le $maxChecks)\n\t    {\n\t\t    Write-Host \"$checkCount/$maxChecks Attempts\"\n\t    }\n\t\n\t    $applicationResponse = Invoke-RestMethod -Method Get -Uri \"https://api.newrelic.com/v2/applications.json?filter[name]=$urlEncodedApplicationName\" -Headers @{\"Api-Key\"=$apiKey}\n        $targetApplication = $applicationResponse.applications | Select-Object -First 1\n    }\n\n    return $targetApplication\n}\n\n\n$application = GetNewRelicApplication -applicationName $applicationName -apiKey $apiKey -maxChecks $maxChecks -checkInterval $checkInterval\n\nif ($application -eq $null)\n{\n    Write-Error -Message \"Newrelic app not found.  This usually means check your application is not running or configured correctly to report\"\n\tExit 1\n}\n\nWrite-Host \"Newrelic app found. Sending a deployment marker\"\n\n\n$deploymentmarkerPayload = @\"\n{\n    \"deployment\": {\n    \"revision\": \"$($releaseNumber)\",\n    \"changelog\": \"$($releaseNotes)\",\n    \"description\": \"Octopus deployment of $($projectName) to $($machineName). ($($deploymentLink))\",\n    \"user\": \"$($user)\"\n    }\n}\n\"@\n\nWrite-Host $deploymentmarkerPayload\n\nInvoke-WebRequest -Uri \"https://api.newrelic.com/v2/applications/$($application.id)/deployments.json\" -Method POST -Headers @{'Api-Key'=$apiKey} -ContentType 'application/json' -Body $deploymentmarkerPayload",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false",
@@ -16,19 +16,19 @@
   "Parameters": [
     {
       "Id": "caf3f015-671f-4600-bce0-ebcc7d5957fe",
-      "Name": "ApiKey",
+      "Name": "nrcp_ApiKey",
       "Label": "Api Key",
       "HelpText": "Your New Relic API key.",
       "DefaultValue": null,
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+        "Octopus.ControlType": "Sensitive"
       }
     },
     {
-      "Id": "3748da93-614d-4040-8c63-7c86a260c79e",
-      "Name": "AppId",
-      "Label": "App ID",
-      "HelpText": "The ID of the application in New Relic RPM.",
+      "Id": "58107827-abba-4c14-a176-80f6fcae02ac",
+      "Name": "nrcp_ApplicationName",
+      "Label": "Application Name",
+      "HelpText": "The Name of the application in New Relic.",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
@@ -36,17 +36,39 @@
     },
     {
       "Id": "719ab099-a361-4a58-ad34-b1d4acb70dd2",
-      "Name": "User",
+      "Name": "nrcp_User",
       "Label": "User (optional)",
       "HelpText": "The name of the user/process that triggered this deployment.",
-      "DefaultValue": null,
+      "DefaultValue": "#{Octopus.Deployment.CreatedBy.Username}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
+    },
+    {
+      "Id": "1e9856d3-0a0b-413f-a852-473b855fc9f8",
+      "Name": "nrcp_CheckInterval",
+      "Label": "Check Interval",
+      "HelpText": "The number of seconds to wait before re-checking for the New Relic application.",
+      "DefaultValue": "10",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "675b20bd-bc91-43e0-a1f7-922ce8eb3a1f",
+      "Name": "nrcp_MaxChecks",
+      "Label": "Maximum Checks",
+      "HelpText": "The maximum number of times to check for the existance of the New Relic application before giving up.",
+      "DefaultValue": "6",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
     }
   ],
-  "LastModifiedOn": "2021-07-26T16:50:00.000+00:00",
-  "LastModifiedBy": "bobjwalker",
+  "LastModifiedOn": "2021-11-13T12:00:00.000+00:00",
+  "LastModifiedBy": "tragiccode",
   "$Meta": {
     "ExportedAt": "2020-04-16T09:18:09.541Z",
     "OctopusVersion": "2019.12.0",


### PR DESCRIPTION
Right now, with the newrelic deployment marker step template that is a bit annoying.  It requires the application id.  In order to get the application id you must first deploy the app and have it reporting to newrelic (so it created the app).  This makes is very annoying and painful when adding a new application as your first deploys will always fail.  This change adds a configurable polling functionality to wait till the app shows up and bomb out if the app doesn't appear.