### PR TITLE
Add capturing liquibase command output

### DIFF
--- a/step-templates/liquibase-run-command.json
+++ b/step-templates/liquibase-run-command.json
@@ -1,7 +1,7 @@
 {
   "Id": "36df3e84-8501-4f2a-85cc-bd9eb22030d1",
   "Name": "Liquibase - Run command",
-  "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.\n\nNote:\n- AWS EC2 IAM Authentication requires the AWS CLI to be installed.\n- Windows Authentication has been tested with \n  - Microsoft SQL Server \n  - PostgreSQL",
+  "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.\n\nNote:\n- AWS EC2 IAM Authentication requires the AWS CLI to be installed.\n- Windows Authentication has been tested with \n  - Microsoft SQL Server \n  - PostgreSQL\n\nOnce the Liquibase commands have executed, the output is stored in an Octopus [output variable](https://octopus.com/docs/projects/variables/output-variables) called `LiquibaseCommandOutput` for use in subsequent Octopus deployment or runbook steps.",
   "ActionType": "Octopus.Script",
   "Version": 15,
   "Author": "twerthi",

--- a/step-templates/liquibase-run-command.json
+++ b/step-templates/liquibase-run-command.json
@@ -1,73 +1,73 @@
 {
-    "Id": "36df3e84-8501-4f2a-85cc-bd9eb22030d1",
-    "Name": "Liquibase - Run command",
-    "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.\n\nNote:\n- AWS EC2 IAM Authentication requires the AWS CLI to be installed.\n- Windows Authentication has been tested with \n  - Microsoft SQL Server \n  - PostgreSQL",
-    "ActionType": "Octopus.Script",
-    "Version": 14,
-    "Author": "twerthi",
-    "Packages": [
-      {
-        "Name": "liquibaseChangeset",
-        "Id": "15eeeac8-d80d-46ba-bc52-413fddae36f3",
-        "PackageId": null,
-        "FeedId": null,
-        "AcquisitionLocation": "Server",
-        "Properties": {
-          "Extract": "True",
-          "SelectionMode": "deferred",
-          "PackageParameterName": "liquibaseChangeset"
-        }
+  "Id": "36df3e84-8501-4f2a-85cc-bd9eb22030d1",
+  "Name": "Liquibase - Run command",
+  "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.\n\nNote:\n- AWS EC2 IAM Authentication requires the AWS CLI to be installed.\n- Windows Authentication has been tested with \n  - Microsoft SQL Server \n  - PostgreSQL",
+  "ActionType": "Octopus.Script",
+  "Version": 15,
+  "Author": "twerthi",
+  "Packages": [
+    {
+      "Name": "liquibaseChangeset",
+      "Id": "15eeeac8-d80d-46ba-bc52-413fddae36f3",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "liquibaseChangeset"
       }
-    ],
-    "Properties": {
-      "Octopus.Action.Script.ScriptSource": "Inline",
-      "Octopus.Action.Script.Syntax": "PowerShell",
-      "Octopus.Action.Script.ScriptBody": "# Configure template\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows)\n{\n\tWrite-Host \"Determining Operating System...\"\n    switch ([System.Environment]::OSVersion.Platform)\n    {\n    \t\"Win32NT\"\n        {\n        \t# Set variable\n            $IsWindows = $true\n            $IsLinux = $false\n        }\n        \"Unix\"\n        {\n        \t$IsWindows = $false\n            $IsLinux = $true\n        }\n    }\n}\n\n# Set TLS\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n\n# Disable progress bar for PowerShell\n$ProgressPreference = 'SilentlyContinue'\n\n# Downloads and extracts liquibase to the work folder\nFunction Get-Liquibase\n{\n    # Define parameters\n    param ($Version) \n\n\t$repositoryName = \"liquibase/liquibase\"\n\n    # Check to see if version wasn't specified\n    if ([string]::IsNullOrEmpty($Version))\n    {\n        # Get the latest version download url\n        $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".zip\")})\n    }\n    else\n    {\n    \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $Version | Where-Object {$_.EndsWith(\".zip\")})\n    }\n\n\tExpand-DownloadedFile -DownloadUrls $downloadUrl\n}\n\n# Downloads the files\nFunction Expand-DownloadedFile\n{\n\t# Define parameters\n    param (\n    \t$DownloadUrls\n    )\n    \n     # Loop through results\n    foreach ($url in $DownloadUrls)\n    {\n        # Download the zip file\n        $folderName = [System.IO.Path]::GetFileName(\"$PSScriptroot/$($url.Substring($url.LastIndexOf(\"/\")))\").Replace(\".zip\", \"\")\n        $zipFile = \"$PSScriptroot/$folderName/$($url.Substring($url.LastIndexOf(\"/\")))\"\n        Write-Host \"Downloading $zipFile from $url ...\"\n        \n        if ((Test-Path -Path \"$PSScriptroot/$folderName\") -eq $false)\n        {\n            # Create folder\n            New-Item -Path \"$PSScriptroot/$folderName/\" -ItemType Directory\n        }\n\n        # Download the zip file\n        Invoke-WebRequest -Uri $url -OutFile $zipFile -UseBasicParsing\n\n        # Extract package\n        Write-Host \"Extracting $zipFile ...\"\n        Expand-Archive -Path $zipFile -DestinationPath \"$PSSCriptRoot/$folderName\"\n    }\n}\n\n\n# Downloads and extracts Java to the work folder, then adds the location of java.exe to the $env:PATH variabble so it can be called\nFunction Get-Java\n{\n    # Check to see if a folder needs to be created\n    if((Test-Path -Path \"$PSScriptRoot/jdk\") -eq $false)\n    {\n        # Create new folder\n        New-Item -ItemType Directory -Path \"$PSSCriptRoot/jdk\"\n    }\n\n    # Download java\n    Write-Output \"Downloading Java ... \"\n    \n    # Determine OS\n    if ($IsWindows)\n    {\n      Invoke-WebRequest -Uri \"https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip\" -OutFile \"$PSScriptroot/jdk/openjdk-14.0.2_windows-x64_bin.zip\" -UseBasicParsing\n\n      # Extract\n      Write-Output \"Extracting Java ... \"\n      Expand-Archive -Path \"$PSScriptroot\\jdk\\openjdk-14.0.2_windows-x64_bin.zip\" -DestinationPath \"$PSSCriptRoot/jdk\"\n\n      # Get Java executable\n      $javaExecutable = Get-ChildItem -Path \"$PSScriptRoot\\jdk\" -Recurse | Where-Object {$_.Name -eq \"java.exe\"}\n    }\n    \n    if ($IsLinux)\n    {\n      Invoke-WebRequest -Uri \"https://download.java.net/openjdk/jdk14/ri/openjdk-14+36_linux-x64_bin.tar.gz\" -OutFile \"$PSScriptroot/jdk/openjdk-14+36_linux-x64_bin.tar.gz\" -UseBasicParsing\n\n      # Extract\n      Write-Output \"Extracting Java ... \"\n      tar -xvzf \"$PSScriptroot/jdk/openjdk-14+36_linux-x64_bin.tar.gz\" --directory \"$PSScriptRoot/jdk\"\n\n      # Get Java executable\n      $javaExecutable = Get-ChildItem -Path \"$PSScriptRoot/jdk\" -Recurse | Where-Object {$_.Name -eq \"java\"}   \n    }\n    \n    # Add path to current session as first entry to bypass other versions of Java that may be installed.\n    $env:PATH = \"$($javaExecutable.Directory)$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n}\n\n# Gets download url of latest release with an asset\nFunction Get-LatestVersionDownloadUrl\n{\n    # Define parameters\n    param(\n    \t$Repository,\n        $Version\n    )\n    \n    # Define local variables\n    $releases = \"https://api.github.com/repos/$Repository/releases\"\n    \n    # Get latest version\n    Write-Host \"Determining latest release of $Repository ...\"\n    \n    $tags = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)\n    \n    if ($null -ne $Version)\n    {\n    \t$tags = ($tags | Where-Object {$_.name.EndsWith($Version)})\n    }\n\n    # Find the latest version with a downloadable asset\n    foreach ($tag in $tags)\n    {\n        if ($tag.assets.Count -gt 0)\n        {\n            return $tag.assets.browser_download_url\n        }\n    }\n\n    # Return the version\n    return $null\n}\n\n# Finds the specified changelog file\nFunction Get-ChangeLog\n{\n    # Define parameters\n    param ($FileName)\n    \n    # Find file\n    $fileReference = (Get-ChildItem -Path $OctopusParameters[\"Octopus.Action.Package[liquibaseChangeSet].ExtractedPath\"] -Recurse | Where-Object {$_.Name -eq $FileName})\n\n    # Check to see if something weas returned\n    if ($null -eq $fileReference)\n    {\n        # Not found\n        Write-Error \"$FileName was not found in $PSScriptRoot or subfolders.\"\n    }\n\n    # Return the reference\n    return $fileReference\n}\n\n# Downloads the appropriate JDBC driver\nFunction Get-DatabaseJar\n{\n    # Define parameters\n    param ($DatabaseType)\n\n    # Declare local variables\n    $driverPath = \"\"\n\n    # Check to see if a folder needs to be created\n    if((Test-Path -Path \"$PSScriptRoot/DatabaseDriver\") -eq $false)\n    {\n        # Create new folder\n        New-Item -ItemType Directory -Path \"$PSSCriptRoot/DatabaseDriver\" | Out-Null\n    }\n\n    # Download the driver for the selected type\n    switch ($DatabaseType)\n    {\n        \"Cassandra\"\n        {\n        \tWrite-Host \"Downloading Simba JDBC driver ...\"\n            Invoke-WebRequest -Uri \"https://downloads.datastax.com/jdbc/cql/2.0.8.1009/SimbaCassandraJDBC42-2.0.8.1009.zip\" -OutFile \"$PSScriptroot\\DatabaseDriver\\SimbaCassandraJDBC42-2.0.8.1009.zip\" -UseBasicParsing\n            \n            # Extract package\n            Write-Host \"Extracting Simba JDBC driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/SimbaCassandraJDBC42-2.0.8.1009.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSSCriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"CassandraJDBC42.jar\"}).FullName\n\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-cassandra\"\n            \n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }           \n\n\t\t\tWrite-Host \"Downloading Cassandra Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\") + 1))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n\n        \tbreak\n        }\n        \"MariaDB\"\n        {\n            # Download MariaDB driver\n            Write-Host \"Downloading MariaDB driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/mariadb-java-client-2.6.2.jar\"\n            Invoke-WebRequest -Uri \"https://downloads.mariadb.com/Connectors/java/connector-java-2.6.2/mariadb-java-client-2.6.2.jar\" -OutFile $driverPath -UseBasicParsing\n             \n            break\n        }\n        \"MongoDB\"\n        {\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-mongodb\"\n            \n            # Download MongoDB driver\n            Write-Host \"Downloading Maven MongoDB driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/mongo-java-driver-3.12.7.jar\"\n            Invoke-WebRequest -Uri \"https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.12.7/mongo-java-driver-3.12.7.jar\" -Outfile $driverPath -UseBasicParsing\n            \n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }\n                        \n\t\t\tWrite-Host \"Downloading MongoDB Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\")))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n            \n            break\n        }\n        \"MySQL\"\n        {\n            # Download MariaDB driver\n            Write-Host \"Downloading MySQL driver ...\"\n            Invoke-WebRequest -Uri \"https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.28.zip\" -OutFile \"$PSScriptroot/DatabaseDriver/mysql-connector-java-8.0.28.zip\" -UseBasicParsing\n\n            # Extract package\n            Write-Host \"Extracting MySQL driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/mysql-connector-java-8.0.28.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"mysql-connector-java-8.0.28.jar\"}).FullName\n\n            break\n        }\n        \"Oracle\"\n        {\n            # Download Oracle driver\n            Write-Host \"Downloading Oracle driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/ojdbc10.jar\"\n            Invoke-WebRequest -Uri \"https://download.oracle.com/otn-pub/otn_software/jdbc/211/ojdbc11.jar\" -OutFile $driverPath -UseBasicParsing\n\n            break\n        }\n        \"SqlServer\"\n        {\n            # Download Microsoft driver\n            Write-Host \"Downloading Sql Server driver ...\"\n            Invoke-WebRequest -Uri \"https://go.microsoft.com/fwlink/?linkid=2186163\" -OutFile \"$PSScriptroot/DatabaseDriver/sqljdbc_10.2.0.0_enu.zip\" -UseBasicParsing\n\n            # Extract package\n            Write-Host \"Extracting SqlServer driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/sqljdbc_10.2.0.0_enu.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSSCriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"mssql-jdbc-10.2.0.jre11.jar\"}).FullName\n            \n            # Determine architecture\n            if ([System.Environment]::Is64BitOperatingSystem)\n            {\n            \t# Locate auth dll\n                $authDll = Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse |Where-Object {$_.Name -eq \"mssql-jdbc_auth-10.2.0.x64.dll\"}\n            }\n            else\n            {\n            \t$authDll = Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse |Where-Object {$_.Name -eq \"mssql-jdbc_auth-10.2.0.x86.dll\"}\n            }\n            \n            # Add the dll to the path so it can find it.\n            $env:PATH += \"$([IO.Path]::PathSeparator)$($authDll.Directory)\"\n            \n\t\t\tbreak\n        }\n        \"PostgreSQL\"\n        {\n            # Download PostgreSQL driver\n            Write-Host \"Downloading PostgreSQL driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/postgresql-42.2.12.jar\"\n            Invoke-WebRequest -Uri \"https://jdbc.postgresql.org/download/postgresql-42.2.12.jar\" -OutFile $driverPath -UseBasicParsing\n            \n            # Download the WAFFLE jna driver for Windows Authentication\n            $repositoryName = \"waffle/waffle\"\n            \n            # Latest version of Waffle (2.3.0) doesn't seem to work, can't find sspi method, specify version 1.9.0\n            $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version \"1.9.0\" | Where-Object {$_.EndsWith(\".zip\")})\n            Expand-DownloadedFile -DownloadUrls $downloadUrl | Out-Null\n            \n            # Get all waffle jars\n            $waffleFolder = (Get-ChildItem -Path \"$PSScriptroot\" -Recurse | Where-Object {$_.PSIsContainer -and $_.Name -like \"Waffle*\"})           \n            $waffleJars = (Get-ChildItem -Path $waffleFolder.FullName -Recurse | Where-Object {$_.Extension -eq \".jar\"})\n            \n            foreach ($jar in $waffleJars)\n            {\n            \t$driverPath += \"$([IO.Path]::PathSeparator)$($jar.FullName)\"\n            }\n\n            break\n        }\n        \"Snowflake\"\n        {\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-snowflake\"\n\n\t\t\t# Download Snowflake driver\n            Write-Host \"Downloading Snowflake driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/snowflake-jdbc-3.9.2.jar\"\n            Invoke-WebRequest -Uri \"https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.9.2/snowflake-jdbc-3.9.2.jar\" -OutFile $driverPath -UseBasicParsing\n\n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }\n                        \n\t\t\tWrite-Host \"Downloading Snowflake Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\")))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n\n\n            break\n        }\n        default\n        {\n            # Display error\n            Write-Error \"Unknown database type: $DatabaseType.\"\n        }\n    }\n\n    # Return the driver location\n    return $driverPath\n}\n\n# Returns the connection string formatted for the database type\nFunction Get-ConnectionUrl\n{\n    # Define parameters\n    param ($DatabaseType, \n    \t$ServerPort, \n        $ServerName, \n        $DatabaseName, \n        $QueryStringParameters)\n\n    # Define local variables\n    $connectionUrl = \"\"\n\n    # Download the driver for the selected type\n    switch ($DatabaseType)\n    {\n        \"Cassandra\"\n        {\n            $connectionUrl = \"jdbc:cassandra://{0}:{1};DefaultKeyspace={2}\"\n            break\n        }\n        \"MariaDB\"\n        {\n            $connectionUrl = \"jdbc:mariadb://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?integratedSecurity=true\"\n            }\n            \n            break\n        }\n        \"MongoDB\"\n        {\n        \t$connectionUrl = \"mongodb://{0}:{1}/{2}\"            \n            break\n        }\n        \"MySQL\"\n        {\n            $connectionUrl = \"jdbc:mysql://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?integratedSecurity=true\"\n            }\n            \n            break\n        }\n        \"Oracle\"\n        {\n            $connectionUrl = \"jdbc:oracle:thin:@{0}:{1}/{2}\"\n            break\n        }\n        \"SqlServer\"\n        {\n            $connectionUrl = \"jdbc:sqlserver://{0}:{1};database={2};\"\n            \n            switch ($liquibaseAuthenticationMethod)\n            {\n                \"azuremanagedidentity\"\n                {\n                \t# Add querystring parameter\n                    $connectionUrl += \"Authentication=ActiveDirectoryMSI;\"\n                    break\n                }\n                \"windowsauthentication\"\n                {\n\t            \t# Add querysting parameter\n    \t            $connectionUrl += \"integratedSecurity=true;\"\n                \t\n                    break\n                }\n            }\n            \n            break\n        }\n        \"PostgreSQL\"\n        {\n            $connectionUrl = \"jdbc:postgresql://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?gsslib=sspi\"\n            }\n            \n            break\n        }\n        \"Snowflake\"\n        {\n        \t$connectionUrl = \"jdbc:snowflake://{0}.snowflakecomputing.com?db={2}\"\n            break\n        }\n        default\n        {\n            # Display error\n            Write-Error \"Unkonwn database type: $DatabaseType.\"\n        }\n    }\n\n    if (![string]::IsNullOrWhitespace($QueryStringParameters))\n    {       \t\n        if ($connectionUrl.Contains(\"?\"))\n\t\t{\n           \t# Replace the ? with & in connection string parameters\n            $QueryStringParameters = $QueryStringParameters.Replace(\"?\", \"&\")\n        }\n        \n        # Appen connecion string\n        $connectionUrl += \"$QueryStringParameters\"\n    }\n\n    # Return the url\n    return ($connectionUrl -f $ServerName, $ServerPort, $DatabaseName)\n}\n\n# Create array for arguments\n$liquibaseArguments = @()\n\n# Check for license key\nif (![string]::IsNullOrEmpty($liquibaseProLicenseKey))\n{\n\t# Add key to arguments\n    $liquibaseArguments += \"--liquibaseProLicenseKey=$liquibaseProLicenseKey\"\n}\n\n# Find Change log\n$changeLogFile = (Get-ChangeLog -FileName $liquibaseChangeLogFileName)\n$liquibaseArguments += \"--changeLogFile=$($changeLogFile.Name)\"\n\n# Set the location to where the file is\nSet-Location -Path $changeLogFile.Directory\n\n# Check to see if it needs to be downloaed to machine\nif ($liquibaseDownload -eq $true)\n{\n    # Download and extract liquibase\n    Get-Liquibase -Version $liquibaseVersion -DownloadFolder $workingFolder\n\n    # Download and extract java and add it to PATH environment variable\n    Get-Java\n\n    # Get the driver\n    $driverPath = Get-DatabaseJar -DatabaseType $liquibaseDatabaseType\n\n    # Create folder to hold jar files to override\n    New-Item -Path \"$PWD/liquibase_libs/\" -ItemType Directory    \n    \n    # Copy contents into liquibase_libs folder\n    $driverPaths = $driverPath.Split([IO.Path]::PathSeparator)\n    \n    foreach ($driver in $driverPaths)\n    {\n    \t# Copy the items\n        $files = Get-ChildItem -Path $driver\n        \n        foreach ($file in $files)\n        {\n        \tWrite-Host \"Copying $($file.FullName) to $PWD/liquibase_libs/$($file.Name)\"\n            Copy-Item -Path $file.FullName -Destination \"$PWD/liquibase_libs/$($file.Name)\"\n        }\n    }\n}\nelse\n{\n    if (![string]::IsNullOrEmpty($liquibaseClassPath))\n    {\n    \t$liquibaseArguments += \"--classpath=$liquibaseClassPath\"\n    }\n}\n\n# Check to see if liquibase path has been defined\nif ([string]::IsNullOrEmpty($liquibaseExecutablePath))\n{\n    # Assign root\n    $liquibaseExecutablePath = $PSSCriptRoot\n}\n\n# Get the executable location\nif ($IsWindows)\n{\n\t$liquibaseExecutable = Get-ChildItem -Path $liquibaseExecutablePath -Recurse | Where-Object {$_.Name -eq \"liquibase.bat\"}\n}\n\nif ($IsLinux)\n{\n\t$liquibaseExecutable = Get-ChildItem -Path $liquibaseExecutablePath -Recurse | Where-Object {$_.Name -eq \"liquibase\"}\n}\n\n# Add path to current session\n$env:PATH += \"$([IO.Path]::PathSeparator)$($liquibaseExecutable.Directory)\"\n\n# Check to make sure it was found\nif ([string]::IsNullOrEmpty($liquibaseExecutable))\n{\n    # Could not find the executable\n    Write-Error \"Unable to find liquibase.bat in $PSScriptRoot or subfolders.\"\n}\n\n# Get connection Url\n$connectionUrl = Get-ConnectionUrl -DatabaseType $liquibaseDatabaseType -ServerPort $liquibaseServerPort -ServerName $liquibaseServerName -DatabaseName $liquibaseDatabaseName -QueryStringParameters $liquibaseQueryStringParameters\n\n# Add username\n$liquibaseArguments += \"--username=$liquibaseUsername\"\n\n# Determine authentication method\nswitch ($liquibaseAuthenticationMethod)\n{\n\t\"azuremanagedidentity\"\n    {\n    \t# SQL Server driver doesn't assign password\n        if ($liquibaseDatabaseType -ne \"SqlServer\")\n        {\n          # Get login token\n          Write-Host \"Generating Azure Managed Identity token ...\"\n          $token = Invoke-RestMethod -Method GET -Uri \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ossrdbms-aad.database.windows.net\" -Headers @{\"MetaData\" = \"true\"} -UseBasicParsing\n\n          $liquibasePassword = $token.access_token\n          $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n        }\n    }\n\t\"awsiam\"\n    {\n\t\t# Region is part of the RDS endpoint, extract\n        $region = ($liquibaseServerName.Split(\".\"))[2]\n\n\t\tWrite-Host \"Generating AWS IAM token ...\"\n\t\t$liquibasePassword = (aws rds generate-db-auth-token --hostname $liquibaseServerName --region $region --port $liquibaseServerPort --username $liquibaseUsername)\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n\n\t\tbreak\n    }\n    \"gcpserviceaccount\"\n    {\n        # Define header\n        $header = @{ \"Metadata-Flavor\" = \"Google\"}\n\n        # Retrieve service accounts\n        $serviceAccounts = Invoke-RestMethod -Method Get -Uri \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/\" -Headers $header -UseBasicParsing\n\n        # Results returned in plain text format, get into array and remove empty entries\n        $serviceAccounts = $serviceAccounts.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries)\n\n        # Retreive the specific service account assigned to the VM\n        $serviceAccount = $serviceAccounts | Where-Object {$_.Contains(\"iam.gserviceaccount.com\") }\n\n\t\tWrite-Host \"Generating GCP IAM token ...\"\n        # Retrieve token for account\n        $token = Invoke-RestMethod -Method Get -Uri \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/$serviceAccount/token\" -Headers $header -UseBasicParsing\n        \n        $liquibasePassword = $token.access_token\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n    }\n    \"usernamepassword\"\n    {\n    \t# Add password\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n        \n        break\n    }\n}\n\n# Add connection url\n$liquibaseArguments += \"--url=`\"$connectionUrl`\"\"\n\n# Determine if the output variable needs to be set\nif ($liquibaseCommand.EndsWith(\"SQL\"))\n{\n\t# Add the output variable as the command name\n    $liquibaseArguments += \"--outputFile=`\"$PSScriptRoot/artifacts/$($liquibaseCommand).sql`\"\"\n    \n    # Create the folder\n    if ((Test-Path -Path \"$PSScriptRoot/artifacts\") -eq $false)\n    {\n    \tNew-Item -Path \"$PSScriptRoot/artifacts\" -ItemType \"Directory\"\n    }\n}\n\n\n# Add the additional switches\nforeach ($liquibaseSwitch in $liquibaseAdditionalSwitches)\n{\n    $liquibaseArguments += $liquibaseSwitch\n}\n\nswitch ($liquibaseCommandStyle)\n{\n\t\"legacy\"\n    {\n    \t# Add the command to execute\n\t\t$liquibaseArguments += $liquibaseCommand\n    }\n    \"modern\"\n    {\n    \t# Insert the command at the beginning\n        $liquibaseArguments = @($liquibaseCommand) + $liquibaseArguments\n    }\n}\n\n# Add command arguments\n$liquibaseArguments += $liquibaseCommandArguments\n\n# Display what's going to be run\nif (![string]::IsNullOrWhitespace($liquibasePassword))\n{\n\t$liquibaseDisplayArguments = $liquibaseArguments.PSObject.Copy()\n    $arrayIndex = 0\n    for ($i = 0; $i -lt $liquibaseDisplayArguments.Count; $i++)\n    {\n    \tif ($null -ne $liquibaseDisplayArguments[$i])\n        {\n        \tif ($liquibaseDisplayArguments[$i].Contains($liquibasePassword))\n            {\n                $liquibaseDisplayArguments[$i] = $liquibaseDisplayArguments[$i].Replace($liquibasePassword, \"****\")\n        \t}\n        }\n    }\n    \n    Write-Host \"Executing the following command: $($liquibaseExecutable.FullName) $liquibaseDisplayArguments\"\n}\nelse \n{\n\tWrite-Host \"Executing the following command: $($liquibaseExecutable.FullName) $liquibaseArguments\"\n}\n\n\n# Redirection of stderr to stdout is done different on Windows versus Linux\nif ($IsWindows)\n{\n\t$liquibaseArguments += \"2>&1\"\n\t# Execute Liquibase\n\t& $liquibaseExecutable.FullName $liquibaseArguments\n}\n\nif ($IsLinux)\n{\n\t# Execute Liquibase\n\t& $liquibaseExecutable.FullName $liquibaseArguments 2>&1\n}\n\n# Check exit code\nif ($lastExitCode -ne 0)\n{\n\t# Fail the step\n    Write-Error \"Execution of Liquibase failed!\"\n}\n\n# Check to see if there were any files output\nif ((Test-Path -Path \"$PSScriptRoot/artifacts\") -eq $true)\n{\n\t# Loop through items\n    foreach ($item in (Get-ChildItem -Path \"$PSScriptRoot/artifacts\"))\n    {\n    \tNew-OctopusArtifact -Path $item.FullName -Name $item.Name\n    }\n}\n"
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "# Configure template\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows)\n{\n\tWrite-Host \"Determining Operating System...\"\n    switch ([System.Environment]::OSVersion.Platform)\n    {\n    \t\"Win32NT\"\n        {\n        \t# Set variable\n            $IsWindows = $true\n            $IsLinux = $false\n        }\n        \"Unix\"\n        {\n        \t$IsWindows = $false\n            $IsLinux = $true\n        }\n    }\n}\n\n# Set TLS\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n\n# Disable progress bar for PowerShell\n$ProgressPreference = 'SilentlyContinue'\n\n# Downloads and extracts liquibase to the work folder\nFunction Get-Liquibase\n{\n    # Define parameters\n    param ($Version) \n\n\t$repositoryName = \"liquibase/liquibase\"\n\n    # Check to see if version wasn't specified\n    if ([string]::IsNullOrEmpty($Version))\n    {\n        # Get the latest version download url\n        $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".zip\")})\n    }\n    else\n    {\n    \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $Version | Where-Object {$_.EndsWith(\".zip\")})\n    }\n\n\tExpand-DownloadedFile -DownloadUrls $downloadUrl\n}\n\n# Downloads the files\nFunction Expand-DownloadedFile\n{\n\t# Define parameters\n    param (\n    \t$DownloadUrls\n    )\n    \n     # Loop through results\n    foreach ($url in $DownloadUrls)\n    {\n        # Download the zip file\n        $folderName = [System.IO.Path]::GetFileName(\"$PSScriptroot/$($url.Substring($url.LastIndexOf(\"/\")))\").Replace(\".zip\", \"\")\n        $zipFile = \"$PSScriptroot/$folderName/$($url.Substring($url.LastIndexOf(\"/\")))\"\n        Write-Host \"Downloading $zipFile from $url ...\"\n        \n        if ((Test-Path -Path \"$PSScriptroot/$folderName\") -eq $false)\n        {\n            # Create folder\n            New-Item -Path \"$PSScriptroot/$folderName/\" -ItemType Directory\n        }\n\n        # Download the zip file\n        Invoke-WebRequest -Uri $url -OutFile $zipFile -UseBasicParsing\n\n        # Extract package\n        Write-Host \"Extracting $zipFile ...\"\n        Expand-Archive -Path $zipFile -DestinationPath \"$PSSCriptRoot/$folderName\"\n    }\n}\n\n\n# Downloads and extracts Java to the work folder, then adds the location of java.exe to the $env:PATH variabble so it can be called\nFunction Get-Java\n{\n    # Check to see if a folder needs to be created\n    if((Test-Path -Path \"$PSScriptRoot/jdk\") -eq $false)\n    {\n        # Create new folder\n        New-Item -ItemType Directory -Path \"$PSSCriptRoot/jdk\"\n    }\n\n    # Download java\n    Write-Output \"Downloading Java ... \"\n    \n    # Determine OS\n    if ($IsWindows)\n    {\n      Invoke-WebRequest -Uri \"https://download.java.net/java/GA/jdk14.0.2/205943a0976c4ed48cb16f1043c5c647/12/GPL/openjdk-14.0.2_windows-x64_bin.zip\" -OutFile \"$PSScriptroot/jdk/openjdk-14.0.2_windows-x64_bin.zip\" -UseBasicParsing\n\n      # Extract\n      Write-Output \"Extracting Java ... \"\n      Expand-Archive -Path \"$PSScriptroot\\jdk\\openjdk-14.0.2_windows-x64_bin.zip\" -DestinationPath \"$PSSCriptRoot/jdk\"\n\n      # Get Java executable\n      $javaExecutable = Get-ChildItem -Path \"$PSScriptRoot\\jdk\" -Recurse | Where-Object {$_.Name -eq \"java.exe\"}\n    }\n    \n    if ($IsLinux)\n    {\n      Invoke-WebRequest -Uri \"https://download.java.net/openjdk/jdk14/ri/openjdk-14+36_linux-x64_bin.tar.gz\" -OutFile \"$PSScriptroot/jdk/openjdk-14+36_linux-x64_bin.tar.gz\" -UseBasicParsing\n\n      # Extract\n      Write-Output \"Extracting Java ... \"\n      tar -xvzf \"$PSScriptroot/jdk/openjdk-14+36_linux-x64_bin.tar.gz\" --directory \"$PSScriptRoot/jdk\"\n\n      # Get Java executable\n      $javaExecutable = Get-ChildItem -Path \"$PSScriptRoot/jdk\" -Recurse | Where-Object {$_.Name -eq \"java\"}   \n    }\n    \n    # Add path to current session as first entry to bypass other versions of Java that may be installed.\n    $env:PATH = \"$($javaExecutable.Directory)$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n}\n\n# Gets download url of latest release with an asset\nFunction Get-LatestVersionDownloadUrl\n{\n    # Define parameters\n    param(\n    \t$Repository,\n        $Version\n    )\n    \n    # Define local variables\n    $releases = \"https://api.github.com/repos/$Repository/releases\"\n    \n    # Get latest version\n    Write-Host \"Determining latest release of $Repository ...\"\n    \n    $tags = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)\n    \n    if ($null -ne $Version)\n    {\n    \t$tags = ($tags | Where-Object {$_.name.EndsWith($Version)})\n    }\n\n    # Find the latest version with a downloadable asset\n    foreach ($tag in $tags)\n    {\n        if ($tag.assets.Count -gt 0)\n        {\n            return $tag.assets.browser_download_url\n        }\n    }\n\n    # Return the version\n    return $null\n}\n\n# Finds the specified changelog file\nFunction Get-ChangeLog\n{\n    # Define parameters\n    param ($FileName)\n    \n    # Find file\n    $fileReference = (Get-ChildItem -Path $OctopusParameters[\"Octopus.Action.Package[liquibaseChangeSet].ExtractedPath\"] -Recurse | Where-Object {$_.Name -eq $FileName})\n\n    # Check to see if something weas returned\n    if ($null -eq $fileReference)\n    {\n        # Not found\n        Write-Error \"$FileName was not found in $PSScriptRoot or subfolders.\"\n    }\n\n    # Return the reference\n    return $fileReference\n}\n\n# Downloads the appropriate JDBC driver\nFunction Get-DatabaseJar\n{\n    # Define parameters\n    param ($DatabaseType)\n\n    # Declare local variables\n    $driverPath = \"\"\n\n    # Check to see if a folder needs to be created\n    if((Test-Path -Path \"$PSScriptRoot/DatabaseDriver\") -eq $false)\n    {\n        # Create new folder\n        New-Item -ItemType Directory -Path \"$PSSCriptRoot/DatabaseDriver\" | Out-Null\n    }\n\n    # Download the driver for the selected type\n    switch ($DatabaseType)\n    {\n        \"Cassandra\"\n        {\n        \tWrite-Host \"Downloading Simba JDBC driver ...\"\n            Invoke-WebRequest -Uri \"https://downloads.datastax.com/jdbc/cql/2.0.8.1009/SimbaCassandraJDBC42-2.0.8.1009.zip\" -OutFile \"$PSScriptroot\\DatabaseDriver\\SimbaCassandraJDBC42-2.0.8.1009.zip\" -UseBasicParsing\n            \n            # Extract package\n            Write-Host \"Extracting Simba JDBC driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/SimbaCassandraJDBC42-2.0.8.1009.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSSCriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"CassandraJDBC42.jar\"}).FullName\n\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-cassandra\"\n            \n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }           \n\n\t\t\tWrite-Host \"Downloading Cassandra Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\") + 1))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n\n        \tbreak\n        }\n        \"MariaDB\"\n        {\n            # Download MariaDB driver\n            Write-Host \"Downloading MariaDB driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/mariadb-java-client-2.6.2.jar\"\n            Invoke-WebRequest -Uri \"https://downloads.mariadb.com/Connectors/java/connector-java-2.6.2/mariadb-java-client-2.6.2.jar\" -OutFile $driverPath -UseBasicParsing\n             \n            break\n        }\n        \"MongoDB\"\n        {\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-mongodb\"\n            \n            # Download MongoDB driver\n            Write-Host \"Downloading Maven MongoDB driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/mongo-java-driver-3.12.7.jar\"\n            Invoke-WebRequest -Uri \"https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver/3.12.7/mongo-java-driver-3.12.7.jar\" -Outfile $driverPath -UseBasicParsing\n            \n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }\n                        \n\t\t\tWrite-Host \"Downloading MongoDB Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\")))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n            \n            break\n        }\n        \"MySQL\"\n        {\n            # Download MariaDB driver\n            Write-Host \"Downloading MySQL driver ...\"\n            Invoke-WebRequest -Uri \"https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.28.zip\" -OutFile \"$PSScriptroot/DatabaseDriver/mysql-connector-java-8.0.28.zip\" -UseBasicParsing\n\n            # Extract package\n            Write-Host \"Extracting MySQL driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/mysql-connector-java-8.0.28.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"mysql-connector-java-8.0.28.jar\"}).FullName\n\n            break\n        }\n        \"Oracle\"\n        {\n            # Download Oracle driver\n            Write-Host \"Downloading Oracle driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/ojdbc10.jar\"\n            Invoke-WebRequest -Uri \"https://download.oracle.com/otn-pub/otn_software/jdbc/211/ojdbc11.jar\" -OutFile $driverPath -UseBasicParsing\n\n            break\n        }\n        \"SqlServer\"\n        {\n            # Download Microsoft driver\n            Write-Host \"Downloading Sql Server driver ...\"\n            Invoke-WebRequest -Uri \"https://go.microsoft.com/fwlink/?linkid=2186163\" -OutFile \"$PSScriptroot/DatabaseDriver/sqljdbc_10.2.0.0_enu.zip\" -UseBasicParsing\n\n            # Extract package\n            Write-Host \"Extracting SqlServer driver ...\"\n            Expand-Archive -Path \"$PSScriptroot/DatabaseDriver/sqljdbc_10.2.0.0_enu.zip\" -DestinationPath \"$PSSCriptRoot/DatabaseDriver\"\n\n            # Find driver\n            $driverPath = (Get-ChildItem -Path \"$PSSCriptRoot/DatabaseDriver\" -Recurse | Where-Object {$_.Name -eq \"mssql-jdbc-10.2.0.jre11.jar\"}).FullName\n            \n            # Determine architecture\n            if ([System.Environment]::Is64BitOperatingSystem)\n            {\n            \t# Locate auth dll\n                $authDll = Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse |Where-Object {$_.Name -eq \"mssql-jdbc_auth-10.2.0.x64.dll\"}\n            }\n            else\n            {\n            \t$authDll = Get-ChildItem -Path \"$PSScriptRoot/DatabaseDriver\" -Recurse |Where-Object {$_.Name -eq \"mssql-jdbc_auth-10.2.0.x86.dll\"}\n            }\n            \n            # Add the dll to the path so it can find it.\n            $env:PATH += \"$([IO.Path]::PathSeparator)$($authDll.Directory)\"\n            \n\t\t\tbreak\n        }\n        \"PostgreSQL\"\n        {\n            # Download PostgreSQL driver\n            Write-Host \"Downloading PostgreSQL driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/postgresql-42.2.12.jar\"\n            Invoke-WebRequest -Uri \"https://jdbc.postgresql.org/download/postgresql-42.2.12.jar\" -OutFile $driverPath -UseBasicParsing\n            \n            # Download the WAFFLE jna driver for Windows Authentication\n            $repositoryName = \"waffle/waffle\"\n            \n            # Latest version of Waffle (2.3.0) doesn't seem to work, can't find sspi method, specify version 1.9.0\n            $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version \"1.9.0\" | Where-Object {$_.EndsWith(\".zip\")})\n            Expand-DownloadedFile -DownloadUrls $downloadUrl | Out-Null\n            \n            # Get all waffle jars\n            $waffleFolder = (Get-ChildItem -Path \"$PSScriptroot\" -Recurse | Where-Object {$_.PSIsContainer -and $_.Name -like \"Waffle*\"})           \n            $waffleJars = (Get-ChildItem -Path $waffleFolder.FullName -Recurse | Where-Object {$_.Extension -eq \".jar\"})\n            \n            foreach ($jar in $waffleJars)\n            {\n            \t$driverPath += \"$([IO.Path]::PathSeparator)$($jar.FullName)\"\n            }\n\n            break\n        }\n        \"Snowflake\"\n        {\n        \t# Set repo name\n            $repositoryName = \"liquibase/liquibase-snowflake\"\n\n\t\t\t# Download Snowflake driver\n            Write-Host \"Downloading Snowflake driver ...\"\n            $driverPath = \"$PSScriptroot/DatabaseDriver/snowflake-jdbc-3.9.2.jar\"\n            Invoke-WebRequest -Uri \"https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.9.2/snowflake-jdbc-3.9.2.jar\" -OutFile $driverPath -UseBasicParsing\n\n            if ([string]::IsNullOrEmpty($liquibaseVersion))\n            {\n            \t# Get the latest version for the extension\n            \t$downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName | Where-Object {$_.EndsWith(\".jar\")})\n           \t}\n            else\n            {\n            \t# Download version matching extension\n                $downloadUrl = (Get-LatestVersionDownloadUrl -Repository $repositoryName -Version $liquibaseVersion | Where-Object {$_.EndsWith(\".jar\")})\n            }\n                        \n\t\t\tWrite-Host \"Downloading Snowflake Liquibase extension from $downloadUrl ...\"\n            $extensionPath = \"$PSScriptroot/$($downloadUrl.Substring($downloadUrl.LastIndexOf(\"/\")))\"\n            \n            Invoke-WebRequest -Uri $downloadUrl -Outfile $extensionPath -UseBasicParsing\n                        \n            # Make driver path null\n            $driverPath = \"$driverPath$([IO.Path]::PathSeparator)$extensionPath\"\n\n\n            break\n        }\n        default\n        {\n            # Display error\n            Write-Error \"Unknown database type: $DatabaseType.\"\n        }\n    }\n\n    # Return the driver location\n    return $driverPath\n}\n\n# Returns the connection string formatted for the database type\nFunction Get-ConnectionUrl\n{\n    # Define parameters\n    param ($DatabaseType, \n    \t$ServerPort, \n        $ServerName, \n        $DatabaseName, \n        $QueryStringParameters)\n\n    # Define local variables\n    $connectionUrl = \"\"\n\n    # Download the driver for the selected type\n    switch ($DatabaseType)\n    {\n        \"Cassandra\"\n        {\n            $connectionUrl = \"jdbc:cassandra://{0}:{1};DefaultKeyspace={2}\"\n            break\n        }\n        \"MariaDB\"\n        {\n            $connectionUrl = \"jdbc:mariadb://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?integratedSecurity=true\"\n            }\n            \n            break\n        }\n        \"MongoDB\"\n        {\n        \t$connectionUrl = \"mongodb://{0}:{1}/{2}\"            \n            break\n        }\n        \"MySQL\"\n        {\n            $connectionUrl = \"jdbc:mysql://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?integratedSecurity=true\"\n            }\n            \n            break\n        }\n        \"Oracle\"\n        {\n            $connectionUrl = \"jdbc:oracle:thin:@{0}:{1}/{2}\"\n            break\n        }\n        \"SqlServer\"\n        {\n            $connectionUrl = \"jdbc:sqlserver://{0}:{1};database={2};\"\n            \n            switch ($liquibaseAuthenticationMethod)\n            {\n                \"azuremanagedidentity\"\n                {\n                \t# Add querystring parameter\n                    $connectionUrl += \"Authentication=ActiveDirectoryMSI;\"\n                    break\n                }\n                \"windowsauthentication\"\n                {\n\t            \t# Add querysting parameter\n    \t            $connectionUrl += \"integratedSecurity=true;\"\n                \t\n                    break\n                }\n            }\n            \n            break\n        }\n        \"PostgreSQL\"\n        {\n            $connectionUrl = \"jdbc:postgresql://{0}:{1}/{2}\"\n            \n            # Check for Windows Authentication type\n            if ($liquibaseAuthenticationMethod -eq \"windowsauthentication\")\n            {\n            \t# Add querysting parameter\n                $connectionUrl += \"?gsslib=sspi\"\n            }\n            \n            break\n        }\n        \"Snowflake\"\n        {\n        \t$connectionUrl = \"jdbc:snowflake://{0}.snowflakecomputing.com?db={2}\"\n            break\n        }\n        default\n        {\n            # Display error\n            Write-Error \"Unkonwn database type: $DatabaseType.\"\n        }\n    }\n\n    if (![string]::IsNullOrWhitespace($QueryStringParameters))\n    {       \t\n        if ($connectionUrl.Contains(\"?\"))\n\t\t{\n           \t# Replace the ? with & in connection string parameters\n            $QueryStringParameters = $QueryStringParameters.Replace(\"?\", \"&\")\n        }\n        \n        # Appen connecion string\n        $connectionUrl += \"$QueryStringParameters\"\n    }\n\n    # Return the url\n    return ($connectionUrl -f $ServerName, $ServerPort, $DatabaseName)\n}\n\n# Create array for arguments\n$liquibaseArguments = @()\n\n# Check for license key\nif (![string]::IsNullOrEmpty($liquibaseProLicenseKey))\n{\n\t# Add key to arguments\n    $liquibaseArguments += \"--liquibaseProLicenseKey=$liquibaseProLicenseKey\"\n}\n\n# Find Change log\n$changeLogFile = (Get-ChangeLog -FileName $liquibaseChangeLogFileName)\n$liquibaseArguments += \"--changeLogFile=$($changeLogFile.Name)\"\n\n# Set the location to where the file is\nSet-Location -Path $changeLogFile.Directory\n\n# Check to see if it needs to be downloaed to machine\nif ($liquibaseDownload -eq $true)\n{\n    # Download and extract liquibase\n    Get-Liquibase -Version $liquibaseVersion -DownloadFolder $workingFolder\n\n    # Download and extract java and add it to PATH environment variable\n    Get-Java\n\n    # Get the driver\n    $driverPath = Get-DatabaseJar -DatabaseType $liquibaseDatabaseType\n\n    # Create folder to hold jar files to override\n    New-Item -Path \"$PWD/liquibase_libs/\" -ItemType Directory    \n    \n    # Copy contents into liquibase_libs folder\n    $driverPaths = $driverPath.Split([IO.Path]::PathSeparator)\n    \n    foreach ($driver in $driverPaths)\n    {\n    \t# Copy the items\n        $files = Get-ChildItem -Path $driver\n        \n        foreach ($file in $files)\n        {\n        \tWrite-Host \"Copying $($file.FullName) to $PWD/liquibase_libs/$($file.Name)\"\n            Copy-Item -Path $file.FullName -Destination \"$PWD/liquibase_libs/$($file.Name)\"\n        }\n    }\n}\nelse\n{\n    if (![string]::IsNullOrEmpty($liquibaseClassPath))\n    {\n    \t$liquibaseArguments += \"--classpath=$liquibaseClassPath\"\n    }\n}\n\n# Check to see if liquibase path has been defined\nif ([string]::IsNullOrEmpty($liquibaseExecutablePath))\n{\n    # Assign root\n    $liquibaseExecutablePath = $PSSCriptRoot\n}\n\n# Get the executable location\nif ($IsWindows)\n{\n\t$liquibaseExecutable = Get-ChildItem -Path $liquibaseExecutablePath -Recurse | Where-Object {$_.Name -eq \"liquibase.bat\"}\n}\n\nif ($IsLinux)\n{\n\t$liquibaseExecutable = Get-ChildItem -Path $liquibaseExecutablePath -Recurse | Where-Object {$_.Name -eq \"liquibase\"}\n}\n\n# Add path to current session\n$env:PATH += \"$([IO.Path]::PathSeparator)$($liquibaseExecutable.Directory)\"\n\n# Check to make sure it was found\nif ([string]::IsNullOrEmpty($liquibaseExecutable))\n{\n    # Could not find the executable\n    Write-Error \"Unable to find liquibase.bat in $PSScriptRoot or subfolders.\"\n}\n\n# Get connection Url\n$connectionUrl = Get-ConnectionUrl -DatabaseType $liquibaseDatabaseType -ServerPort $liquibaseServerPort -ServerName $liquibaseServerName -DatabaseName $liquibaseDatabaseName -QueryStringParameters $liquibaseQueryStringParameters\n\n# Add username\n$liquibaseArguments += \"--username=$liquibaseUsername\"\n\n# Determine authentication method\nswitch ($liquibaseAuthenticationMethod)\n{\n\t\"azuremanagedidentity\"\n    {\n    \t# SQL Server driver doesn't assign password\n        if ($liquibaseDatabaseType -ne \"SqlServer\")\n        {\n          # Get login token\n          Write-Host \"Generating Azure Managed Identity token ...\"\n          $token = Invoke-RestMethod -Method GET -Uri \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://ossrdbms-aad.database.windows.net\" -Headers @{\"MetaData\" = \"true\"} -UseBasicParsing\n\n          $liquibasePassword = $token.access_token\n          $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n        }\n    }\n\t\"awsiam\"\n    {\n\t\t# Region is part of the RDS endpoint, extract\n        $region = ($liquibaseServerName.Split(\".\"))[2]\n\n\t\tWrite-Host \"Generating AWS IAM token ...\"\n\t\t$liquibasePassword = (aws rds generate-db-auth-token --hostname $liquibaseServerName --region $region --port $liquibaseServerPort --username $liquibaseUsername)\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n\n\t\tbreak\n    }\n    \"gcpserviceaccount\"\n    {\n        # Define header\n        $header = @{ \"Metadata-Flavor\" = \"Google\"}\n\n        # Retrieve service accounts\n        $serviceAccounts = Invoke-RestMethod -Method Get -Uri \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/\" -Headers $header -UseBasicParsing\n\n        # Results returned in plain text format, get into array and remove empty entries\n        $serviceAccounts = $serviceAccounts.Split([Environment]::NewLine, [StringSplitOptions]::RemoveEmptyEntries)\n\n        # Retreive the specific service account assigned to the VM\n        $serviceAccount = $serviceAccounts | Where-Object {$_.Contains(\"iam.gserviceaccount.com\") }\n\n\t\tWrite-Host \"Generating GCP IAM token ...\"\n        # Retrieve token for account\n        $token = Invoke-RestMethod -Method Get -Uri \"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/$serviceAccount/token\" -Headers $header -UseBasicParsing\n        \n        $liquibasePassword = $token.access_token\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n    }\n    \"usernamepassword\"\n    {\n    \t# Add password\n        $liquibaseArguments += \"--password=`\"$liquibasePassword`\"\"\n        \n        break\n    }\n}\n\n# Add connection url\n$liquibaseArguments += \"--url=`\"$connectionUrl`\"\"\n\n# Determine if the output variable needs to be set\nif ($liquibaseCommand.EndsWith(\"SQL\"))\n{\n\t# Add the output variable as the command name\n    $liquibaseArguments += \"--outputFile=`\"$PSScriptRoot/artifacts/$($liquibaseCommand).sql`\"\"\n    \n    # Create the folder\n    if ((Test-Path -Path \"$PSScriptRoot/artifacts\") -eq $false)\n    {\n    \tNew-Item -Path \"$PSScriptRoot/artifacts\" -ItemType \"Directory\"\n    }\n}\n\n\n# Add the additional switches\nforeach ($liquibaseSwitch in $liquibaseAdditionalSwitches)\n{\n    $liquibaseArguments += $liquibaseSwitch\n}\n\nswitch ($liquibaseCommandStyle)\n{\n\t\"legacy\"\n    {\n    \t# Add the command to execute\n\t\t$liquibaseArguments += $liquibaseCommand\n    }\n    \"modern\"\n    {\n    \t# Insert the command at the beginning\n        $liquibaseArguments = @($liquibaseCommand) + $liquibaseArguments\n    }\n}\n\n# Add command arguments\n$liquibaseArguments += $liquibaseCommandArguments\n\n# Display what's going to be run\nif (![string]::IsNullOrWhitespace($liquibasePassword))\n{\n\t$liquibaseDisplayArguments = $liquibaseArguments.PSObject.Copy()\n    $arrayIndex = 0\n    for ($i = 0; $i -lt $liquibaseDisplayArguments.Count; $i++)\n    {\n    \tif ($null -ne $liquibaseDisplayArguments[$i])\n        {\n        \tif ($liquibaseDisplayArguments[$i].Contains($liquibasePassword))\n            {\n                $liquibaseDisplayArguments[$i] = $liquibaseDisplayArguments[$i].Replace($liquibasePassword, \"****\")\n        \t}\n        }\n    }\n    \n    Write-Host \"Executing the following command: $($liquibaseExecutable.FullName) $liquibaseDisplayArguments\"\n}\nelse \n{\n\tWrite-Host \"Executing the following command: $($liquibaseExecutable.FullName) $liquibaseArguments\"\n}\n\n$liquibaseCommandOutput;\n\n# Redirection of stderr to stdout is done different on Windows versus Linux\nif ($IsWindows)\n{\n\t$liquibaseArguments += \"2>&1\"\n\t# Execute Liquibase\n  & $liquibaseExecutable.FullName $liquibaseArguments | Tee-Object -Variable liquibaseCommandOutput\n}\n\nif ($IsLinux)\n{\n\t# Execute Liquibase\n  & $liquibaseExecutable.FullName $liquibaseArguments 2>&1 | Tee-Object -Variable liquibaseCommandOutput\n}\n\nSet-OctopusVariable -name \"LiquibaseCommandOutput\" -value $liquibaseCommandOutput\n\n# Check exit code\nif ($lastExitCode -ne 0)\n{\n\t# Fail the step\n    Write-Error \"Execution of Liquibase failed!\"\n}\n\n# Check to see if there were any files output\nif ((Test-Path -Path \"$PSScriptRoot/artifacts\") -eq $true)\n{\n\t# Loop through items\n    foreach ($item in (Get-ChildItem -Path \"$PSScriptRoot/artifacts\"))\n    {\n    \tNew-OctopusArtifact -Path $item.FullName -Name $item.Name\n    }\n}\n"
+  },
+  "Parameters": [
+    {
+      "Id": "a5f6167a-3e45-4337-ad76-fdacf385ac9c",
+      "Name": "liquibaseProLicenseKey",
+      "Label": "Pro license key",
+      "HelpText": "Enter your Liquibase Pro license key. [Request a free 30-day trial.](https://www.liquibase.com/trial) Leave blank to use the Community Edition.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     },
-    "Parameters": [
-      {
-        "Id": "a5f6167a-3e45-4337-ad76-fdacf385ac9c",
-        "Name": "liquibaseProLicenseKey",
-        "Label": "Pro license key",
-        "HelpText": "Enter your Liquibase Pro license key. [Request a free 30-day trial.](https://www.liquibase.com/trial) Leave blank to use the Community Edition.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "f56f8e65-bd97-4be4-a9e8-979a5d8e5208",
-        "Name": "liquibaseDatabaseType",
-        "Label": "Database type",
-        "HelpText": "Select the database type to deploy to.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "Cassandra|Cassandra\nMariaDB|MariaDB\nMongoDB|MongoDB\nMySQL|MySQL\nOracle|Oracle\nPostgreSQL|PostgreSQL\nSnowflake|Snowflake\nSqlServer|SqlServer"
-        }
-      },
-      {
-        "Id": "e0e2ba23-69f4-4a82-8310-b06f9a485802",
-        "Name": "liquibaseCommand",
-        "Label": "Command",
-        "HelpText": "Use the drop down to select the command to execute.\nCommands with `*` have partial functionality with Community edition, full functionality with Pro edition.\n\nCommands with `**` are Pro only (all Pro only commands require the use of Additional switches).\n\nCommands with `***` require Additiona switches.\n\nAll commands that end in `SQL` will automatically add the `--outputFile` switch and include the generated output as an artifact.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "changelogSync|changelogSync\nchangelogSyncSQL|changelogSyncSQL\nclearCheckSums|clearCheckSums\ndeactivateChangeLog|deactivateChangeLog\ndropAll|dropAll*\nfutureRollbackSQL|futureRollbackSQL\nhistory|history\nrollbackOneChangeSet|rollbackOneChangeSet**\nrollbackOneChangeSetSQL|rollbackOneChangeSetSQL**\nrollbackOneUpdate|rollbackOneUpdate**\nrollbackOneUpdateSQL|rollbackOneUpdateSQL**\nrollbackToDate|rollbackToDate***\nrollbackToDateSQL|rollbackToDateSQL***\nstatus|status\ntag-exists|tag-exists\nupdateSQL|updateSQL\nupdate|update\nupdateTestingRollback|updateTestingRollback\nvalidate|validate"
-        }
-      },
-      {
-        "Id": "86049fa3-866d-4687-b128-25be358cc5aa",
-        "Name": "liquibaseCommandStyle",
-        "Label": "Command style",
-        "HelpText": "Select the style of command, Legacy or Modern.  Legacy will place the Liquibase command at the end of the call, Modern will place it at the beginning\n\nLegacy:\n`liquibase --switch1 command`\n\nModern:\n`liquibase command --switch1`",
-        "DefaultValue": "modern",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "legacy|Legacy\nmodern|Modern"
-        }
-      },  
+    {
+      "Id": "f56f8e65-bd97-4be4-a9e8-979a5d8e5208",
+      "Name": "liquibaseDatabaseType",
+      "Label": "Database type",
+      "HelpText": "Select the database type to deploy to.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "Cassandra|Cassandra\nMariaDB|MariaDB\nMongoDB|MongoDB\nMySQL|MySQL\nOracle|Oracle\nPostgreSQL|PostgreSQL\nSnowflake|Snowflake\nSqlServer|SqlServer"
+      }
+    },
+    {
+      "Id": "e0e2ba23-69f4-4a82-8310-b06f9a485802",
+      "Name": "liquibaseCommand",
+      "Label": "Command",
+      "HelpText": "Use the drop down to select the command to execute.\nCommands with `*` have partial functionality with Community edition, full functionality with Pro edition.\n\nCommands with `**` are Pro only (all Pro only commands require the use of Additional switches).\n\nCommands with `***` require Additiona switches.\n\nAll commands that end in `SQL` will automatically add the `--outputFile` switch and include the generated output as an artifact.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "changelogSync|changelogSync\nchangelogSyncSQL|changelogSyncSQL\nclearCheckSums|clearCheckSums\ndeactivateChangeLog|deactivateChangeLog\ndropAll|dropAll*\nfutureRollbackSQL|futureRollbackSQL\nhistory|history\nrollbackOneChangeSet|rollbackOneChangeSet**\nrollbackOneChangeSetSQL|rollbackOneChangeSetSQL**\nrollbackOneUpdate|rollbackOneUpdate**\nrollbackOneUpdateSQL|rollbackOneUpdateSQL**\nrollbackToDate|rollbackToDate***\nrollbackToDateSQL|rollbackToDateSQL***\nstatus|status\ntag-exists|tag-exists\nupdateSQL|updateSQL\nupdate|update\nupdateTestingRollback|updateTestingRollback\nvalidate|validate"
+      }
+    },
+    {
+      "Id": "86049fa3-866d-4687-b128-25be358cc5aa",
+      "Name": "liquibaseCommandStyle",
+      "Label": "Command style",
+      "HelpText": "Select the style of command, Legacy or Modern.  Legacy will place the Liquibase command at the end of the call, Modern will place it at the beginning\n\nLegacy:\n`liquibase --switch1 command`\n\nModern:\n`liquibase command --switch1`",
+      "DefaultValue": "modern",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "legacy|Legacy\nmodern|Modern"
+      }
+    },
     {
       "Id": "0af1aaa8-0cfb-4018-85fc-c996fd450d8c",
       "Name": "liquibaseCommandArguments",
@@ -78,153 +78,153 @@
         "Octopus.ControlType": "SingleLineText"
       }
     },
