### PR TITLE
Adding new SQL Server templates.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7773,9 +7773,9 @@
       }
     },
     "jasmine-core": {
-      "version": "3.99.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.1.tgz",
-      "integrity": "sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==",
+      "version": "3.99.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.99.0.tgz",
+      "integrity": "sha512-+ZDaJlEfRopINQqgE+hvzRyDIQDeKfqqTvF8RzXsvU1yE3pBDRud2+Qfh9WvGgRpuzqxyQJVI6Amy5XQ11r/3w==",
       "dev": true
     },
     "jasmine-reporters": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^2.6.5",
     "gulp-uglify-es": "^2.0.0",
+    "jasmine-core": "3.99.0",
     "jasmine-reporters": "^2.5.0",
     "jasmine-terminal-reporter": "^1.0.3",
     "node-sass": "^7.0.1",

--- a/step-templates/sql-create-database-enhanced.json
+++ b/step-templates/sql-create-database-enhanced.json
@@ -1,0 +1,96 @@
+{
+    "Id": "ba43c3a7-fb77-4377-a1e2-e7918fb6df0b",
+    "Name": "SQL - Create Database If Not Exists Enhanced",
+    "Description": "Creates a database if the database does not exist without using SMO. ",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [],
+    "Properties": {
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "# Initialize variables\n$connectionString = \"\"\n$sqlConnection = New-Object System.Data.SqlClient.SqlConnection\n\n# Determine authentication method\nswitch ($createAuthenticationMethod)\n{\n\t\"AzureADManaged\"\n    {\n    \tWrite-Host \"Using Azure Managed Identity authentication ...\"\n        $connectionString = \"Server=$createSqlServer;Database=master;\"\n        #$token = Invoke-RestMethod -Method GET -Uri \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ossrdbms-aad.database.windows.net\" -Headers @{\"MetaData\" = \"true\"}\n        $response = Invoke-WebRequest -Uri 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fdatabase.windows.net%2F' -Method GET -Headers @{Metadata=\"true\"}\n        $content = $response.Content | ConvertFrom-Json\n        $AccessToken = $content.access_token\n        \n        $sqlConnection.AccessToken = $AccessToken\n        break\n    }\n    \"SqlAuthentication\"\n    {\n    \tWrite-Host \"Using Sql account authentication ...\"\n        $connectionString = \"Server=$createSqlServer;Database=master;User ID=$createSqlLoginUserWhoHasCreateUserRights;Password=$createSqlLoginPasswordWhoHasRights;\"\n        break\n    }\n    \"WindowsIntegrated\"\n    {\n    \tWrite-Host \"Using Windows Integrated authentication ...\"\n        $connectionString = \"Server=$createSqlServer;Database=master;integrated security=true;\"\n        break\n    }\n}\n\n\n$sqlConnection.ConnectionString = $connectionString\n\n$command = $sqlConnection.CreateCommand()\n$command.CommandType = [System.Data.CommandType]'Text'\n$command.CommandTimeout = $createCommandTimeout\n\nWrite-Host \"Opening the connection to $createSqlServer\"\n$sqlConnection.Open()\n\n$escapedDatabaseName = $createDatabaseName.Replace(\"'\", \"''\")\n\nWrite-Host \"Running the if not exists then create for $createDatabaseName\"\n$command.CommandText = \"IF NOT EXISTS (select Name from sys.databases where Name = '$escapedDatabaseName')\n        create database [$createDatabaseName]\"\n        \nif (![string]::IsNullOrEmpty($createAzureEdition))\n{\n\t$command.CommandText += (\"`r`n (EDITION = '{0}');\" -f $createAzureEdition)\n}\n\n$command.ExecuteNonQuery()\n\nWrite-Host \"Successfully created the account $createDatabaseName\"\nWrite-Host \"Closing the connection to $createSqlServer\"\n$sqlConnection.Close()"
+    },
+    "Parameters": [
+      {
+        "Id": "4a30febf-479b-4427-a382-04a84183e1ae",
+        "Name": "createSqlServer",
+        "Label": "SQL Server",
+        "HelpText": "The SQL Server to perform the work on",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "9cfe1756-9e7d-4670-af75-1bb4a1899ce1",
+        "Name": "createAuthenticationMethod",
+        "Label": "Authentication Method",
+        "HelpText": "Select the method for authentication to the SQL Server.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Select",
+          "Octopus.SelectOptions": "AzureADManaged|Azure Active Directory Managed Identity\nSqlAuthentication|SQL Authentication\nWindowsIntegrated|Windows Integrated"
+        }
+      },
+      {
+        "Id": "ba759a10-c230-4530-855a-2d7e210fe822",
+        "Name": "createSqlLoginUserWhoHasCreateUserRights",
+        "Label": "SQL Login",
+        "HelpText": "The login of the user who has permissions to create a database.\n\nLeave blank for integrated security",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "0519fc45-e342-4982-beea-ab5123cad39b",
+        "Name": "createSqlLoginPasswordWhoHasRights",
+        "Label": "SQL Password",
+        "HelpText": "The password of the user who has permissions to create SQL Logins\n\nLeave blank for integrated security",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "0662b998-acf3-425d-8fff-abd93a4a038d",
+        "Name": "createDatabaseName",
+        "Label": "Database to create",
+        "HelpText": "The name of the database to create",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "4617d70a-fb52-4b1b-95f1-07929e47e7c0",
+        "Name": "createCommandTimeout",
+        "Label": "Command timeout",
+        "HelpText": "Number of seconds before throwing a timeout error.",
+        "DefaultValue": "30",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "7be71f0c-4df5-4f41-9b2f-3a29800a2e00",
+        "Name": "createAzureEdition",
+        "Label": "Azure database edition",
+        "HelpText": "Defines the database edition for Azure SQL Databases, leave blank if not using Azure.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Select",
+          "Octopus.SelectOptions": "basic|Basic Edition\nstandard|Standard Edition\npremium|Premium Edition\ngeneralpurpose|General Purpose Edition\nbusinesscritical|Business Critical Edition\nhyperscale|Hyperscale Edition"
+        }
+      }
+    ],
+    "StepPackageId": "Octopus.Script",
+    "$Meta": {
+      "ExportedAt": "2022-07-29T19:31:49.538Z",
+      "OctopusVersion": "2022.3.5513-hotfix.6004",
+      "Type": "ActionTemplate"
+    },
+    "LastModifiedBy": "twerthi",
+    "Category": "sql"
+  }

