### PR TITLE
Forgot to add new paramater

### DIFF
--- a/step-templates/sql-execute-sql-files.json
+++ b/step-templates/sql-execute-sql-files.json
@@ -3,7 +3,7 @@
     "Name": "SQL - Execute SQL Script Files",
     "Description": "Executes SQL script file(s) against the specified database using the `SQLServer` Powershell Module.  This template includes an `Authentication` selector and supports SQL Authentication, Windows Authentication, and Azure Managed Identity.\n\nNote: If the `SqlServer` PowerShell module is not present, the template will download a temporary copy to perform the task.",
     "ActionType": "Octopus.Script",
-    "Version": 4,
+    "Version": 5,
     "CommunityActionTemplateId": null,
     "Packages": [
       {
@@ -103,6 +103,16 @@
         "Name": "ExecuteSQL.DisplaySQLServerOutput",
         "Label": "Display SQL Output",
         "HelpText": "You can display SQL Server message output, such as those that result from the SQL `PRINT` statement, by checking this parameter",
+        "DefaultValue": "False",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "52d8f897-696b-4f77-87b5-383d6ce559c3",
+        "Name": "ExecuteSQL.TrustServerCertificate",
+        "Label": "Trust Server Certificate",
+        "HelpText": "Force connection to trust the server certificate.",
         "DefaultValue": "False",
         "DisplaySettings": {
           "Octopus.ControlType": "Checkbox"


### PR DESCRIPTION


---

# Background

Added the new code, forgot the new parameter.

# Results

Adds the new parameter for forcing trust of the server certificate

## Before

No checkbox for trusting ceritificate

## After

A new checkbox!

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes stupid mistake I made.