-      {
-        "Id": "9f2a3e0c-1afd-4472-acc9-66bd8743ec37",
-        "Name": "liquibaseAdditionalSwitches",
-        "Label": "Additional switches",
-        "HelpText": "A list of additional switches to include for the command, one per line.  (I.e. `--logLevel=debug`)",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "MultiLineText"
-        }
-      },
-      {
-        "Id": "ef523320-65ec-44ce-a0cd-0e65a0fed9f9",
-        "Name": "liquibaseChangeLogFileName",
-        "Label": "Change Log file name",
-        "HelpText": "Name of the changelog file in the package.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "2ff32870-827c-45c1-86f8-f31842ef547b",
-        "Name": "liquibaseChangeset",
-        "Label": "Changeset package",
-        "HelpText": "Select the package with the changeset.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Package"
-        }
-      },
-      {
-        "Id": "dbb7c649-f87b-42f3-b6c9-6db97df39a2f",
-        "Name": "liquibaseServerName",
-        "Label": "Server name",
-        "HelpText": "Name or IP address of the database server.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "481b1bd7-ed0a-40da-8ee6-81397c8d0769",
-        "Name": "liquibaseServerPort",
-        "Label": "Server port",
-        "HelpText": "The port the database server listens on.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "56db5b8b-ceaa-4ee8-b231-df15ea7d9a43",
-        "Name": "liquibaseAuthenticationMethod",
-        "Label": "Authentication Method",
-        "HelpText": "Method used to authenticate to the database server.",
-        "DefaultValue": "usernamepassword",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nazuremanagedidentity|Azure Managed Identity\ngcpserviceaccount|GCP Service Account\nusernamepassword|Username\\Password\nwindowsauthentication|Windows Authentication"
-        }
-      },      
-      {
-        "Id": "8d4337f3-3e37-40e7-983b-b85cc630a720",
-        "Name": "liquibaseDatabaseName",
-        "Label": "Database name",
-        "HelpText": "Name of the database to deploy to.\n- Service name for Oracle\n- KeySpace for Cassandra",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "0524f7f4-fb8e-4747-8f1b-679237e398a7",
-        "Name": "liquibaseUsername",
-        "Label": "Username",
-        "HelpText": "Username of a user that has permission to make changes to the database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "d58b5a73-681b-434a-92a9-b373216fedc3",
-        "Name": "liquibasePassword",
-        "Label": "Password",
-        "HelpText": "Password for the user with permissions to make changes to the database.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Sensitive"
-        }
-      },
-      {
-        "Id": "bac7d86b-eb37-4b3f-a99c-0779ffae3fca",
-        "Name": "liquibaseQueryStringParameters",
-        "Label": "Connection query string parameters",
-        "HelpText": "Add additional parameters to the connection string URL. Example: ?useUnicode=true or ;AuthMech=1",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "8f1c2bc5-6b39-4c95-8eb0-bd97b0fe62f0",
-        "Name": "liquibaseClassPath",
-        "Label": "Database driver path",
-        "HelpText": "Filepath to the location of the .jar driver for the database type.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "cae0020d-595b-407c-a96b-02f7a6bc9788",
-        "Name": "liquibaseExecutablePath",
-        "Label": "Executable file path",
-        "HelpText": "File path to the Liquibase executable.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
-      },
-      {
-        "Id": "2eae1d4e-a12d-47dd-8a43-1a6e49983fd9",
-        "Name": "liquibaseDownload",
-        "Label": "Download Liquibase?",
-        "HelpText": "Use this option to download the software necessary to deploy a Liquibase changeset.  This will download Liquibase, java, and the appropriate driver for the selected database type.  Using this option overrides the `Database driver path` and `Executable file path` inputs.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "Checkbox"
-        }
-      },
-      {
-        "Id": "3f37288f-a4df-4ed7-b309-bb361a496572",
-        "Name": "liquibaseVersion",
-        "Label": "Liquibase version",
-        "HelpText": "Used with `Download Liquibase` to specify the version of Liquibase to use.",
-        "DefaultValue": "",
-        "DisplaySettings": {
-          "Octopus.ControlType": "SingleLineText"
-        }
+    {
+      "Id": "9f2a3e0c-1afd-4472-acc9-66bd8743ec37",
+      "Name": "liquibaseAdditionalSwitches",
+      "Label": "Additional switches",
+      "HelpText": "A list of additional switches to include for the command, one per line.  (I.e. `--logLevel=debug`)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
       }
-    ],
-    "$Meta": {
-      "ExportedAt": "2022-09-12T22:28:42.324Z",
-      "OctopusVersion": "2022.3.10382",
-      "Type": "ActionTemplate"
-    },  
-    "LastModifiedBy": "twerthi",
-    "Category": "liquibase"
-  }
+    },
+    {
+      "Id": "ef523320-65ec-44ce-a0cd-0e65a0fed9f9",
+      "Name": "liquibaseChangeLogFileName",
+      "Label": "Change Log file name",
+      "HelpText": "Name of the changelog file in the package.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2ff32870-827c-45c1-86f8-f31842ef547b",
+      "Name": "liquibaseChangeset",
+      "Label": "Changeset package",
+      "HelpText": "Select the package with the changeset.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "dbb7c649-f87b-42f3-b6c9-6db97df39a2f",
+      "Name": "liquibaseServerName",
+      "Label": "Server name",
+      "HelpText": "Name or IP address of the database server.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "481b1bd7-ed0a-40da-8ee6-81397c8d0769",
+      "Name": "liquibaseServerPort",
+      "Label": "Server port",
+      "HelpText": "The port the database server listens on.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "56db5b8b-ceaa-4ee8-b231-df15ea7d9a43",
+      "Name": "liquibaseAuthenticationMethod",
+      "Label": "Authentication Method",
+      "HelpText": "Method used to authenticate to the database server.",
+      "DefaultValue": "usernamepassword",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "awsiam|AWS EC2 IAM Role\nazuremanagedidentity|Azure Managed Identity\ngcpserviceaccount|GCP Service Account\nusernamepassword|Username\\Password\nwindowsauthentication|Windows Authentication"
+      }
+    },
+    {
+      "Id": "8d4337f3-3e37-40e7-983b-b85cc630a720",
+      "Name": "liquibaseDatabaseName",
+      "Label": "Database name",
+      "HelpText": "Name of the database to deploy to.\n- Service name for Oracle\n- KeySpace for Cassandra",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "0524f7f4-fb8e-4747-8f1b-679237e398a7",
+      "Name": "liquibaseUsername",
+      "Label": "Username",
+      "HelpText": "Username of a user that has permission to make changes to the database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d58b5a73-681b-434a-92a9-b373216fedc3",
+      "Name": "liquibasePassword",
+      "Label": "Password",
+      "HelpText": "Password for the user with permissions to make changes to the database.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "bac7d86b-eb37-4b3f-a99c-0779ffae3fca",
+      "Name": "liquibaseQueryStringParameters",
+      "Label": "Connection query string parameters",
+      "HelpText": "Add additional parameters to the connection string URL. Example: ?useUnicode=true or ;AuthMech=1",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8f1c2bc5-6b39-4c95-8eb0-bd97b0fe62f0",
+      "Name": "liquibaseClassPath",
+      "Label": "Database driver path",
+      "HelpText": "Filepath to the location of the .jar driver for the database type.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "cae0020d-595b-407c-a96b-02f7a6bc9788",
+      "Name": "liquibaseExecutablePath",
+      "Label": "Executable file path",
+      "HelpText": "File path to the Liquibase executable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2eae1d4e-a12d-47dd-8a43-1a6e49983fd9",
+      "Name": "liquibaseDownload",
+      "Label": "Download Liquibase?",
+      "HelpText": "Use this option to download the software necessary to deploy a Liquibase changeset.  This will download Liquibase, java, and the appropriate driver for the selected database type.  Using this option overrides the `Database driver path` and `Executable file path` inputs.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "3f37288f-a4df-4ed7-b309-bb361a496572",
+      "Name": "liquibaseVersion",
+      "Label": "Liquibase version",
+      "HelpText": "Used with `Download Liquibase` to specify the version of Liquibase to use.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "$Meta": {
+    "ExportedAt": "2022-09-12T22:28:42.324Z",
+    "OctopusVersion": "2022.3.10382",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "olsh",
+  "Category": "liquibase"
+}


### PR DESCRIPTION
Add capturing the output of the Liquibase command to `LiquibaseCommandOutput` variable.
It may be useful when you want to use conditions in other steps.

Our use case is to run `liquibase status` command first, analyze the output, and the skip manual intervention step (and other Liquibase steps) if there are no changes.