### PR TITLE
Adding code to accomodate different PS versions in regards to the -Us…

### DIFF
--- a/step-templates/slack-send-simple-notification.json
+++ b/step-templates/slack-send-simple-notification.json
@@ -3,12 +3,12 @@
   "Name": "Slack - Send Simple Notification",
   "Description": "Send a basic message notification to Slack.",
   "ActionType": "Octopus.Script",
-  "Version": 14,
+  "Version": 15,
   "CommunityActionTemplateId": null,
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
-    "Octopus.Action.Script.ScriptBody": "$payload = @{\n    channel = $OctopusParameters['ssn_Channel']\n    username = $OctopusParameters['ssn_Username'];\n    icon_url = $OctopusParameters['ssn_IconUrl'];\n    link_names = \"true\";\n    attachments = @(\n        @{\n            mrkdwn_in = $('pretext', 'text');\n            pretext = $OctopusParameters['ssn_Title'];\n            text = $OctopusParameters['ssn_Message'];\n            color = $OctopusParameters['ssn_Color'];\n        }\n    )\n}\n\ntry {\n\t[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n    Invoke-Restmethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['ssn_HookUrl'] -UseBasicParsing\n} catch {\n    Write-Host \"An error occurred while attempting to send Slack notification\"\n    Write-Host $_.Exception\n    Write-Host $_\n    throw\n}"
+    "Octopus.Action.Script.ScriptBody": "$payload = @{\n    channel = $OctopusParameters['ssn_Channel']\n    username = $OctopusParameters['ssn_Username'];\n    icon_url = $OctopusParameters['ssn_IconUrl'];\n    link_names = \"true\";\n    attachments = @(\n        @{\n            mrkdwn_in = $('pretext', 'text');\n            pretext = $OctopusParameters['ssn_Title'];\n            text = $OctopusParameters['ssn_Message'];\n            color = $OctopusParameters['ssn_Color'];\n        }\n    )\n}\n\ntry {\n\t[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n    if ($PSVersionTable.PSVersion.Major -ge 6)\n    {\n        Invoke-Restmethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['ssn_HookUrl']\n    }\n    else\n    {\n        Invoke-Restmethod -Method POST -Body ($payload | ConvertTo-Json -Depth 4) -Uri $OctopusParameters['ssn_HookUrl'] -UseBasicParsing\n    }\n} catch {\n    Write-Host \"An error occurred while attempting to send Slack notification\"\n    Write-Host $_.Exception\n    Write-Host $_\n    throw\n}"
   },
   "Parameters": [
     {
@@ -92,8 +92,8 @@
   ],
   "LastModifiedBy": "twerthi",
   "$Meta": {
-    "ExportedAt": "2022-09-08T17:51:38.980Z",
-    "OctopusVersion": "2022.3.10382",
+    "ExportedAt": "2022-12-02T23:43:25.720Z",
+    "OctopusVersion": "2022.3.10828",
     "Type": "ActionTemplate"
   },
   "Category": "Slack"


### PR DESCRIPTION

---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes Adding code to accomodate different PS versions in regards to the -UseBasicParsing argument