### PR TITLE
Creating the json validator, version one

### DIFF
--- a/step-templates/json-validate-format-and-schema.json
+++ b/step-templates/json-validate-format-and-schema.json
@@ -1,0 +1,44 @@
+{
+  "Id": "7f4f6d86-50aa-43b1-be7b-f0ab27e4a0ac",
+  "Name": "JSON - Validate format and schema",
+  "Description": null,
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Python",
+    "Octopus.Action.Script.ScriptBody": "import json\nfrom jsonschema import validate\n\ndef validateJSON(jsonData):\n    try:\n        #jsonData must be STRING type\n        json.loads(jsonData)\n    except Exception as e:\n        #print(str(e))\n        #print(e.message)\n        return str(e)\n    return None\n\ndef validateSchema(jsonData, jsonSchema):\n    try:\n        validate(instance=json.loads(jsonData), schema=json.loads(jsonSchema))\n    except Exception as e:\n        #print(e.message)\n        #print(str(e))\n        return e.message\n    return None\n\nvSchema = get_octopusvariable(\"vSchema\")\nvJsonData = get_octopusvariable(\"vJsonData\")\n\nvError = validateJSON(vJsonData)\nif vError == None:\n   vRslt = 'Correct!'\n   print('JSON Structure is valid !','\\n')\n\n   if vSchema:\n      vError = validateSchema(vJsonData, vSchema)\n      if vError == None:\n         vRslt = 'Correct!'\n         print('JSON Schema is valid !','\\n')\n      else:\n         vRslt = 'Wrong !'        \n         print('JSON Schema error:', vError, file=sys.stderr)\nelse:\n    vRslt = 'Wrong!'\n    print('JSON structure error:', vError, file=sys.stderr)\n\nprint ('Result:', vRslt)"
+  },
+  "Parameters": [
+    {
+      "Id": "9b3e93aa-0cef-45e9-bd9c-268bf66ddd5b",
+      "Name": "vJsonData",
+      "Label": "JSON",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "3089fe56-964f-4d5f-b940-31ca81e358cb",
+      "Name": "vSchema",
+      "Label": "Schema",
+      "HelpText": null,
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2022-05-27T22:02:24.575Z",
+    "OctopusVersion": "2022.1.2121",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "cramoscr",
+  "Category": "json"
+}


### PR DESCRIPTION
---

### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
