### PR TITLE
Adding google tag manager

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -1,6 +1,15 @@
 doctype html
 html
   head
+    //- <!-- Google Tag Manager -->
+    script(type='text/javascript').
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-M6BF84M');
+    //- <!-- End Google Tag Manager -->
+
     meta(charset='UTF-8')
     meta(http-equiv='X-UA-Compatible',content='IE=edge')
     meta(name='viewport',content='width=device-width, initial-scale=1.0')
@@ -19,6 +28,11 @@ html
     //- inject:css
     //- endinject
   body
+    //- <!-- Google Tag Manager (noscript) -->
+    noscript
+      iframe(src="https://www.googletagmanager.com/ns.html?id=GTM-M6BF84M" height="0" width="0" style="display:none;visibility:hidden")
+    //- <!-- End Google Tag Manager (noscript) -->
+
     script(type='text/javascript').
       window.stepTemplates = !{stepTemplates}
 


### PR DESCRIPTION
This PR adds google tag manager to the octopus Library [internal Slack thread for reference 🔒](https://octopusdeploy.slack.com/archives/C020P7U9Z9S/p1658929201189609).  This adds google tag manager to all pages via the server index.pug with the following html 

![image](https://user-images.githubusercontent.com/101079287/182056936-e1a07de6-e86b-48ea-a144-5435779c2cca.png)