### PR TITLE
Add Python syntax support for unpacking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ scriptcs_packages.config
 
 step-templates/*.ps1
 step-templates/*.sh
+step-templates/*.py
 /.vs
 !.vscode

--- a/tools/StepTemplatePacker/scripts/Get-OctopusStepTemplateFileType.ps1
+++ b/tools/StepTemplatePacker/scripts/Get-OctopusStepTemplateFileType.ps1
@@ -20,6 +20,10 @@ function Get-OctopusStepTemplateFileType
             return ".sh";
         }
 
+        "Python" {
+            return ".py";
+        }
+
         default {
             throw new-object System.NotImplementedException("Unhandled script syntax '$syntax'.");
         }


### PR DESCRIPTION
Some steps are written in Python. And if you run `./tools/_unpack.ps1` the script throws an error
```
Unhandled script syntax 'Python'.
```