### PR TITLE
Fix Azure tentacle templates with correct default value

### DIFF
--- a/step-templates/azure-install-windows-tentacle.json
+++ b/step-templates/azure-install-windows-tentacle.json
@@ -1,9 +1,9 @@
 {
-    "Id": "07b23f27-e76a-4b4b-acb1-017006a83269",
-    "Name": "Azure Windows - Install Octopus Tentacle",
+  "Id": "07b23f27-e76a-4b4b-acb1-017006a83269",
+  "Name": "Azure Windows - Install Octopus Tentacle",
   "Description": "This step template will install the latest tentacle on an Azure hosted, Windows virtual machine. This will also open the firewall for inbound traffic on port 10933 on both the NSG and the the vm.\n<hr />\n*note: expects the Azure CLI to be installed on the worker running this task*",
   "ActionType": "Octopus.AzurePowerShell",
-  "Version": 3,
+  "Version": 4,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
@@ -118,7 +118,7 @@
       "Name": "installWinTentacle.tentacleType",
       "Label": "Tentacle Type",
       "HelpText": "Select between a listing or polling tentacle",
-      "DefaultValue": "Listening",
+      "DefaultValue": "TentaclePassive",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
         "Octopus.SelectOptions": "TentaclePassive|Listening\nTentacleActive|Polling"
@@ -146,10 +146,10 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2021-08-23T12:40:10.975Z",
-    "OctopusVersion": "2021.1.7687",
+    "ExportedAt": "2022-02-09T15:56:03.173Z",
+    "OctopusVersion": "2021.3.12155",
     "Type": "ActionTemplate"
   },
-    "LastModifiedBy": "benjimac93",
-    "Category": "azure"
+  "LastModifiedBy": "benjimac93",
+  "Category": "azure"
 }

--- a/step-templates/azure-install-windows-tentacle.json
+++ b/step-templates/azure-install-windows-tentacle.json
@@ -150,6 +150,6 @@
     "OctopusVersion": "2021.3.12155",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "benjimac93",
+  "LastModifiedBy": "harrisonmeister",
   "Category": "azure"
 }

--- a/step-templates/azure-linux-install-octopus-tentacle.json
+++ b/step-templates/azure-linux-install-octopus-tentacle.json
@@ -3,7 +3,7 @@
   "Name": "Azure Linux - Install Octopus Tentacle",
   "Description": "This step template will install the latest tentacle on an Azure hosted, Linux virtual machine. This will also open the firewall for inbound traffic on port 10933 on the NSG.\n<hr />\n*Note: Expects the Azure CLI and Powershell to be installed on the worker running this task*<br />\n*Note: Requires dotnet core to be pre-installed on the target machine* <br />\n*Note: Firewall ports will not be opened on the remote machine*",
   "ActionType": "Octopus.AzurePowerShell",
-  "Version": 3,
+  "Version": 4,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
@@ -118,7 +118,7 @@
       "Name": "installLinuxTentacle.tentacleType",
       "Label": "Tentacle Type",
       "HelpText": "Select between a listening or polling tentacle",
-      "DefaultValue": "",
+      "DefaultValue": "TentaclePassive",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
         "Octopus.SelectOptions": "TentaclePassive|Listening\nTentacleActive|Polling"
@@ -146,10 +146,10 @@
     }
   ],
   "$Meta": {
-    "ExportedAt": "2021-08-23T12:40:10.975Z",
-    "OctopusVersion": "2021.1.7687",
+    "ExportedAt": "2022-02-09T15:56:03.173Z",
+    "OctopusVersion": "2021.3.12155",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "benjimac93",
+  "LastModifiedBy": "harrisonmeister",
   "Category": "azure"
 }


### PR DESCRIPTION
Fix Azure tentacle templates with correct default value:

- `Azure Windows - Install Octopus Tentacle`
- `Azure Linux - Install Octopus Tentacle`