### PR TITLE
Removing Windows Auth from mariadb

### DIFF
--- a/step-templates/mariadb-add-database-user-to-role.json
+++ b/step-templates/mariadb-add-database-user-to-role.json
@@ -90,7 +90,7 @@
         "DefaultValue": "usernamepassword",
         "DisplaySettings": {
             "Octopus.ControlType": "Select",
-            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nwindowsauthentication|Windows Authentication\nusernamepassword|Username\\Password"
+            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nusernamepassword|Username\\Password"
         }
     }
     ],

--- a/step-templates/mariadb-add-database-user-to-role.json
+++ b/step-templates/mariadb-add-database-user-to-role.json
@@ -3,7 +3,7 @@
     "Name": "MariaDB - Add Database User To Role",
     "Description": "Adds a database user to a role",
     "ActionType": "Octopus.Script",
-    "Version": 4,
+    "Version": 5,
     "Author": "twerthi",
     "Packages": [],
     "Properties": {

--- a/step-templates/mariadb-create-database.json
+++ b/step-templates/mariadb-create-database.json
@@ -70,7 +70,7 @@
         "DefaultValue": "usernamepassword",
         "DisplaySettings": {
             "Octopus.ControlType": "Select",
-            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nwindowsauthentication|Windows Authentication\nusernamepassword|Username\\Password"
+            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nusernamepassword|Username\\Password"
         }
     }
     ],

--- a/step-templates/mariadb-create-database.json
+++ b/step-templates/mariadb-create-database.json
@@ -3,7 +3,7 @@
     "Name": "MariaDB - Create Database If Not Exists",
     "Description": "Creates a MariaDB database if it doesn't already exist.",
     "ActionType": "Octopus.Script",
-    "Version": 4,
+    "Version": 5,
     "Author": "twerthi",
     "Packages": [],
     "Properties": {

--- a/step-templates/mariadb-create-user.json
+++ b/step-templates/mariadb-create-user.json
@@ -90,7 +90,7 @@
         "DefaultValue": "usernamepassword",
         "DisplaySettings": {
             "Octopus.ControlType": "Select",
-            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nwindowsauthentication|Windows Authentication\nusernamepassword|Username\\Password"
+            "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nusernamepassword|Username\\Password"
         }
     }
     ],

--- a/step-templates/mariadb-create-user.json
+++ b/step-templates/mariadb-create-user.json
@@ -3,7 +3,7 @@
     "Name": "MariaDB - Create User If Not Exists",
     "Description": "Creates a new user account on a MariaDB database server",
     "ActionType": "Octopus.Script",
-    "Version": 4,
+    "Version": 5,
     "Author": "twerthi",
     "Packages": [],
     "Properties": {


### PR DESCRIPTION


---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes goofup by me to include Windows Auth.
