### PR TITLE
Adding DACPAC SqlPackage template

### DIFF
--- a/step-templates/sql-deploy-dacpac-sqlpackage.json
+++ b/step-templates/sql-deploy-dacpac-sqlpackage.json
@@ -1,0 +1,179 @@
+{
+  "Id": "c323cbcd-aab8-4229-b07c-e6c26f7e9a8a",
+  "Name": "SQL - Deploy DACPAC using SqlPackage",
+  "Description": "Calls SqlPackage commands such as:\n * [Deploy](https://learn.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage-publish?view=sql-server-ver16)\n * [Script](https://learn.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage-script?view=sql-server-ver16)\n * [DeployReport](https://learn.microsoft.com/en-us/sql/tools/sqlpackage/sqlpackage-deploy-drift-report?view=sql-server-ver16)\n\nAs SqlPackage is cross-platform, this template is both Windows and Linux* compatible.\n\nResults of `Deploy script` and `deploy report` options will upload to Octopus Deploy as an artifact. This allows you to put in place a manual intervention step if required. It is also useful for auditing purposes.\n\nSqlCmd variables are now supported.  To specify SqlCmd variables, create your Octopus variable with the following naming convention: SqlCmdVariable.<Variable name> (case insensitive) and then assign it a value.  Examples:\n* SqlCmdVariable.Variable1\n* my.sqlcmdvariable.variable2\n\nNOTE: \n - Requires version 2019.10 or above. \n - `TrustServerCertificate=true` is set by default\n - Requires PowerShell or *PowerShell Core",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "edff7d94-0feb-48a9-8185-48feb084a94f",
+      "Name": "DACPACPackage",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "DACPACPackage"
+      }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "# Set TLS\n[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls11 -bor [System.Net.SecurityProtocolType]::Tls12\n\nWrite-Host \"Determining Operating System...\"\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows)\n{\n    switch ([System.Environment]::OSVersion.Platform)\n    {\n    \t\"Win32NT\"\n        {\n        \t# Set variable\n            $IsWindows = $true\n            $IsLinux = $false\n        }\n        \"Unix\"\n        {\n        \t$IsWindows = $false\n            $IsLinux = $true\n        }\n    }\n}\n\nif ($IsWindows)\n{\n\tWrite-Host \"Detected OS is Windows\"\n}\nelse\n{\n\tWrite-Host \"Detected OS is Linux\"\n}\n\n<#\n .SYNOPSIS\n Finds the DAC File that you specify\n\n .DESCRIPTION\n Looks through the supplied PathList array and searches for the file you specify.  It will return the first one that it finds.\n\n .PARAMETER FileName\n Name of the file you are looking for\n\n .PARAMETER PathList\n Array of Paths to search through.\n\n .EXAMPLE\n Find-DacFile -FileName \"Microsoft.SqlServer.TransactSql.ScriptDom.dll\" -PathList @(\"${env:ProgramFiles}\\Microsoft SQL Server\", \"${env:ProgramFiles(x86)}\\Microsoft SQL Server\")\n#>\nFunction Find-DacFile {\n    Param(\n        [Parameter(Mandatory=$true)]\n        [string]$FileName,\n        [Parameter(Mandatory=$true)]\n        [string[]]$PathList\n    )\n\n    $File = $null\n\n    ForEach($Path in $PathList)\n    {\n        Write-Debug (\"Searching: {0}\" -f $Path)\n\n        If (!($File))\n        {\n            $File = (\n                Get-ChildItem $Path -ErrorAction SilentlyContinue -Filter $FileName -Recurse |\n                    Sort-Object FullName -Descending |\n                    Select-Object -First 1\n                )\n\n            If ($File)\n            {\n                Write-Debug (\"Found: {0}\" -f $File.FullName)\n            }\n        }\n    }\n\n    Return $File\n}\n\n\n<#\n .SYNOPSIS\n Generates a connection string\n\n .DESCRIPTION\n Derive a connection string from the supplied variables\n\n .PARAMETER ServerName\n Name of the server to connect to\n\n .PARAMETER Database\n Name of the database to connect to\n\n .PARAMETER UseIntegratedSecurity\n Boolean value to indicate if Integrated Security should be used or not\n\n .PARAMETER UserName\n User name to use if we are not using integrated security\n\n .PASSWORD Password\n Password to use if we are not using integrated security\n\n .PARAMETER EnableMultiSubnetFailover\n Flag as to whether we should enable multi subnet failover\n\n .EXAMPLE\n Get-ConnectionString -ServerName localhost -UseIntegratedSecurity -Database OctopusDeploy\n\n .EXAMPLE\n Get-ConnectionString -ServerName localhost -UserName sa -Password ProbablyNotSecure -Database OctopusDeploy\n#>\nFunction Get-ConnectionString {\n    Param(\n        [Parameter(Mandatory=$True)]\n        [string]$ServerName,\n        [string]$UserName,\n        [string]$Password,\n        [string]$Database,\n        [string]$AuthenticationType\n    )\n\n    $ApplicationName = \"OctopusDeploy\"\n    $connectionString = (\"Application Name={0};Server={1}\" -f $ApplicationName, $ServerName)\n\n    switch ($AuthenticationType)\n    {\n    \t\"AzureADPassword\"\n        {\n            Write-Verbose \"Using Azure Active Directory username and password\"\n            $connectionString += (\";Authentication='Active Directory Password';Uid={0};Pwd={1}\" -f $UserName, $Password)                \n            break\n        }\n        \"AzureADIntegrated\"\n        {\n            Write-Verbose \"Using Azure Active Directory integrated\"\n            $connectionString += (\";Authentication='Active Directory Integrated'\")                \n            break\n        }\n        \"AzureADManaged\"\n        {\n        \tWrite-Verbose \"Using Azure Active Directory managed identity\"\n            break\n        }\n        \"SqlAuthentication\"\n        {\n            Write-Verbose \"Using SQL Authentication username and password\"\n            $connectionString += (\";Uid={0};Pwd={1}\" -f $UserName, $Password)                \n            break        \n        }\n        \"WindowsIntegrated\"\n        {\n            Write-Verbose \"Using integrated security\"\n            $connectionString += \";Trusted_Connection=True\"\n            break\n        }\n    }\n    \n    if ($EnableMultiSubnetFailover)\n    {\n        Write-Verbose \"Enabling multi subnet failover\"\n        $connectionString += \";MultisubnetFailover=True\"\n    }\n\n    If ($Database)\n    {\n        $connectionString += (\";Initial Catalog={0}\" -f $Database)\n    }\n\n\t$connectionString += \";TrustServerCertificate=true;\"\n\n    Return $connectionString\n}\n\n<#\n .SYNOPSIS\n Will find the full path of a given filename (For dacpac or publish profile)\n .DESCRIPTION\n Will search through an extracted package folder provided as the BasePath and hunt for any matches for the given filename.\n .PARAMETER BasePath\n String value of the root folder to begine the recursive search.\n .PARAMETER FileName\n String value of the name of the file to search for.\n .PARAMETER FileType\n String value of \"DacPac\" or \"PublishProfile\" to identify the type of file to search for.\n .EXAMPLE\n Get-DacFilePath -BasePath $ExtractPath -FileName $DACPACPackageName -FileType \"DacPac\"\n#>\nfunction Get-DacFilePath {\n    [cmdletbinding()]\n    param(\n        [parameter(Mandatory=$true)]\n        [string]$BasePath,\n\n        [parameter(Mandatory=$true)]\n        [string]$FileName,\n\n        [parameter(Mandatory=$true)]\n        [ValidateSet(\"DacPac\",\"PublishProfile\")]\n        [string]$FileType\n    )\n\n    # Add file extension for a dacpac if it's missing\n    if($FileName.Split(\".\")[-1] -ne \"dacpac\" -and $FileType -eq \"DacPac\"){\n        $FileName = \"$FileName.dacpac\"\n    }\n\n    Write-Verbose \"Looking for $FileType $FileName in $BasePath.\"\n\n    $filePath = (Get-ChildItem -Path $BasePath -Recurse -Filter $FileName).FullName\n\n    if(@($filePath).Length -gt 1){\n        Write-Warning \"Found $(@($filePath).Length) instances of $FileName. Using $($filePath[0]).\"\n        Write-Warning \"Multiple paths for $FileName`: $(@($filePath) -join \"; \")\"\n        $filePath = $filePath[0]\n    }\n    elseif(@($filePath).Length -lt 1 -or $null -eq $filePath){\n        Throw \"Could not find $FileName.\"\n    }\n\n    return $filePath\n}\n\nfunction Add-SqlCmdVariables\n{\n\t# Get all SqlCmdVariables\n    $sqlCmdVariables = $OctopusParameters.Keys -imatch \"SqlCmdVariable.*\"\n    $argumentList = @()\n        \n\t# Check to see if something is there\n\tif ($null -ne $sqlCmdVariables)\n    {\n    \tWrite-Host \"Adding SqlCmdVariables ...\"\n        \n\t\t# Loop through the variable collection\n        foreach ($sqlCmdVariable in $sqlCmdVariables)\n        {\n        \t# Add variable to the deploy options\n            $sqlCmdVariableKey = $sqlCmdVariable.Substring(($sqlCmdVariable.ToLower().IndexOf(\"sqlcmdvariable.\") + \"sqlcmdvariable.\".Length))\n            \n            Write-Host \"Adding variable: $sqlCmdVariableKey with value: $($OctopusParameters[$sqlCmdVariable])\"\n            \n            $argumentList += (\"/variables:{0}={1}\" -f $sqlCmdVariableKey, $OctopusParameters[$sqlCmdVariable])\n        }\n    }\n    \n    # return the list of variables\n    return $argumentList\n}\n\nfunction Add-AdditionalArguments\n{\n\t# Define parameters\n    param (\n    \t$AdditionalArguments\n    )\n    \n    # Define local variables\n    $argumentsToAdd = @()\n    \n    # Check for emmpty or null\n    if (![string]::IsNullOrWhitespace($AdditionalArguments))\n    {\n    \t# Split the arguments\n    \t$argumentsToAdd += $AdditionalArguments.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries).Trim()\n    }\n    \n    # Return list\n    return $argumentsToAdd\n}\n\nfunction Get-SqlPackage\n{\n\t# Define local variables\n    $workFolder = $OctopusParameters['Octopus.Action.Package[DACPACPackage].ExtractedPath']\n    $downloadUrl = \"\"\n\n\t# Check to see if a folder needs to be created\n    if((Test-Path -Path \"$workFolder/sqlpackage\") -eq $false)\n    {\n        # Create new folder\n        New-Item -ItemType Directory -Path \"$workFolder/sqlpackage\"\n    }\n    \n    Write-Host \"Downloading SqlPackage ...\"\n    \n    if ($IsWindows)\n    {\n    \t# Set url\n        $downloadUrl = \"https://aka.ms/sqlpackage-windows\"\n    }\n    \n    if ($IsLinux)\n    {\n    \t# Set url\n        $downloadUrl = \"https://aka.ms/sqlpackage-linux\"\n    }\n    \n    # Download sql package\n    if ($PSVersionTable.PSVersion.Major -ge 6)\n    {\n    \t# Download\n        Invoke-WebRequest -Uri $downloadUrl -OutFile \"$workFolder/sqlpackage/sqlpackage.zip\"\n    }\n    else\n    {\n    \tInvoke-WebRequest -Uri $downloadUrl -OutFile \"$workFolder/sqlpackage/sqlpackage.zip\" -UseBasicParsing\n    }\n    \n    # Expand the archive\n    Write-Host \"Extracting .zip ...\"\n    Expand-Archive -Path \"$workFolder/sqlpackage/sqlpackage.zip\" -DestinationPath \"$workFolder/sqlpackage\"\n    \n    # Add to PATH\n    $env:PATH = \"$workFolder/sqlpackage$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n    # Make it executable\n    if ($IsLinux)\n    {\n    \t& chmod a+x \"$workFolder/sqlpackage/sqlpackage\"\n    }\n}\n\nFunction Format-OctopusArgument {\n\n    Param(\n        [string]$Value\n    )\n\n    $Value = $Value.Trim()\n\n    # There must be a better way to do this\n    Switch -Wildcard ($Value){\n\n        \"True\" { Return $True }\n        \"False\" { Return $False }\n        \"#{*}\" { Return $null }\n        Default { Return $Value }\n    }\n}\n\nFunction Get-ManagedIdentityToken\n{\n\t# Get the identity token\n    Write-Host \"Getting Azure Managed Identity token ...\"\n    $token = $null\n    $tokenUrl = \"http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fdatabase.windows.net%2F\"\n    \n    if ($PSVersionTable.PSVersion.Major -ge 6)\n    {\n    \t$token = Invoke-RestMethod -Method GET -Uri $tokenUrl -Headers @{\"MetaData\" = \"true\"}\n    }\n    else\n    {\n    \t$token = Invoke-RestMethod -Method GET -Uri $tokenUrl -Headers @{\"MetaData\" = \"true\"} -UseBasicParsing\n    }\n    \n    # Return the token\n    return $token.access_token\n}\n\nfunction Invoke-SqlPackage\n{\n\t# Define parameters\n    param (\n    \t$Action,\n        $Arguments\n    )\n    \n    # Add the action\n    $Arguments += \"/Action:$Action\"\n\n\t#Write-Host \"Executing `\"sqlpackage $Arguments `\"\"\n    \n    # Display what's going to be run\n    if (![string]::IsNullOrWhitespace($Password))\n    {\n        $displayArguments = $Arguments.PSObject.Copy()\n        $arrayIndex = 0\n        for ($i = 0; $i -lt $displayArguments.Count; $i++)\n        {\n            if ($null -ne $displayArguments[$i])\n            {\n                if ($displayArguments[$i].Contains($Password))\n                {\n                    $DisplayArguments[$i] = $displayArguments[$i].Replace($Password, \"****\")\n                }\n            }\n        }\n\n        Write-Host \"Executing the following command: sqlpackage $displayArguments\"\n    }\n    else \n    {\n        Write-Host \"Executing the following command: sqlpackage $Arguments\"\n    }    \n    \n    & sqlpackage $Arguments\n\n<#\n\t# Redirection of stderr to stdout is done different on Windows versus Linux\n\tif ($IsWindows)\n\t{\n\t\t$Arguments += \"2>&1\"\n\t\t# Execute Liquibase\n  \t\t& sqlpackage $Arguments #| Tee-Object -Variable liquibaseCommandOutput\n\t}\n\n\tif ($IsLinux)\n\t{\n\t\t# Execute Liquibase\n  \t\t& sqlpackage $Arguments 2>&1 #| Tee-Object -Variable liquibaseCommandOutput\n\t}\n#>\n\n\t# Check exit code\n\tif ($lastExitCode -ne 0)\n\t{\n\t\t# Fail the step\n    \tWrite-Error \"Execution failed!\"\n\t}\n}\n\nfunction Validate-Folder\n{\n\t# Define parameters\n    param (\n    \t$TestPath\n    )\n    \n    # Check for folder\n    if ((Test-Path -Path $TestPath) -eq $false)\n    {\n    \t# Create the folder\n        New-Item -Path \"$TestPath\" -ItemType \"directory\"\n    }\n}\n\n# Get the supplied parameters\n$PublishProfile = $OctopusParameters[\"DACPACPublishProfile\"]\n$DACPACReport = Format-OctopusArgument -Value $OctopusParameters[\"DACPACReport\"]\n$DACPACScript = Format-OctopusArgument -Value $OctopusParameters[\"DACPACScript\"]\n$DACPACDeploy = Format-OctopusArgument -Value $OctopusParameters[\"DACPACDeploy\"]\n$DACPACTargetServer = $OctopusParameters[\"DACPACTargetServer\"]\n$DACPACTargetDatabase = $OctopusParameters[\"DACPACTargetDatabase\"]\n$DACPACAdditionalArguments = $OctopusParameters[\"DACPACAdditionalArguments\"]\n$DACPACExeLocation = $OctopusParameters[\"DACPACExeLocation\"]\n\n$Username = $OctopusParameters[\"DACPACSQLUsername\"]\n$Password = $OctopusParameters[\"DACPACSQLPassword\"]\n$PackageReferenceName = \"DACPACPackage\"\n\n$authenticationType = $OctopusParameters[\"DACPACAuthenticationType\"]\n\n$ExtractPathKey = (\"Octopus.Action.Package[{0}].ExtractedPath\" -f $PackageReferenceName)\n$ExtractPath = $OctopusParameters[$ExtractPathKey]\n\nif(!(Test-Path $ExtractPath)) {\n    Throw (\"The package extraction folder '{0}' does not exist or the Octopus Tentacle does not have permission to access it.\" -f $ExtractPath)\n}\n\n# Get the DACPAC location\n$DACPACPackagePath = Get-DacFilePath -BasePath $ExtractPath -FileName $DACPACPackageName -FileType \"DacPac\"\n\n# Invoke the DacPac utility\ntry\n{\n\t# Declare working variables\n    $sqlPackageArguments = @()\n    \n    # Build arugment list\n    $sqlPackageArguments += \"/SourceFile:`\"$DACPACPackagePath`\"\"\n    $sqlPackageArguments += \"/TargetConnectionString:`\"$(Get-ConnectionString -ServerName $DACPACTargetServer -Database $DACPACTargetDatabase -UserName $UserName -Password $Password -AuthenticationType $AuthenticationType)`\"\"\n    \n\t# Check to see if a publish profile was designated\n\tIf ($PublishProfile){\n    \t$PublishProfilePath = Get-DacFilePath -BasePath $ExtractPath -FileName $PublishProfile -FileType \"PublishProfile\"\n    \n    \t# Add to arguments\n    \t$sqlPackageArguments += \"/Profile:`\"$PublishProfilePath`\"\"\n\t}    \n    \n    # Check to see if it's using managed identity\n    if ($authenticationType -eq \"AzureADManaged\")\n    {\n    \t# Add access token\n        $Password = Get-ManagedIdentityToken\n        $sqlPackageArguments += \"/AccessToken:$Password\"\n    }\n    \n    # Add sqlcmd variables\n    $sqlPackageArguments += Add-SqlCmdVariables\n    \n\t# Add addtional arguments\n    $sqlPackageArguments += Add-AdditionalArguments -AdditionalArguments $DACPACAdditionalArguments\n    \n    # Check to see if sqlpackage needs to be downloaded\n    if ([string]::IsNullOrWhitespace($DACPACExeLocation))\n    {\n    \t# Download and extract sqlpackage\n        Get-SqlPackage\n    }\n    else\n    {\n    \t# Add folder location to path\n        $env:PATH = \"$([IO.Path]::GetDirectoryName($DACPACExeLocation))$([IO.Path]::PathSeparator)\" + $env:PATH\n        Write-Host \"It is $($env:PATH)\"\n    }\n    \n    # Execute the actions\n    if ($DACPACReport)\n    {\n    \t$workFolder = \"$($OctopusParameters['Octopus.Action.Package[DACPACPackage].ExtractedPath'])/reports\"\n        $sqlReportArguments = @()\n        $sqlReportArguments += \"/OutputPath:$workFolder/report.xml\"\n        \n        # Validate the folder\n        Validate-Folder -TestPath $workFolder\n        \n        # Execute the action\n        Invoke-SqlPackage -Action \"DeployReport\" -Arguments ($sqlPackageArguments + $sqlReportArguments)\n        \n        # Attach artifacts\n        foreach ($item in (Get-ChildItem -Path $workFolder))\n        {\n        \t# Upload artifact\n            New-OctopusArtifact $item.FullName\n        }\n    }\n    \n    if ($DACPACScript)\n    {\n    \t$workFolder = \"$($OctopusParameters['Octopus.Action.Package[DACPACPackage].ExtractedPath'])/scripts\"\n        $sqlScriptArguments = @()\n        $sqlScriptArguments += \"/OutputPath:$workFolder/scripts.sql\"\n        \n        # Validate folder\n        Validate-Folder -TestPath $workFolder\n        \n        # Execute the action\n        Invoke-SqlPackage -Action \"Script\" -Arguments ($sqlPackageArguments + $sqlScriptArguments)\n        \n        # Attach artifacts\n        foreach ($item in (Get-ChildItem -Path $workFolder))\n        {\n        \t# Upload artifact\n            New-OctopusArtifact $item.FullName\n        }        \n    }\n    \n    if ($DACPACDeploy)\n    {\n    \t# Execute action\n        Invoke-SqlPackage -Action \"Publish\" -Arguments $sqlPackageArguments\n    }\n}\ncatch\n{\n    Write-Host $_.Exception.ToString()\n    throw;\n}\n",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "false"
+  },
+  "Parameters": [
+    {
+      "Id": "f2fcbf76-89ad-4fa2-9be3-cd80de2e39a1",
+      "Name": "DACPACPackageName",
+      "Label": "DACPACPackageName",
+      "HelpText": "The name of the .dacpac file that contains the SSDT model.  Include the .dacpac extensions.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "0d21c2a7-3e6e-4411-81d7-0e5866faa8fd",
+      "Name": "DACPACPublishProfile",
+      "Label": "Publish profile file name",
+      "HelpText": "Name of the publish profile file to use",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "7b302914-8d6c-4df2-b392-e45a44e0147c",
+      "Name": "DACPACReport",
+      "Label": "Report",
+      "HelpText": "Whether a deployment report should be generated and loaded into OctopusDeploy as an artifact",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "aa612324-c2ea-4e86-921a-8ad7494df752",
+      "Name": "DACPACScript",
+      "Label": "Script",
+      "HelpText": "Whether a deploy script should be generated and loaded into OctopusDeploy as an artifact",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "94c4da0b-5c55-4d3d-ab0b-e175a767694f",
+      "Name": "DACPACDeploy",
+      "Label": "Deploy",
+      "HelpText": "Whether a deployment of the dacpac should occur",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "d2265a95-ee58-4430-8db0-c7bb03826de0",
+      "Name": "DACPACTargetServer",
+      "Label": "Target Servername",
+      "HelpText": "Name of the server to target this deployment against",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "74397a3b-b007-43cf-bc26-7a1fc2690e24",
+      "Name": "DACPACTargetDatabase",
+      "Label": "Target Database",
+      "HelpText": "Name of the database to target this deployment against",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e1710f37-5f38-4d77-8a05-5fbb6d79132e",
+      "Name": "DACPACAuthenticationType",
+      "Label": "Authentication type",
+      "HelpText": "Select the method to authenticate to the SQL Server.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "SqlAuthentication|SQL Authentication\nWindowsIntegrated|Windows Integrated\nAzureADManaged|Azure Active Directory Managed Identity\nAzureADPassword|Azure Active Directory Username/Password\nAzureADIntegrated|Azure Active Directory Integrated"
+      }
+    },
+    {
+      "Id": "a51747d3-514d-4110-bf6b-e5f3932d4f22",
+      "Name": "DACPACSQLUsername",
+      "Label": "Username",
+      "HelpText": "User name to use to connect to the server if we are not using Integrated Security",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1afb7ff1-4447-425e-8625-33d76f32c321",
+      "Name": "DACPACSQLPassword",
+      "Label": "Password",
+      "HelpText": "Password to use to connect to the server if we are not using Integrated Security",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "fa1d3a63-f2c0-4969-a4ac-d797df53bed1",
+      "Name": "DACPACPackage",
+      "Label": "DACPAC Package",
+      "HelpText": "The package containing the `.dacpac` file from the specified repository.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "2afcffb6-6c2c-4012-8ea8-80ce9f3f4a19",
+      "Name": "DACPACCommandTimeout",
+      "Label": "Command Timeout",
+      "HelpText": "Override the default command timeout for longer-running scripts.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "17444647-1f19-42e9-bde2-839601de5347",
+      "Name": "DACPACExeLocation",
+      "Label": "SqlPackage executable location",
+      "HelpText": "Location of the SqlPackage executable.  Leave blank to dynamically download.<br />\nExamples:<br />\nEmbedded within the package:`#{Octopus.Action.Package[DACPACPackage].ExtractedPath}/MySubFolder`<br />\nOn disk:`c:\\sqlpackage\\sqlpackage.exe` or `/etc/sqlpackage/sqlpackage`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "99d63959-edbb-4f06-a4be-15dd7cf24c35",
+      "Name": "DACPACAdditionalArguments",
+      "Label": "Additional arguments",
+      "HelpText": "A comma-delimited list of additional arguments to add to the SqlPackage command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-03-07T17:45:42.921Z",
+    "OctopusVersion": "2023.1.9680",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "twerthi",
+  "Category": "sql"
+}


### PR DESCRIPTION


---

### Step template checklist

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

