### PR TITLE
feat: Check existing LXC on proxmox and remove if force

### DIFF
--- a/step-templates/proxmox-deploy-lxc.json
+++ b/step-templates/proxmox-deploy-lxc.json
@@ -1,194 +1,194 @@
 {
-	"Id": "ab90cb93-96ae-4841-8058-1cc5ec6feebe",
+	"Id": "cc29a809-2cdb-4d33-8d8c-585a79118307",
 	"Name": "Proxmox Deploy LXC Container",
 	"Description": "Creates a new Proxmox LXC container using the Proxmox API.\n\nRequires a Proxmox [API token](https://pve.proxmox.com/wiki/Proxmox_VE_API#API_Tokens) to authenticate to the Proxmox Server/Cluster",
 	"ActionType": "Octopus.Script",
-	"Version": 2,
-	"CommunityActionTemplateId": null,
+	"Version": 3,
+	"CommunityActionTemplateId": "CommunityActionTemplates-1621",
 	"Packages": [],
 	"Properties": {
-		"Octopus.Action.Script.ScriptSource": "Inline",
-		"Octopus.Action.Script.Syntax": "PowerShell",
-		"Octopus.Action.Script.ScriptBody": "# Proxmox Connection Variables\n$ProxmoxHost = $OctopusParameters[\"Proxmox.Host\"];\n$ProxmoxPort = [int]$OctopusParameters[\"Proxmox.Port\"];\n$ProxmoxUser = $OctopusParameters[\"Proxmox.User\"];\n\n$ProxmoxNode = $OctopusParameters[\"Proxmox.Node\"];\n\n$ProxmoxTokenID = $OctopusParameters[\"Proxmox.TokenID\"];\n$ProxmoxToken = $OctopusParameters[\"Proxmox.Token\"];\n\n# LXC Variables\n$LXC_VMID = [int]$OctopusParameters[\"Proxmox.LXC.VMID\"];\n$LXC_Hostname = $OctopusParameters[\"Proxmox.LXC.Hostname\"];\n$LXC_OSTemplate = $OctopusParameters[\"Proxmox.LXC.OSTemplate\"];\n$LXC_Storage = $OctopusParameters[\"Proxmox.LXC.Storage\"];\n$LXC_CPU = [int]$OctopusParameters[\"Proxmox.LXC.Cores\"];\n$LXC_Memory = [int]$OctopusParameters[\"Proxmox.LXC.Memory\"];\n$LXC_RootSize = [int]$OctopusParameters[\"Proxmox.LXC.RootSize\"];\n$LXC_Networks = $OctopusParameters[\"Proxmox.LXC.Network\"];\n$LXC_Password = $OctopusParameters[\"Proxmox.LXC.Password\"];\n\n$BaseURL = \"https://$($ProxmoxHost):$($ProxmoxPort)/api2/json\"\n\n$header = @{\n\t\"Authorization\" = \"PVEAPIToken=$($ProxmoxUser)!$($ProxmoxTokenID)=$($ProxmoxToken)\"\n}\n\n\nWrite-Host \"Testing Connection To Proxmox Server/Cluster ...\"\n\ntry{\n\tInvoke-RestMethod -Method GET -uri \"$($BaseURL)\" -Headers $header | out-null\n}catch{\n\tthrow \"Couldn't Connect to the Proxmox Server/Cluster\"\n}\n\nWrite-Host \"Successfully Connected To Proxmox Server/Cluster\"\n\n$LXC_Start = 0\ntry {\n  $Start = [System.Convert]::ToBoolean($OctopusParameters[\"Proxmox.LXC.StartOnCreate\"])\n  \n  if($Start -eq $True){\n  \t$LXC_Start = 1\n  }\n  \n} catch {}\n\n$LXC_Force = 0\ntry {\n  $Force = [System.Convert]::ToBoolean($OctopusParameters[\"Proxmox.LXC.Force\"])\n  \n  if($Force -eq $True){\n  \t$LXC_Force = 1\n  }\n  \n} catch {}\n\nif($LXC_CPU -lt 1){\n\t$LXC_CPU=1;\n}\n\nif($LXC_Memory -lt 16){\n\t$LXC_Memory = 16;\n}\n\nif($LXC_RootSize -lt 1){\n\t$LXC_RootSize = 1;\n}\n\nif($LXC_Hostname -eq $null -or $LXC_Hostname -eq \"\"){\n\tthrow \"LXC Hostname must be provided!\"\n}\n\nif($LXC_OSTemplate -eq $null -or $LXC_OSTemplate -eq \"\"){\n\tthrow \"LXC OS Template must be provided!\"\n}\n\nif($LXC_Storage -eq $null -or $LXC_Storage -eq \"\"){\n\tthrow \"LXC Storage must be provided!\"\n}\n\nif($LXC_Networks -eq $null){\n\tthrow \"You must provide at least one network property\"\n}\n\nif($LXC_Password -eq $null -or $LXC_Password -eq \"\"){\n\tthrow \"LXC Password must be provided!\"\n}\n\nif($LXC_VMID -eq \"-1\"){\n\t$LXC_VMID=(Invoke-RestMethod -Method GET -uri \"$($BaseURL)/cluster/nextid\" -headers $header).data\n    Write-Host \"Found next vm id: $($LXC_VMID)\"\n}\n\nif($LXC_VMID -lt 1){\n\tthrow \"The LXC VMID was not valid ($LXC_VMID), Set this to -1 to automatically find the next id\"\n}\n\n$LXCData = @{\n\t\"vmid\" = $LXC_VMID\n    \"hostname\" = $LXC_Hostname\n    \"ostemplate\" = $LXC_OSTemplate\n    \"rootfs\" = \"volume=$($LXC_Storage):$($LXC_RootSize)\"\n    \"cores\" = $LXC_CPU\n    \"memory\" = $LXC_Memory\n    \"storage\" = $LXC_Storage\n    \"password\" = $LXC_Password\n    \"start\" = $LXC_Start\n    \"force\" = $LXC_Force\n}\n\n$NetworkIndex = 0;\n\n$Networks = $LXC_Networks.replace(\"\\n\", \"`n\").split(\"`n\")\n\nif($Networks.Count -lt 1){\n\tthrow \"You must provide at least one network property\"\n}\n\nforeach ($network in $Networks){\n    $LXCData[\"net$($NetworkIndex)\"] = $network;\n    $NetworkIndex++;\n}\n\nWrite-Host \"New LXC Summary:\"\n\n$LXCData | Convertto-json -depth 10\n\n$LXCCreateAsyncTask = (Invoke-RestMethod -Method POST -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/lxc\" -Headers $header -Body $LXCData)\n\n\n$count = 1;\n$maxCount = 10;\n\nDO\n{\n \n $TaskID = $LXCCreateAsyncTask.Data;\n    Write-Host \"Checking if LXC has finished creating..\"\n    $LXCCreateAsyncTaskStatus = (Invoke-RestMethod -Method GET -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/tasks/$($TaskID)/status\" -Headers $header).data\n    \n    if($LXCCreateAsyncTaskStatus.status -eq \"stopped\"){\n    \tif($LXCCreateAsyncTaskStatus.exitstatus -ne \"OK\"){\n        \tWrite-Error \"LXC create task finished with error: $($LXCCreateAsyncTaskStatus.exitstatus)\"\n        }else{\n        \tWrite-Host \"LXC create task has successfully completed!\"\n        }\n        \n        break;\n    }\n    \n\tWrite-Host \"LXC create task has not finished yet, retring in 5 seconds..\"\n    Write-Host \"Task Status: $($LXCCreateAsyncTaskStatus.status)\"\n    sleep 5\n    \n    If($count -gt $maxCount) {\n      Write-Warning \"Task Timed out!\"\n      break;\n    }\n    $count++\n\n} While ($count -le $maxCount)\n"
+	  "Octopus.Action.Script.ScriptSource": "Inline",
+	  "Octopus.Action.Script.Syntax": "PowerShell",
+	  "Octopus.Action.Script.ScriptBody": "# Proxmox Connection Variables\n$ProxmoxHost = $OctopusParameters[\"Proxmox.Host\"];\n$ProxmoxPort = [int]$OctopusParameters[\"Proxmox.Port\"];\n$ProxmoxUser = $OctopusParameters[\"Proxmox.User\"];\n\n$ProxmoxNode = $OctopusParameters[\"Proxmox.Node\"];\n\n$ProxmoxTokenID = $OctopusParameters[\"Proxmox.TokenID\"];\n$ProxmoxToken = $OctopusParameters[\"Proxmox.Token\"];\n\n# LXC Variables\n$LXC_VMID = [int]$OctopusParameters[\"Proxmox.LXC.VMID\"];\n$LXC_Hostname = $OctopusParameters[\"Proxmox.LXC.Hostname\"];\n$LXC_OSTemplate = $OctopusParameters[\"Proxmox.LXC.OSTemplate\"];\n$LXC_Storage = $OctopusParameters[\"Proxmox.LXC.Storage\"];\n$LXC_CPU = [int]$OctopusParameters[\"Proxmox.LXC.Cores\"];\n$LXC_Memory = [int]$OctopusParameters[\"Proxmox.LXC.Memory\"];\n$LXC_RootSize = [int]$OctopusParameters[\"Proxmox.LXC.RootSize\"];\n$LXC_Networks = $OctopusParameters[\"Proxmox.LXC.Network\"];\n$LXC_Password = $OctopusParameters[\"Proxmox.LXC.Password\"];\n\n$BaseURL = \"https://$($ProxmoxHost):$($ProxmoxPort)/api2/json\"\n\n$header = @{\n\t\"Authorization\" = \"PVEAPIToken=$($ProxmoxUser)!$($ProxmoxTokenID)=$($ProxmoxToken)\"\n}\n\n\nWrite-Host \"Testing Connection To Proxmox Server/Cluster ...\"\n\ntry{\n\tInvoke-RestMethod -Method GET -uri \"$($BaseURL)\" -Headers $header | out-null\n}catch{\n\tthrow \"Couldn't Connect to the Proxmox Server/Cluster\"\n}\n\nWrite-Host \"Successfully Connected To Proxmox Server/Cluster\"\n\n$LXC_Start = 0\ntry {\n  $Start = [System.Convert]::ToBoolean($OctopusParameters[\"Proxmox.LXC.StartOnCreate\"])\n  \n  if($Start -eq $True){\n  \t$LXC_Start = 1\n  }\n  \n} catch {}\n\n$LXC_Force = 0\ntry {\n  $Force = [System.Convert]::ToBoolean($OctopusParameters[\"Proxmox.LXC.Force\"])\n  \n  if($Force -eq $True){\n  \t$LXC_Force = 1\n  }\n  \n} catch {}\n\nif($LXC_CPU -lt 1){\n\t$LXC_CPU=1;\n}\n\nif($LXC_Memory -lt 16){\n\t$LXC_Memory = 16;\n}\n\nif($LXC_RootSize -lt 1){\n\t$LXC_RootSize = 1;\n}\n\nif($LXC_Hostname -eq $null -or $LXC_Hostname -eq \"\"){\n\tthrow \"LXC Hostname must be provided!\"\n}\n\nif($LXC_OSTemplate -eq $null -or $LXC_OSTemplate -eq \"\"){\n\tthrow \"LXC OS Template must be provided!\"\n}\n\nif($LXC_Storage -eq $null -or $LXC_Storage -eq \"\"){\n\tthrow \"LXC Storage must be provided!\"\n}\n\nif($LXC_Networks -eq $null){\n\tthrow \"You must provide at least one network property\"\n}\n\nif($LXC_Password -eq $null -or $LXC_Password -eq \"\"){\n\tthrow \"LXC Password must be provided!\"\n}\n\nif($LXC_VMID -eq \"-1\"){\n\t$LXC_VMID=(Invoke-RestMethod -Method GET -uri \"$($BaseURL)/cluster/nextid\" -headers $header).data\n    Write-Host \"Found next vm id: $($LXC_VMID)\"\n}\n\nif($LXC_VMID -lt 1){\n\tthrow \"The LXC VMID was not valid ($LXC_VMID), Set this to -1 to automatically find the next id\"\n}\n\n$LXCData = @{\n\t\"vmid\" = $LXC_VMID\n    \"hostname\" = $LXC_Hostname\n    \"ostemplate\" = $LXC_OSTemplate\n    \"rootfs\" = \"volume=$($LXC_Storage):$($LXC_RootSize)\"\n    \"cores\" = $LXC_CPU\n    \"memory\" = $LXC_Memory\n    \"storage\" = $LXC_Storage\n    \"password\" = $LXC_Password\n    \"start\" = $LXC_Start\n    \"force\" = $LXC_Force\n}\n\n$NetworkIndex = 0;\n\n$Networks = $LXC_Networks.replace(\"\\n\", \"`n\").split(\"`n\")\n\nif($Networks.Count -lt 1){\n\tthrow \"You must provide at least one network property\"\n}\n\nforeach ($network in $Networks){\n    $LXCData[\"net$($NetworkIndex)\"] = $network;\n    $NetworkIndex++;\n}\n\n$existingLXC = $null;\n\ntry{\n    $existingLXC = Invoke-RestMethod -Method GET -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/lxc/$($LXCData.vmid)\" -Headers $header\n}catch{}\n\nif($existingLXC -ne $null -and $LXCData.force -eq 0){\n    throw \"LXC with VMID: $($LXCData.vmid) already exists. Use Force parameter to overwrite this LXC.\"\n\n}elseif($existingLXC -ne $null -and $LXCData.force -eq 1){\n\n    Write-host \"Deleting existing LXC with VMID: $($LXCData.vmid)\"\n    $LXCDestroyAsyncTask =Invoke-RestMethod -Method DELETE -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/lxc/$($LXCData.vmid)\" -Headers $header\n\n    $count = 1;\n    $maxCount = 10;\n    $TaskID = $LXCDestroyAsyncTask.Data;\n\n    DO\n    {\n        Write-Host \"Checking if LXC has finished Deleting..\"\n        $LXCDestroyAsyncTaskStatus = (Invoke-RestMethod -Method GET -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/tasks/$($TaskID)/status\" -Headers $header).data\n    \n        if($LXCDestroyAsyncTaskStatus.status -eq \"stopped\"){\n    \t    if($LXCDestroyAsyncTaskStatus.exitstatus -ne \"OK\"){\n        \t    Write-Error \"LXC destroy task finished with error: $($LXCDestroyAsyncTaskStatus.exitstatus)\"\n            }else{\n        \t    Write-Host \"LXC destroy task has successfully completed!\"\n            }\n        \n            break;\n        }\n    \n\t    Write-Host \"LXC destroy task has not finished yet, retring in 5 seconds..\"\n        Write-Host \"Task Status: $($LXCDestroyAsyncTaskStatus.status)\"\n        sleep 5\n    \n        If($count -gt $maxCount) {\n          Write-Warning \"Task Timed out!\"\n          break;\n        }\n        $count++\n\n    } While ($count -le $maxCount)\n}\n\nWrite-Host \"\"\n\nWrite-Host \"New LXC Summary:\"\n\n$LXCData | Convertto-json -depth 10\n\n$LXCCreateAsyncTask = (Invoke-RestMethod -Method POST -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/lxc\" -Headers $header -Body $LXCData)\n\n\n$count = 1;\n$maxCount = 10;\n\nWrite-Host \"\"\n\nDO\n{\n \n $TaskID = $LXCCreateAsyncTask.Data;\n    Write-Host \"Checking if LXC has finished creating..\"\n    $LXCCreateAsyncTaskStatus = (Invoke-RestMethod -Method GET -uri \"$($BaseURL)/nodes/$($ProxmoxNode)/tasks/$($TaskID)/status\" -Headers $header).data\n    \n    if($LXCCreateAsyncTaskStatus.status -eq \"stopped\"){\n    \tif($LXCCreateAsyncTaskStatus.exitstatus -ne \"OK\"){\n        \tWrite-Error \"LXC create task finished with error: $($LXCCreateAsyncTaskStatus.exitstatus)\"\n        }else{\n        \tWrite-Host \"LXC create task has successfully completed!\"\n        }\n        \n        break;\n    }\n    \n\tWrite-Host \"LXC create task has not finished yet, retring in 5 seconds..\"\n    Write-Host \"Task Status: $($LXCCreateAsyncTaskStatus.status)\"\n    sleep 5\n    \n    If($count -gt $maxCount) {\n      Write-Warning \"Task Timed out!\"\n      break;\n    }\n    $count++\n\n} While ($count -le $maxCount)\n"
 	},
 	"Parameters": [
-        {
-			"Id": "c75c69c5-bdfb-4cbf-8b5a-aeb6ef93c274",
-			"Name": "Proxmox.Host",
-			"Label": "Proxmox Host",
-			"HelpText": "The hostname or IP address of the Proxmox cluster/host",
-			"DefaultValue": "1.2.3.4",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "eddd73e2-cb63-4c1b-8100-05e8e9586180",
-			"Name": "Proxmox.Port",
-			"Label": "Proxmox Port",
-			"HelpText": "Port number for Proxmox Cluster/Host",
-			"DefaultValue": "8006",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "eae18957-8977-4f51-8e09-2402453fd531",
-			"Name": "Proxmox.User",
-			"Label": "Proxmox User Account",
-			"HelpText": "The Proxmox user account associated with the api token.",
-			"DefaultValue": "root@pam",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "b413ee30-ba94-4ff3-8b4e-148c1fbc52f6",
-			"Name": "Proxmox.Node",
-			"Label": "Proxmox Node",
-			"HelpText": "The Proxmox node in the cluster.",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "3f70fe63-2b55-44f5-af8e-27d8717ade20",
-			"Name": "Proxmox.TokenID",
-			"Label": "Proxmox Token ID",
-			"HelpText": "This is token id that was used to create an API token in proxmox.",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "741c3b80-af85-47c6-b49e-36aea9b2bc9a",
-			"Name": "Proxmox.Token",
-			"Label": "Proxmox API Token",
-			"HelpText": "The API Token secret key",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "Sensitive"
-			}
-		},
-		{
-			"Id": "003db066-99a7-4d4c-a794-7a6310c2c86b",
-			"Name": "Proxmox.LXC.VMID",
-			"Label": "LXC VM ID",
-			"HelpText": "The new VMID for the new LXC container default is -1 to find the next ID",
-			"DefaultValue": "-1",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "63ba1450-8c9e-4d06-bedf-00389a63ef3f",
-			"Name": "Proxmox.LXC.Hostname",
-			"Label": "LXC Hostname",
-			"HelpText": "The new LXC hostname",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "0a13d075-3a2f-4718-9793-f9b2f5963455",
-			"Name": "Proxmox.LXC.OSTemplate",
-			"Label": "LXC OS Template",
-			"HelpText": "The template image or backup image for the LXC",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "55f7937b-4a5f-49bb-b129-f589c3ce51cc",
-			"Name": "Proxmox.LXC.Password",
-			"Label": "LXC Root Password",
-			"HelpText": "This will be the root password once the LXC container has been created",
-			"DefaultValue": "",
-			"DisplaySettings": {
-				"Octopus.ControlType": "Sensitive"
-			}
-		},
-		{
-			"Id": "671751a5-d213-445a-a73f-dd9f1f33d754",
-			"Name": "Proxmox.LXC.Storage",
-			"Label": "LXC Storage",
-			"HelpText": "Where the rootfs for this LXC will be stored.",
-			"DefaultValue": "local",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "e796b021-0c31-4e03-8825-23c19cbf8876",
-			"Name": "Proxmox.LXC.Network",
-			"Label": "LXC Networks",
-			"HelpText": "The list of network connections this LXC has. Each network connection on a new line.\n\n\n`name=<name>,bridge=<bridge>,firewall=<0|1>,gw=<IPv4>,ip=<IPv4/CIDR|dhcp|manual>`\n\n\nMore Info: [https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc)",
-			"DefaultValue": "name=eth0,bridge=vmbr0",
-			"DisplaySettings": {
-				"Octopus.ControlType": "MultiLineText"
-			}
-		},
-		{
-			"Id": "c9e865ea-a7b2-42d3-aca6-8772e54b893a",
-			"Name": "Proxmox.LXC.Cores",
-			"Label": "LXC CPU Cores",
-			"HelpText": "The amount of CPU cores the LXC is assigned",
-			"DefaultValue": "1",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "74b64687-8aed-433d-bce3-714bfd738927",
-			"Name": "Proxmox.LXC.Memory",
-			"Label": "LXC Memory",
-			"HelpText": "The amount of Memory the LXC is assigned.",
-			"DefaultValue": "2048",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "85c52eb6-a25f-4f8e-a068-2a165160d94d",
-			"Name": "Proxmox.LXC.RootSize",
-			"Label": "LXC Rootfs Size",
-			"HelpText": "The size of the root volume for this LXC, Size is in GB",
-			"DefaultValue": "60",
-			"DisplaySettings": {
-				"Octopus.ControlType": "SingleLineText"
-			}
-		},
-		{
-			"Id": "fd072ced-1c8b-4205-a724-e9456b5152c6",
-			"Name": "Proxmox.LXC.StartOnCreate",
-			"Label": "LXC Start Once Created",
-			"HelpText": "Should the LXC start once the LXC has been created",
-			"DefaultValue": "False",
-			"DisplaySettings": {
-				"Octopus.ControlType": "Checkbox"
-			}
-		},
-		{
-			"Id": "dfea6eea-47ff-4489-9434-8ff80bbb8694",
-			"Name": "Proxmox.LXC.Force",
-			"Label": "LXC Overwrite Container",
-			"HelpText": "Overwrites an existing LXC with the same VMID",
-			"DefaultValue": "False",
-			"DisplaySettings": {
-				"Octopus.ControlType": "Checkbox"
-			}
+	  {
+		"Id": "",
+		"Name": "Proxmox.Host",
+		"Label": "Proxmox Host",
+		"HelpText": "The hostname or IP address of the Proxmox cluster/host",
+		"DefaultValue": "1.2.3.4",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
 		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.Port",
+		"Label": "Proxmox Port",
+		"HelpText": "Port number for Proxmox Cluster/Host",
+		"DefaultValue": "8006",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.User",
+		"Label": "Proxmox User Account",
+		"HelpText": "The Proxmox user account associated with the api token.",
+		"DefaultValue": "root@pam",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.Node",
+		"Label": "Proxmox Node",
+		"HelpText": "The Proxmox node in the cluster.",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.TokenID",
+		"Label": "Proxmox Token ID",
+		"HelpText": "This is token id that was used to create an API token in proxmox.",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.Token",
+		"Label": "Proxmox API Token",
+		"HelpText": "The API Token secret key",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "Sensitive"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.VMID",
+		"Label": "LXC VM ID",
+		"HelpText": "The new VMID for the new LXC container default is -1 to find the next ID",
+		"DefaultValue": "-1",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Hostname",
+		"Label": "LXC Hostname",
+		"HelpText": "The new LXC hostname",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.OSTemplate",
+		"Label": "LXC OS Template",
+		"HelpText": "The template image or backup image for the LXC",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Password",
+		"Label": "LXC Root Password",
+		"HelpText": "This will be the root password once the LXC container has been created",
+		"DefaultValue": "",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "Sensitive"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Storage",
+		"Label": "LXC Storage",
+		"HelpText": "Where the rootfs for this LXC will be stored.",
+		"DefaultValue": "local",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Network",
+		"Label": "LXC Networks",
+		"HelpText": "The list of network connections this LXC has. Each network connection on a new line.\n\n\n`name=<name>,bridge=<bridge>,firewall=<0|1>,gw=<IPv4>,ip=<IPv4/CIDR|dhcp|manual>`\n\n\nMore Info: [https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc)",
+		"DefaultValue": "name=eth0,bridge=vmbr0",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "MultiLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Cores",
+		"Label": "LXC CPU Cores",
+		"HelpText": "The amount of CPU cores the LXC is assigned",
+		"DefaultValue": "1",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Memory",
+		"Label": "LXC Memory",
+		"HelpText": "The amount of Memory the LXC is assigned.",
+		"DefaultValue": "2048",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.RootSize",
+		"Label": "LXC Rootfs Size",
+		"HelpText": "The size of the root volume for this LXC, Size is in GB",
+		"DefaultValue": "60",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "SingleLineText"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.StartOnCreate",
+		"Label": "LXC Start Once Created",
+		"HelpText": "Should the LXC start once the LXC has been created",
+		"DefaultValue": "False",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "Checkbox"
+		}
+	  },
+	  {
+		"Id": "",
+		"Name": "Proxmox.LXC.Force",
+		"Label": "LXC Overwrite Container",
+		"HelpText": "Overwrites an existing LXC with the same VMID",
+		"DefaultValue": "False",
+		"DisplaySettings": {
+		  "Octopus.ControlType": "Checkbox"
+		}
+	  }
 	],
 	"StepPackageId": "Octopus.Script",
 	"$Meta": {
-		"ExportedAt": "2023-03-28T12:27:22.630Z",
-		"OctopusVersion": "2023.2.2028",
-		"Type": "ActionTemplate"
+	  "ExportedAt": "2023-05-04T10:44:27.968Z",
+	  "OctopusVersion": "2023.2.9087",
+	  "Type": "ActionTemplate"
 	},
 	"LastModifiedBy": "domrichardson",
 	"Category": "proxmox"
-}
+  }


### PR DESCRIPTION
Check for an existing LXC container on proxmox and throw an error.

If using the Force parameter, then it will remove the LXC and create a new one.
As the inbuilt force API parameter is currently broken ([Forum Post](https://forum.proxmox.com/threads/api-lxc-force-create-returns-500-error.126889/)) more validation was required in the script.