### PR TITLE
(fix) Remove choco alias

### DIFF
--- a/step-templates/aws-execute-powershell.json
+++ b/step-templates/aws-execute-powershell.json
@@ -3,9 +3,9 @@
   "Name": "Execute AWS Powershell Script",
   "Description": "This combines two previous library templates of [checking for Chocolatey being installed](https://library.octopus.com//step-templates/c364b0a5-a0b7-48f8-a1a4-35e9f54a82d3/actiontemplate-chocolatey-ensure-installed), and [installing something via Chocolatey](https://library.octopus.com/step-templates/b2385b12-e5b5-440f-bed8-6598c29b2528/actiontemplate-chocolatey-install-package), in this case awstools.powershell, and then adds on a third piece of running a custom Powershell script using AWS Powershell tools",
   "ActionType": "Octopus.Script",
-  "Version": 7,
+  "Version": 8,
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocolateyExe = \"$chocolateyBin\\cinst.exe\"\n$chocInstalled = Test-Path $chocolateyExe\n\nif (-not $chocInstalled) {\n  Write-Output \"Chocolatey not found, installing...\"\n\n  $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n  Invoke-Expression $installPs1\n\n  Write-Output \"Chocolatey installation complete.\"\n} else {\n  Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n\n$ChocolateyPackageId = 'awstools.powershell'\n\nif (-not $ChocolateyPackageId) {\n  throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n  Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n  & $chocolateyExe $ChocolateyPackageId\n} else {\n  Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n  & $chocolateyExe $ChocolateyPackageId -Version $ChocolateyPackageVersion\n}\n\nImport-Module \"C:\\Program Files (x86)\\AWS Tools\\PowerShell\\AWSPowerShell\\AWSPowerShell.psd1\"\n\nSet-AWSCredentials -AccessKey $AccessKey -SecretKey $SecretKey -StoreAs AWSKeyProfile\n\nInitialize-AWSDefaults -ProfileName AWSKeyProfile -Region $Region\n\n\nInvoke-Expression $AWSScript",
+    "Octopus.Action.Script.ScriptBody": "Write-Output \"Ensuring the Chocolatey package manager is installed...\"\n\n$chocolateyBin = [Environment]::GetEnvironmentVariable(\"ChocolateyInstall\", \"Machine\") + \"\\bin\"\n$chocolateyExe = \"$chocolateyBin\\choco.exe\"\n$chocInstalled = Test-Path $chocolateyExe\n\nif (-not $chocInstalled) {\n  Write-Output \"Chocolatey not found, installing...\"\n\n  $installPs1 = ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))\n  Invoke-Expression $installPs1\n\n  Write-Output \"Chocolatey installation complete.\"\n} else {\n  Write-Output \"Chocolatey was found at $chocolateyBin and won't be reinstalled.\"\n}\n\n$ChocolateyPackageId = 'awstools.powershell'\n\nif (-not $ChocolateyPackageId) {\n  throw \"Please specify the ID of an application package to install.\"\n}\n\nif (-not $ChocolateyPackageVersion) {\n  Write-Output \"Installing package $ChocolateyPackageId from the Chocolatey package repository...\"\n  & $chocolateyExe install $ChocolateyPackageId\n} else {\n  Write-Output \"Installing package $ChocolateyPackageId version $ChocolateyPackageVersion from the Chocolatey package repository...\"\n  & $chocolateyExe install $ChocolateyPackageId --version $ChocolateyPackageVersion\n}\n\nImport-Module \"C:\\Program Files (x86)\\AWS Tools\\PowerShell\\AWSPowerShell\\AWSPowerShell.psd1\"\n\nSet-AWSCredentials -AccessKey $AccessKey -SecretKey $SecretKey -StoreAs AWSKeyProfile\n\nInitialize-AWSDefaults -ProfileName AWSKeyProfile -Region $Region\n\n\nInvoke-Expression $AWSScript",
     "Octopus.Action.Script.Syntax": "PowerShell"
   },
   "SensitiveProperties": {},
@@ -47,10 +47,10 @@
       }
     }
   ],
-  "LastModifiedOn": "2015-05-01T18:13:05.077+00:00",
-  "LastModifiedBy": "hulahomer",
+  "LastModifiedOn": "2023-06-05T12:27:05.077+00:00",
+  "LastModifiedBy": "pauby",
   "$Meta": {
-    "ExportedAt": "2015-05-01T18:13:07.633+00:00",
+    "ExportedAt": "2023-06-05T12:27:05.077+00:00",
     "OctopusVersion": "2.5.8.447",
     "Type": "ActionTemplate"
   },


### PR DESCRIPTION
### Step template checklist

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

This PR fixes [this comment](https://github.com/OctopusDeploy/Library/issues/1358#issuecomment-1576127305) (but not the issue).
