### PR TITLE
fix incorrect flag to opslevel CLI

### DIFF
--- a/step-templates/opslevel-create-deploy-event-bash.json
+++ b/step-templates/opslevel-create-deploy-event-bash.json
@@ -3,7 +3,7 @@
   "Name": "OpsLevel - Create Deploy Event - Bash",
   "Description": "Track deploys to your services across different environments in [OpsLevel](https://www.opslevel.com/docs/insights/deploys/).",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -22,7 +22,7 @@
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "Bash",
-    "Octopus.Action.Script.ScriptBody": "if test -f \"#{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel\"; then\n\tchmod +x #{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel\n\tcat << EOF | #{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel create deploy --logLevel=WARN -i #{OL_INTEGRATION_URL} -f -\nservice: #{OL_SERVICE}\ndescription: #{OL_DESCRIPTION}\nenvironment: #{OL_ENVIRONMENT}\ndeploy-number: #{OL_DEPLOY_NUMBER}\ndeploy-url: #{OL_DEPLOY_URL}\ndedup-id: #{OL_DEDUP_ID}\ndeployer:\n  name: #{OL_DEPLOYER_NAME}\n  email: #{OL_DEPLOYER_EMAIL}\n#{if Octopus.Release.Package}\n#{if Octopus.Release.Package[].Commits}\ncommit:\n  sha: \"#{Octopus.Release.Package[0].Commits[0].CommitId}\"\n  message: \"#{Octopus.Release.Package[0].Commits[0].Comment}\"\n#{/if}\n#{/if}\nEOF\nelse\n\techo \"Please ensure the `opslevel` CLI package is setup and installed!\"\nfi"
+    "Octopus.Action.Script.ScriptBody": "if test -f \"#{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel\"; then\n\tchmod +x #{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel\n\tcat << EOF | #{Octopus.Action.Package[OpsLevel].ExtractedPath}/opslevel create deploy --log-level=WARN -i #{OL_INTEGRATION_URL} -f -\nservice: #{OL_SERVICE}\ndescription: #{OL_DESCRIPTION}\nenvironment: #{OL_ENVIRONMENT}\ndeploy-number: #{OL_DEPLOY_NUMBER}\ndeploy-url: #{OL_DEPLOY_URL}\ndedup-id: #{OL_DEDUP_ID}\ndeployer:\n  name: #{OL_DEPLOYER_NAME}\n  email: #{OL_DEPLOYER_EMAIL}\n#{if Octopus.Release.Package}\n#{if Octopus.Release.Package[].Commits}\ncommit:\n  sha: \"#{Octopus.Release.Package[0].Commits[0].CommitId}\"\n  message: \"#{Octopus.Release.Package[0].Commits[0].Comment}\"\n#{/if}\n#{/if}\nEOF\nelse\n\techo \"Please ensure the `opslevel` CLI package is setup and installed!\"\nfi"
   },
   "Parameters": [
     {

--- a/step-templates/opslevel-create-deploy-event-ps.json
+++ b/step-templates/opslevel-create-deploy-event-ps.json
@@ -3,7 +3,7 @@
   "Name": "OpsLevel - Create Deploy Event - Powershell",
   "Description": "Track deploys to your services across different environments in [OpsLevel](https://www.opslevel.com/docs/insights/deploys/).",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -22,7 +22,7 @@
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "if (Test-Path -Path #{Octopus.Action.Package[OpsLevel].ExtractedPath}\\opslevel.exe -PathType Leaf) {\n\t@\"\nservice: #{OL_SERVICE}\ndescription: #{OL_DESCRIPTION}\nenvironment: #{OL_ENVIRONMENT}\ndeploy-number: #{OL_DEPLOY_NUMBER}\ndeploy-url: #{OL_DEPLOY_URL}\ndedup-id: #{OL_DEDUP_ID}\ndeployer:\n  name: #{OL_DEPLOYER_NAME}\n  email: #{OL_DEPLOYER_EMAIL}\n#{if Octopus.Release.Package}\n#{if Octopus.Release.Package[].Commits}\ncommit:\n  sha: \\\"#{Octopus.Release.Package[0].Commits[0].CommitId}\\\"\n  message: \\\"#{Octopus.Release.Package[0].Commits[0].Comment}\\\"\n#{/if}\n#{/if}\n\"@ | #{Octopus.Action.Package[OpsLevel].ExtractedPath}\\opslevel.exe create deploy --logLevel=WARN -i \"#{OL_INTEGRATION_URL}\" -f -\n} else {\n\tWrite-Host \"Please ensure the `opslevel` CLI package is setup and installed!\"\n}\n"
+    "Octopus.Action.Script.ScriptBody": "if (Test-Path -Path #{Octopus.Action.Package[OpsLevel].ExtractedPath}\\opslevel.exe -PathType Leaf) {\n\t@\"\nservice: #{OL_SERVICE}\ndescription: #{OL_DESCRIPTION}\nenvironment: #{OL_ENVIRONMENT}\ndeploy-number: #{OL_DEPLOY_NUMBER}\ndeploy-url: #{OL_DEPLOY_URL}\ndedup-id: #{OL_DEDUP_ID}\ndeployer:\n  name: #{OL_DEPLOYER_NAME}\n  email: #{OL_DEPLOYER_EMAIL}\n#{if Octopus.Release.Package}\n#{if Octopus.Release.Package[].Commits}\ncommit:\n  sha: \\\"#{Octopus.Release.Package[0].Commits[0].CommitId}\\\"\n  message: \\\"#{Octopus.Release.Package[0].Commits[0].Comment}\\\"\n#{/if}\n#{/if}\n\"@ | #{Octopus.Action.Package[OpsLevel].ExtractedPath}\\opslevel.exe create deploy --log-level=WARN -i \"#{OL_INTEGRATION_URL}\" -f -\n} else {\n\tWrite-Host \"Please ensure the `opslevel` CLI package is setup and installed!\"\n}\n"
   },
   "Parameters": [
     {


### PR DESCRIPTION
This updates our step to use the correct log-level flag.

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author