--- a/step-templates/sql-execute-sql-files.json
+++ b/step-templates/sql-execute-sql-files.json
@@ -89,16 +89,6 @@
         }
       },
       {
-        "Id": "eac66c87-d6c7-4a8d-9fd6-85ea8134e14c",
-        "Name": "DacpacPackageExtractStepName",
-        "Label": "DACPAC Package Extract Step Name",
-        "HelpText": "Optional: The step in which the DACPAC package was installed. Can be left as blank if SQLScripts is a hardcoded value.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "StepName"
-        }
-      },
-      {
         "Id": "3bfed638-6649-438f-a02b-353e36a63c87",
         "Name": "template.Package",
         "Label": "Package",

--- a/step-templates/sql-execute-sql-files.json
+++ b/step-templates/sql-execute-sql-files.json
@@ -10,7 +10,7 @@
         "Id": "8473acaf-aaeb-4c23-923a-91f664290f16",
         "Name": "template.Package",
         "PackageId": null,
-        "FeedId": "Feeds-1221",
+        "FeedId": null,
         "AcquisitionLocation": "Server",
         "Properties": {
           "Extract": "True",

--- a/step-templates/sql-execute-sql-files.json
+++ b/step-templates/sql-execute-sql-files.json
@@ -1,0 +1,120 @@
+{
+    "Id": "2bd3b8ef-35b4-43e9-b6de-8e0c515f3f10",
+    "Name": "SQL - Execute SQL Script Files",
+    "Description": "Executes SQL script file(s) against the specified database using the `SQLServer` Powershell Module.  This template includes an `Authentication` selector and supports SQL Authentication, Windows Authentication, and Azure Managed Identity.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [
+      {
+        "Id": "8473acaf-aaeb-4c23-923a-91f664290f16",
+        "Name": "template.Package",
+        "PackageId": null,
+        "FeedId": "Feeds-1221",
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "Extract": "True",
+          "SelectionMode": "deferred",
+          "PackageParameterName": "template.Package",
+          "Purpose": ""
+        }
+      }
+    ],
+    "Properties": {
+      "Octopus.Action.Script.ScriptBody": "function Get-ModuleInstalled\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName\n    )\n\n    # Check to see if the module is installed\n    if ($null -ne (Get-Module -ListAvailable -Name $PowerShellModuleName))\n    {\n        # It is installed\n        return $true\n    }\n    else\n    {\n        # Module not installed\n        return $false \n    }\n}\n\nfunction Get-NugetPackageProviderNotInstalled\n{\n\t# See if the nuget package provider has been installed\n    return ($null -eq (Get-PackageProvider -ListAvailable -Name Nuget -ErrorAction SilentlyContinue))\n}\n\nfunction Install-PowerShellModule\n{\n    # Define parameters\n    param(\n        $PowerShellModuleName,\n        $LocalModulesPath\n    )\n    \n    # Set TLS order\n    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n\n\t# Check to see if the package provider has been installed\n    if ((Get-NugetPackageProviderNotInstalled) -ne $false)\n    {\n    \t# Display that we need the nuget package provider\n        Write-Host \"Nuget package provider not found, installing ...\"\n        \n        # Install Nuget package provider\n        Install-PackageProvider -Name Nuget -Force\n    }\n\n\t# Save the module in the temporary location\n    Save-Module -Name $PowerShellModuleName -Path $LocalModulesPath -Force\n\n}\n\n\nfunction Invoke-ExecuteSQLScript {\n\n    [CmdletBinding()]\n    param\n    (\n        [parameter(Mandatory = $true, Position = 0)]\n        [ValidateNotNullOrEmpty()]\n        [string]\n        $serverInstance,\n\n        [parameter(Mandatory = $true, Position = 1)]\n        [ValidateNotNullOrEmpty()]\n        [string]\n        $dbName,\n\n        [string]\n        $Authentication,\n\n        [string]\n        $SQLScripts\n    )\n\n\n    # Check to see if SqlServer module is installed\n    if ((Get-ModuleInstalled -PowerShellModuleName \"SqlServer\") -ne $true)\n    {\n    \t# Display message\n        Write-Output \"PowerShell module SqlServer not present, downloading temporary copy ...\"\n\n        # Download and install temporary copy\n        Install-PowerShellModule -PowerShellModuleName \"SqlServer\" -LocalModulesPath $LocalModules\n    }\n\n    # Display\n    Write-Output \"Importing module SqlServer ...\"\n\n    # Import the module\n    Import-Module -Name \"SqlServer\"\n            \n    foreach ($SQLScript in $SQLScripts.Split(\"`n\"))\n    {\n    \ttry \n        {\n\t\t\t$scripts = (Get-ChildItem -Path \"$($OctopusParameters['Octopus.Action.Package[template.Package].ExtractedPath'])\" | Where-Object {$_.Name -eq $SQLScript})\n\n            foreach ($script in $scripts)\n            {\n            \t$sr = New-Object System.IO.StreamReader($script.FullName)\n                $scriptContent = $sr.ReadToEnd()\n                \n                # Execute based on selected authentication method\n                switch ($Authentication)\n                {\n                \t\"AzureADManaged\"\n                    {\n          \t\t\t\t# Get login token\n          \t\t\t\tWrite-Host \"Authenticating with Azure Managed Identity ...\"\n                        \n        \t\t\t\t$response = Invoke-WebRequest -Uri 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fdatabase.windows.net%2F' -Method GET -Headers @{Metadata=\"true\"}\n\t\t\t\t        $content = $response.Content | ConvertFrom-Json\n        \t\t\t\t$AccessToken = $content.access_token\n\n          \t\t\t\tInvoke-SqlCmd -Query $scriptContent -ServerInstance $serverInstance -AccessToken $AccessToken -Database $dbName\n                        \n                        break\n                    }\n                    \"SqlAuthentication\"\n                    {\n                    \tWrite-Host \"Authentication with SQL Authentication ...\"\n                        Invoke-SqlCmd -Query $scriptContent -ServerInstance $serverInstance -Username $username -Password $password -Database $dbName\n                        \n                        break\n                    }\n                    \"WindowsIntegrated\"\n                    {\n                    \tWrite-Host \"Authenticating with Windows Authentication ...\"\n                        Invoke-SqlCmd -Query $scriptContent -ServerInstance $serverInstance -Database $dbName\n                    }\n                }\n                \n                \n                $sr.Close()\n\n\t\t\t\twrite-verbose (\"Executed manual script - {0}\" -f $script.Name)\n            }\n        }\n        catch \n        {\n        \tWrite-Error $_.Exception\n        }\n    }\n}\n\n# Define PowerShell Modules path\n$LocalModules = (New-Item \"$PSScriptRoot\\Modules\" -ItemType Directory -Force).FullName\n$env:PSModulePath = \"$LocalModules$([System.IO.Path]::PathSeparator)$env:PSModulePath\"\n\nif (Test-Path Variable:OctopusParameters)\n{\n        Write-Verbose \"Locating scripts from the literal entry of Octopus Parameter SQLScripts\"\n        $ScriptsToExecute = $OctopusParameters[\"SQLScripts\"]\n        \n        Invoke-ExecuteSQLScript -serverInstance $OctopusParameters[\"serverInstance\"] `\n                                -dbName $OctopusParameters[\"dbName\"] `\n                                -Authentication $OctopusParameters[\"Authentication\"] `\n                                -SQLScripts $ScriptsToExecute\n}",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.RunOnServer": "false"
+    },
+    "Parameters": [
+      {
+        "Id": "1f2b60c9-b85c-4c23-a313-fc18e82cd500",
+        "Name": "serverInstance",
+        "Label": "Server Instance Name",
+        "HelpText": "The SQL Server Instance name",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "9884b8c1-01a0-4c6f-97b1-ff5146fa0836",
+        "Name": "dbName",
+        "Label": "Database Name",
+        "HelpText": "The database name",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "05dc20d9-f75c-4971-9efb-e9aaad82a3a9",
+        "Name": "Authentication",
+        "Label": "Authentication",
+        "HelpText": "The authentication method",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Select",
+          "Octopus.SelectOptions": "SqlAuthentication|SQL Authentication\nWindowsIntegrated|Windows Integrated\nAzureADManaged|Azure Active Directory Managed Identity"
+        }
+      },
+      {
+        "Id": "4c2fc1b4-bdd0-4a9a-adb1-da1e818e62bc",
+        "Name": "Username",
+        "Label": "Username",
+        "HelpText": "The username to use to connect (only applies with SqlAuthentication selected)",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "819f9b19-042d-42d8-9d19-5f5bf28c06b7",
+        "Name": "Password",
+        "Label": "Password",
+        "HelpText": "The password to use to connect (only applies with SqlAuthentication selected)",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "dd22f955-8317-4d58-8173-fc7d44df1192",
+        "Name": "SQLScripts",
+        "Label": "SQL Scripts",
+        "HelpText": "Full path to each script name on a new line\nWildcards are accepted, eg. C:\\Scripts\\*.sql, C:\\Scripts\\Deploy*.sql",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "MultiLineText"
+        }
+      },
+      {
+        "Id": "eac66c87-d6c7-4a8d-9fd6-85ea8134e14c",
+        "Name": "DacpacPackageExtractStepName",
+        "Label": "DACPAC Package Extract Step Name",
+        "HelpText": "Optional: The step in which the DACPAC package was installed. Can be left as blank if SQLScripts is a hardcoded value.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "StepName"
+        }
+      },
+      {
+        "Id": "3bfed638-6649-438f-a02b-353e36a63c87",
+        "Name": "template.Package",
+        "Label": "Package",
+        "HelpText": "Package containing the SQL scripts to be executed.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Package"
+        }
+      }
+    ],
+    "StepPackageId": "Octopus.Script",
+    "$Meta": {
+      "ExportedAt": "2022-07-29T19:34:49.064Z",
+      "OctopusVersion": "2022.3.5513-hotfix.6004",
+      "Type": "ActionTemplate"
+    },
+    "LastModifiedBy": "twerthi",
+    "Category": "sql"
+  }

--- a/step-templates/sql-execute-sql-files.json
+++ b/step-templates/sql-execute-sql-files.json
@@ -1,7 +1,7 @@
 {
     "Id": "2bd3b8ef-35b4-43e9-b6de-8e0c515f3f10",
     "Name": "SQL - Execute SQL Script Files",
-    "Description": "Executes SQL script file(s) against the specified database using the `SQLServer` Powershell Module.  This template includes an `Authentication` selector and supports SQL Authentication, Windows Authentication, and Azure Managed Identity.",
+    "Description": "Executes SQL script file(s) against the specified database using the `SQLServer` Powershell Module.  This template includes an `Authentication` selector and supports SQL Authentication, Windows Authentication, and Azure Managed Identity.\n\nNote: If the `SqlServer` PowerShell module is not present, the template will download a temporary copy to perform the task.",
     "ActionType": "Octopus.Script",
     "Version": 1,
     "CommunityActionTemplateId": null,


### PR DESCRIPTION

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it


