### PR TITLE
Adding new git steps

### DIFF
--- a/step-templates/git-clone-copy-push-another-repo.json
+++ b/step-templates/git-clone-copy-push-another-repo.json
@@ -109,6 +109,6 @@
     "OctopusVersion": "2023.4.2661",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "twerthi",
+  "Category": "git"
 }

--- a/step-templates/git-clone-copy-push-another-repo.json
+++ b/step-templates/git-clone-copy-push-another-repo.json
@@ -1,0 +1,114 @@
+{
+  "Id": "6db15b08-f6c6-4a6e-833c-773eb38ec0f0",
+  "Name": "Git - Clone, copy, push to another repo",
+  "Description": "Clones both a source and destination repository, copies files from the `Source Path` to the `Destination Path` then commits to the destination repository.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Invoke-Git\n{\n\t# Define parameters\n    param (\n    \t$GitRepositoryUrl,\n        $GitFolder,\n        $GitUsername,\n        $GitPassword,\n        $GitCommand,\n        $AdditionalArguments\n    )\n    \n    # Get current work folder\n    $workDirectory = Get-Location\n\n\t# Check to see if GitFolder exists\n    if (![String]::IsNullOrWhitespace($GitFolder) -and (Test-Path -Path $GitFolder) -eq $false)\n    {\n    \t# Create the folder\n        New-Item -Path $GitFolder -ItemType \"Directory\" -Force | Out-Null\n        \n        # Set the location to the new folder\n        Set-Location -Path $GitFolder\n    }\n    \n    # Create arguments array\n    $gitArguments = @()\n    $gitArguments += $GitCommand\n    \n    # Check for url\n    if (![string]::IsNullOrWhitespace($GitRepositoryUrl))\n    {\n      # Convert url to URI object\n      $gitUri = [System.Uri]$GitRepositoryUrl\n      $gitUrl = \"{0}://{1}:{2}@{3}:{4}{5}\" -f $gitUri.Scheme, $GitUsername, $GitPassword, $gitUri.Host, $gitUri.Port, $gitUri.PathAndQuery\n      $gitArguments += $gitUrl\n\n      # Get the newly created folder name\n      $gitFolderName = $GitRepositoryUrl.SubString($GitRepositoryUrl.LastIndexOf(\"/\") + 1)\n      if ($gitFolderName.Contains(\".git\"))\n      {\n          $gitFolderName = $gitFolderName.SubString(0, $gitFolderName.IndexOf(\".\"))\n      }\n    }\n   \n    \n    # Check for additional arguments\n    if ($null -ne $AdditionalArguments)\n    {\n \t\t# Add the additional arguments\n        $gitArguments += $AdditionalArguments\n    }\n    \n    # Execute git command\n    $results = Execute-Command -commandPath \"git\" -commandArguments $gitArguments -workingDir $GitFolder\n    \n    Write-Host $results.stdout\n    Write-Host $results.stderr\n    \n    # Return the foldername\n    Set-Location -Path $workDirectory\n    \n    # Check to see if GitFolder is null\n    if ($null -ne $GitFolder)\n    {\n    \treturn Join-Path -Path $GitFolder -ChildPath $gitFolderName\n    }\n}\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\nFunction Copy-Files\n{\n\t# Define parameters\n    param (\n    \t$SourcePath,\n        $DestinationPath\n    )\n    \n    # Copy the items from source path to destination path\n    $copyArguments = @{}\n    $copyArguments.Add(\"Path\", $SourcePath)\n    $copyArguments.Add(\"Destination\", $DestinationPath)\n    \n    # Check to make sure destination exists\n    if ((Test-Path -Path $DestinationPath) -eq $false)\n    {\n    \t# Create the destination path\n        New-Item -Path $DestinationPath -ItemType \"Directory\" | Out-Null\n    }\n    \n    # Check for wildcard\n    if ($SourcePath.EndsWith(\"/*\") -or $SourcePath.EndsWith(\"\\*\"))\n    {\n\t\t# Add recurse argument\n\t\t$copyArguments.Add(\"Recurse\", $true)\n    }\n    \n    # Force overwrite\n    $copyArguments.Add(\"Force\", $true)\n    \n    # Copy files\n    Copy-Item @copyArguments\n}\n\nFunction Execute-Command\n{\n\tparam (\n    \t$commandPath,\n        $commandArguments,\n        $workingDir\n    )\n\n\t$gitExitCode = 0\n    $executionResults = $null\n\n  Try {\n    $pinfo = New-Object System.Diagnostics.ProcessStartInfo\n    $pinfo.FileName = $commandPath\n    $pinfo.WorkingDirectory = $workingDir\n    $pinfo.RedirectStandardError = $true\n    $pinfo.RedirectStandardOutput = $true\n    $pinfo.UseShellExecute = $false\n    $pinfo.Arguments = $commandArguments\n    $p = New-Object System.Diagnostics.Process\n    $p.StartInfo = $pinfo\n    $p.Start() | Out-Null\n    $executionResults = [pscustomobject]@{\n        stdout = $p.StandardOutput.ReadToEnd()\n        stderr = $p.StandardError.ReadToEnd()\n        ExitCode = $p.ExitCode\n    }\n    $p.WaitForExit()\n    $gitExitCode = [int]$p.ExitCode\n    \n    if ($gitExitCode -ge 2) \n    {\n\t\t# Fail the step\n        throw\n    }\n    \n    return $executionResults\n  }\n  Catch {\n    # Check exit code\n    Write-Error -Message \"$($executionResults.stderr)\" -ErrorId $gitExitCode\n    exit $gitExitCode\n  }\n\n}\n\nFunction Get-GitExecutable\n{\n\t# Define parameters\n    param (\n    \t$WorkingDirectory\n    )\n      \n    # Define variables\n    $gitExe = \"PortableGit-2.41.0.3-64-bit.7z.exe\"\n    $gitDownloadUrl = \"https://github.com/git-for-windows/git/releases/download/v2.41.0.windows.3/$gitExe\"\n    $gitDownloadArguments = @{}\n    $gitDownloadArguments.Add(\"Uri\", $gitDownloadUrl)\n    $gitDownloadArguments.Add(\"OutFile\", \"$WorkingDirectory/git/$gitExe\")\n    \n    # This makes downloading faster\n    $ProgressPreference = 'SilentlyContinue'\n    \n    # Check to see if git subfolder exists\n    if ((Test-Path -Path \"$WorkingDirectory/git\") -eq $false)\n    {\n    \t# Create subfolder\n        New-Item -Path \"$WorkingDirectory/git\"  -ItemType Directory\n    }\n    \n    # Check PowerShell version\n    if ($PSVersionTable.PSVersion.Major -lt 6)\n    {\n    \t# Use basic parsing is required\n        $gitDownloadArguments.Add(\"UseBasicParsing\", $true)\n    }\n    \n    # Download Git\n    Write-Host \"Downloading Git ...\"\n    Invoke-WebRequest @gitDownloadArguments\n    \n    # Extract Git\n    $gitExtractArguments = @()\n    $gitExtractArguments += \"-o\"\n    $gitExtractArguments += \"$WorkingDirectory\\git\"\n    $gitExtractArguments += \"-y\"\n    $gitExtractArguments += \"-bd\"\n\n    Write-Host \"Extracting Git download ...\"\n    & \"$WorkingDirectory\\git\\$gitExe\" $gitExtractArguments\n\n    # Wait until unzip action is complete\n    while ($null -ne (Get-Process | Where-Object {$_.ProcessName -eq ($gitExe.Substring(0, $gitExe.LastIndexOf(\".\")))}))\n    {\n        Start-Sleep 5\n    }\n    \n    # Add bin folder to path\n    $env:PATH = \"$WorkingDirectory\\git\\bin$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n    # Disable promopt for credential helper\n    Invoke-Git -GitCommand \"config\" -AdditionalArguments @(\"--system\", \"--unset\", \"credential.helper\")\n}\n\n# Get variables\n$sourceGitUrl = $OctopusParameters['Template.Git.Source.Repo.Url']\n$destinationGitUrl = $OctopusParameters['Template.Git.Destination.Repo.Url']\n$gitSourceUser = $OctopusParameters['Template.Git.Source.User.Name']\n$gitSourcePassword = $OctopusParameters['Template.Git.Source.User.Password']\n$gitDestinationUser = $OctopusParameters['Template.Git.Destination.User.Name']\n$gitDestinationPassword = $OctopusParameters['Template.Git.Destination.User.Password']\n$sourceItems = $OctopusParameters['Template.Git.Source.Path']\n$destinationPath = $OctopusParameters['Template.Git.Destination.Path']\n$gitTag = $OctopusParameters['Template.Git.Tag']\n$gitSource = $null\n$gitDestination = $null\n\n# Check to see if it's Windows\nif ($IsWindows -and $OctopusParameters['Octopus.Workerpool.Name'] -eq \"Hosted Windows\")\n{\n\t# Dynamic worker don't have git, download portable version and add to path for execution\n    Write-Host \"Detected usage of Windows Dynamic Worker ...\"\n    Get-GitExecutable -WorkingDirectory $PWD\n}\n\n# Clone destination repository\n$destinationFolderName = Invoke-Git -GitRepositoryUrl $destinationGitUrl -GitUsername $gitDestinationUser -GitPassword $gitDestinationPassword -GitCommand \"clone\" -GitFolder \"$($PWD)/destination/default\"\n\n# Check for tag\nif (![String]::IsNullOrWhitespace($gitTag))\n{\n    $sourceFolderName = Invoke-Git -GitRepositoryUrl $sourceGitUrl -GitUsername $gitSourceUser -GitPassword $gitSourcePassword -GitCommand \"clone\" -GitFolder \"$($PWD)/source/tags/$gitTag\" -AdditionalArguments @(\"-b\", \"$gitTag\")\n}\nelse\n{\n\t$sourceFolderName = Invoke-Git -GitRepositoryUrl $sourceGitUrl -GitUsername $gitSourceUser -GitPassword $gitSourcePassword -GitCommand \"clone\" -GitFolder \"$($PWD)/source/default\"\n}\n\n# Copy files from source to destination\nCopy-Files -SourcePath \"$($sourceFolderName)$($sourceItems)\" -DestinationPath \"$($destinationFolderName)$($destinationPath)\"\n\n# Set user\n$gitAuthorName = $OctopusParameters['Octopus.Deployment.CreatedBy.DisplayName']\n$gitAuthorEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n\n# Check to see if user is system\nif ([string]::IsNullOrWhitespace($gitAuthorEmail) -and $gitAuthorName -eq \"System\")\n{\n\t# Initiated by the Octopus server via automated process, put something in for the email address\n    $gitAuthorEmail = \"system@octopus.local\"\n}\n\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.name\", $gitAuthorName) -GitFolder \"$($destinationFolderName)\" | Out-Null\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.email\", $gitAuthorEmail) -GitFolder \"$($destinationFolderName)\" | Out-Null\n\n# Commit changes\nInvoke-Git -GitCommand \"add\" -GitFolder \"$destinationFolderName\" -AdditionalArguments @(\".\") | Out-Null\nInvoke-Git -GitCommand \"commit\" -GitFolder \"$destinationFolderName\" -AdditionalArguments @(\"-m\", \"`\"Commit from #{Octopus.Project.Name} release version #{Octopus.Release.Number}`\"\") | Out-Null\n\n# Push the changes back to git\nInvoke-Git -GitCommand \"push\" -GitFolder \"$destinationFolderName\" | Out-Null\n\n"
+  },
+  "Parameters": [
+    {
+      "Id": "674d5325-aa93-4779-a734-cee8e5690f17",
+      "Name": "Template.Git.Source.Repo.Url",
+      "Label": "Source Git Repository URL",
+      "HelpText": "The URL used for the `git clone` operation.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f2d07c9c-85fc-485e-8057-5577efd9a26d",
+      "Name": "Template.Git.Source.User.Name",
+      "Label": "Source Git Username",
+      "HelpText": "Username of the credentials to use to log into git.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "597ae9a5-1ef4-4062-a435-2d9bb1fb16a2",
+      "Name": "Template.Git.Source.User.Password",
+      "Label": "Source Git User Password",
+      "HelpText": "Password for the git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "5c080713-029f-4f9b-8037-234c7dd579bc",
+      "Name": "Template.Git.Source.Path",
+      "Label": "Source Path",
+      "HelpText": "Relative path to the folder or items to copy.  This field can take wildcards, eg - `/MyPath/*`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "5fa438c9-2aa7-476f-ae79-bd77cdc22ccc",
+      "Name": "Template.Git.Tag",
+      "Label": "Tag",
+      "HelpText": "**(Optional)** Checkout the code for `SourcePath` from a specific tag.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6d3f8f4f-8e02-48bc-b473-817693aaf835",
+      "Name": "Template.Git.Destination.Repo.Url",
+      "Label": "Destination Git Repository URL",
+      "HelpText": "The destination repository to copy and push files to.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "59590dd8-6698-46f8-884c-78ad9f4b7c2e",
+      "Name": "Template.Git.Destination.User.Name",
+      "Label": "Destination Git Username",
+      "HelpText": "Username of the credentials to log into destination git repo.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d81e0a3d-5eb9-4dd3-a197-e5bf0c48cdf1",
+      "Name": "Template.Git.Destination.User.Password",
+      "Label": "Destination Git User Password",
+      "HelpText": "Password for the destination git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "f9a2141a-bcfa-4e53-862b-429b4f9892d9",
+      "Name": "Template.Git.Destination.Path",
+      "Label": "Destination Path",
+      "HelpText": "Relative path to the folder to copy items to.  This is the folder name only.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-09-12T15:32:07.199Z",
+    "OctopusVersion": "2023.4.2661",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/git-clone-copy-push-package.json
+++ b/step-templates/git-clone-copy-push-package.json
@@ -1,0 +1,100 @@
+{
+  "Id": "4d541683-4731-4f43-a342-5b9f6c915c4d",
+  "Name": "Git - Clone, copy, push from a Package",
+  "Description": "Clones a repository, copies files from the `Source Package` to the `Destination Path` then commits to the repository.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "88b1ab11-c878-4c7f-8227-610c3784311b",
+      "Name": "Template.Package.Reference",
+      "PackageId": null,
+      "FeedId": "Feeds-4139",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "Template.Package.Reference",
+        "Purpose": ""
+      }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Invoke-Git\n{\n\t# Define parameters\n    param (\n    \t$GitRepositoryUrl,\n        $GitFolder,\n        $GitUsername,\n        $GitPassword,\n        $GitCommand,\n        $AdditionalArguments\n    )\n    \n    # Get current work folder\n    $workDirectory = Get-Location\n\n\t# Check to see if GitFolder exists\n    if (![String]::IsNullOrWhitespace($GitFolder) -and (Test-Path -Path $GitFolder) -eq $false)\n    {\n    \t# Create the folder\n        New-Item -Path $GitFolder -ItemType \"Directory\" -Force | Out-Null\n        \n        # Set the location to the new folder\n        Set-Location -Path $GitFolder\n    }\n    \n    # Create arguments array\n    $gitArguments = @()\n    $gitArguments += $GitCommand\n    \n    # Check for url\n    if (![string]::IsNullOrWhitespace($GitRepositoryUrl))\n    {\n      # Convert url to URI object\n      $gitUri = [System.Uri]$GitRepositoryUrl\n      $gitUrl = \"{0}://{1}:{2}@{3}:{4}{5}\" -f $gitUri.Scheme, $GitUsername, $GitPassword, $gitUri.Host, $gitUri.Port, $gitUri.PathAndQuery\n      $gitArguments += $gitUrl\n\n      # Get the newly created folder name\n      $gitFolderName = $GitRepositoryUrl.SubString($GitRepositoryUrl.LastIndexOf(\"/\") + 1)\n      if ($gitFolderName.Contains(\".git\"))\n      {\n          $gitFolderName = $gitFolderName.SubString(0, $gitFolderName.IndexOf(\".\"))\n      }\n    }\n   \n    \n    # Check for additional arguments\n    if ($null -ne $AdditionalArguments)\n    {\n \t\t# Add the additional arguments\n        $gitArguments += $AdditionalArguments\n    }\n    \n    # Execute git command\n    $results = Execute-Command -commandPath \"git\" -commandArguments $gitArguments -workingDir $GitFolder\n    \n    Write-Host $results.stdout\n    Write-Host $results.stderr\n    \n    # Return the foldername\n    Set-Location -Path $workDirectory\n    \n    # Check to see if GitFolder is null\n    if ($null -ne $GitFolder)\n    {\n    \treturn Join-Path -Path $GitFolder -ChildPath $gitFolderName\n    }\n}\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\nFunction Copy-Files\n{\n\t# Define parameters\n    param (\n    \t$SourcePath,\n        $DestinationPath\n    )\n    \n    # Copy the items from source path to destination path\n    $copyArguments = @{}\n    $copyArguments.Add(\"Path\", $SourcePath)\n    $copyArguments.Add(\"Destination\", $DestinationPath)\n    \n    # Check to make sure destination exists\n    if ((Test-Path -Path $DestinationPath) -eq $false)\n    {\n    \t# Create the destination path\n        New-Item -Path $DestinationPath -ItemType \"Directory\" | Out-Null\n    }\n    \n    # Check for wildcard\n    if ($SourcePath.EndsWith(\"/*\") -or $SourcePath.EndsWith(\"\\*\"))\n    {\n\t\t# Add recurse argument\n\t\t$copyArguments.Add(\"Recurse\", $true)\n    }\n    \n    $copyArguments.Add(\"Force\", $true)\n    \n    # Copy files\n    Copy-Item @copyArguments\n}\n\nFunction Execute-Command\n{\n\tparam (\n    \t$commandPath,\n        $commandArguments,\n        $workingDir\n    )\n\n\t$gitExitCode = 0\n    $executionResults = $null\n\n  Try {\n    $pinfo = New-Object System.Diagnostics.ProcessStartInfo\n    $pinfo.FileName = $commandPath\n    $pinfo.WorkingDirectory = $workingDir\n    $pinfo.RedirectStandardError = $true\n    $pinfo.RedirectStandardOutput = $true\n    $pinfo.UseShellExecute = $false\n    $pinfo.Arguments = $commandArguments\n    $p = New-Object System.Diagnostics.Process\n    $p.StartInfo = $pinfo\n    $p.Start() | Out-Null\n    $executionResults = [pscustomobject]@{\n        stdout = $p.StandardOutput.ReadToEnd()\n        stderr = $p.StandardError.ReadToEnd()\n        ExitCode = $p.ExitCode\n    }\n    $p.WaitForExit()\n    $gitExitCode = [int]$p.ExitCode\n    \n    if ($gitExitCode -ge 2) \n    {\n\t\t# Fail the step\n        throw\n    }\n    \n    return $executionResults\n  }\n  Catch {\n    # Check exit code\n    Write-Error -Message \"$($executionResults.stderr)\" -ErrorId $gitExitCode\n    exit $gitExitCode\n  }\n\n}\n\nFunction Get-GitExecutable\n{\n\t# Define parameters\n    param (\n    \t$WorkingDirectory\n    )\n      \n    # Define variables\n    $gitExe = \"PortableGit-2.41.0.3-64-bit.7z.exe\"\n    $gitDownloadUrl = \"https://github.com/git-for-windows/git/releases/download/v2.41.0.windows.3/$gitExe\"\n    $gitDownloadArguments = @{}\n    $gitDownloadArguments.Add(\"Uri\", $gitDownloadUrl)\n    $gitDownloadArguments.Add(\"OutFile\", \"$WorkingDirectory/git/$gitExe\")\n    \n    # This makes downloading faster\n    $ProgressPreference = 'SilentlyContinue'\n    \n    # Check to see if git subfolder exists\n    if ((Test-Path -Path \"$WorkingDirectory/git\") -eq $false)\n    {\n    \t# Create subfolder\n        New-Item -Path \"$WorkingDirectory/git\"  -ItemType Directory\n    }\n    \n    # Check PowerShell version\n    if ($PSVersionTable.PSVersion.Major -lt 6)\n    {\n    \t# Use basic parsing is required\n        $gitDownloadArguments.Add(\"UseBasicParsing\", $true)\n    }\n    \n    # Download Git\n    Write-Host \"Downloading Git ...\"\n    Invoke-WebRequest @gitDownloadArguments\n    \n    # Extract Git\n    $gitExtractArguments = @()\n    $gitExtractArguments += \"-o\"\n    $gitExtractArguments += \"$WorkingDirectory\\git\"\n    $gitExtractArguments += \"-y\"\n    $gitExtractArguments += \"-bd\"\n\n    Write-Host \"Extracting Git download ...\"\n    & \"$WorkingDirectory\\git\\$gitExe\" $gitExtractArguments\n\n    # Wait until unzip action is complete\n    while ($null -ne (Get-Process | Where-Object {$_.ProcessName -eq ($gitExe.Substring(0, $gitExe.LastIndexOf(\".\")))}))\n    {\n        Start-Sleep 5\n    }\n    \n    # Add bin folder to path\n    $env:PATH = \"$WorkingDirectory\\git\\bin$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n    # Disable promopt for credential helper\n    Invoke-Git -GitCommand \"config\" -AdditionalArguments @(\"--system\", \"--unset\", \"credential.helper\")\n}\n\n# Get variables\n$gitUrl = $OctopusParameters['Template.Git.Repo.Url']\n$gitUser = $OctopusParameters['Template.Git.User.Name']\n$gitPassword = $OctopusParameters['Template.Git.User.Password']\n$sourceItems = $OctopusParameters['Octopus.Action.Package[Template.Package.Reference].ExtractedPath']\n$destinationPath = $OctopusParameters['Template.Git.Destination.Path']\n$gitSource = $null\n$gitDestination = $null\n\n# Check to see if it's Windows\nif ($IsWindows -and $OctopusParameters['Octopus.Workerpool.Name'] -eq \"Hosted Windows\")\n{\n\t# Dynamic worker don't have git, download portable version and add to path for execution\n    Write-Host \"Detected usage of Windows Dynamic Worker ...\"\n    Get-GitExecutable -WorkingDirectory $PWD\n}\n\n# Clone repository\n$folderName = Invoke-Git -GitRepositoryUrl $gitUrl -GitUsername $gitUser -GitPassword $gitPassword -GitCommand \"clone\" -GitFolder \"$($PWD)/default\"\n\n$gitSource = $sourceItems\n$gitDestination = $folderName\n\n# Copy files from source to destination\nCopy-Files -SourcePath \"$($gitSource)/*\" -DestinationPath \"$($gitDestination)$($destinationPath)\"\n\n# Set user\n$gitAuthorName = $OctopusParameters['Octopus.Deployment.CreatedBy.DisplayName']\n$gitAuthorEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n\n# Check to see if user is system\nif ([string]::IsNullOrWhitespace($gitAuthorEmail) -and $gitAuthorName -eq \"System\")\n{\n\t# Initiated by the Octopus server via automated process, put something in for the email address\n    $gitAuthorEmail = \"system@octopus.local\"\n}\n\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.name\", $gitAuthorName) -GitFolder \"$($folderName)\" | Out-Null\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.email\", $gitAuthorEmail) -GitFolder \"$($folderName)\" | Out-Null\n\n# Commit changes\nInvoke-Git -GitCommand \"add\" -GitFolder \"$folderName\" -AdditionalArguments @(\".\") | Out-Null\nInvoke-Git -GitCommand \"commit\" -GitFolder \"$folderName\" -AdditionalArguments @(\"-m\", \"`\"Commit from #{Octopus.Project.Name} release version #{Octopus.Release.Number}`\"\") | Out-Null\n\n# Push the changes back to git\nInvoke-Git -GitCommand \"push\" -GitFolder \"$folderName\" | Out-Null\n\n",
+    "Octopus.Action.EnabledFeatures": "Octopus.Features.JsonConfigurationVariables",
+    "Octopus.Action.Package.JsonConfigurationVariablesTargets": "#{Template.VariableReplacement.Paths}"
+  },
+  "Parameters": [
+    {
+      "Id": "674d5325-aa93-4779-a734-cee8e5690f17",
+      "Name": "Template.Git.Repo.Url",
+      "Label": "Git Repository URL",
+      "HelpText": "The URL used for the `git clone` operation.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f2d07c9c-85fc-485e-8057-5577efd9a26d",
+      "Name": "Template.Git.User.Name",
+      "Label": "Git Username",
+      "HelpText": "Username of the credentials to use to log into git.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "597ae9a5-1ef4-4062-a435-2d9bb1fb16a2",
+      "Name": "Template.Git.User.Password",
+      "Label": "Git User Password",
+      "HelpText": "Password for the git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "6d6b0662-22bd-4fbc-b0dd-15799b158abe",
+      "Name": "Template.Package.Reference",
+      "Label": "Package",
+      "HelpText": "Choose the package to copy files from into the Git repository.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "f9a2141a-bcfa-4e53-862b-429b4f9892d9",
+      "Name": "Template.Git.Destination.Path",
+      "Label": "Destination Path",
+      "HelpText": "Relative path to the folder to copy items to.  This is the folder name only.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e382b0db-0ea2-47bb-968b-2dae9a8b861d",
+      "Name": "Template.VariableReplacement.Paths",
+      "Label": "Structured Configuration Variables",
+      "HelpText": "Target files need to be new line seperated, relative to the package contents. Extended wildcard syntax is supported. E.g., appsettings.json, Config\\*.xml, **\\specific-folder\\*.yaml. Learn more about Structured Configuration Variables and view examples.",
+      "DefaultValue": " ",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-09-12T15:31:36.900Z",
+    "OctopusVersion": "2023.4.2661",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/git-clone-copy-push-package.json
+++ b/step-templates/git-clone-copy-push-package.json
@@ -95,6 +95,6 @@
     "OctopusVersion": "2023.4.2661",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "twerthi",
+  "Category": "git"
 }

--- a/step-templates/git-clone-copy-push-package.json
+++ b/step-templates/git-clone-copy-push-package.json
@@ -10,7 +10,7 @@
       "Id": "88b1ab11-c878-4c7f-8227-610c3784311b",
       "Name": "Template.Package.Reference",
       "PackageId": null,
-      "FeedId": "Feeds-4139",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",

--- a/step-templates/git-clone-copy-push.json
+++ b/step-templates/git-clone-copy-push.json
@@ -1,0 +1,84 @@
+{
+  "Id": "492dd5fe-26f5-4d12-800d-ad2cce008de6",
+  "Name": "Git - Clone, copy, push",
+  "Description": "Clones a repository, copies files from the `Source Path` to the `Destination Path` then commits to the repository.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Invoke-Git\n{\n\t# Define parameters\n    param (\n    \t$GitRepositoryUrl,\n        $GitFolder,\n        $GitUsername,\n        $GitPassword,\n        $GitCommand,\n        $AdditionalArguments\n    )\n    \n    # Get current work folder\n    $workDirectory = Get-Location\n\n\t# Check to see if GitFolder exists\n    if (![String]::IsNullOrWhitespace($GitFolder) -and (Test-Path -Path $GitFolder) -eq $false)\n    {\n    \t# Create the folder\n        New-Item -Path $GitFolder -ItemType \"Directory\" -Force | Out-Null\n        \n        # Set the location to the new folder\n        Set-Location -Path $GitFolder\n    }\n    \n    # Create arguments array\n    $gitArguments = @()\n    $gitArguments += $GitCommand\n    \n    # Check for url\n    if (![string]::IsNullOrWhitespace($GitRepositoryUrl))\n    {\n      # Convert url to URI object\n      $gitUri = [System.Uri]$GitRepositoryUrl\n      $gitUrl = \"{0}://{1}:{2}@{3}:{4}{5}\" -f $gitUri.Scheme, $GitUsername, $GitPassword, $gitUri.Host, $gitUri.Port, $gitUri.PathAndQuery\n      $gitArguments += $gitUrl\n\n      # Get the newly created folder name\n      $gitFolderName = $GitRepositoryUrl.SubString($GitRepositoryUrl.LastIndexOf(\"/\") + 1)\n      if ($gitFolderName.Contains(\".git\"))\n      {\n          $gitFolderName = $gitFolderName.SubString(0, $gitFolderName.IndexOf(\".\"))\n      }\n    }\n   \n    \n    # Check for additional arguments\n    if ($null -ne $AdditionalArguments)\n    {\n \t\t# Add the additional arguments\n        $gitArguments += $AdditionalArguments\n    }\n    \n    # Execute git command\n    $results = Execute-Command -commandPath \"git\" -commandArguments $gitArguments -workingDir $GitFolder\n    \n    Write-Host $results.stdout\n    Write-Host $results.stderr\n    \n    # Return the foldername\n    Set-Location -Path $workDirectory\n    \n    # Check to see if GitFolder is null\n    if ($null -ne $GitFolder)\n    {\n    \treturn Join-Path -Path $GitFolder -ChildPath $gitFolderName\n    }\n}\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\nFunction Copy-Files\n{\n\t# Define parameters\n    param (\n    \t$SourcePath,\n        $DestinationPath\n    )\n    \n    # Copy the items from source path to destination path\n    $copyArguments = @{}\n    $copyArguments.Add(\"Path\", $SourcePath)\n    $copyArguments.Add(\"Destination\", $DestinationPath)\n    \n    # Check to make sure destination exists\n    if ((Test-Path -Path $DestinationPath) -eq $false)\n    {\n    \t# Create the destination path\n        New-Item -Path $DestinationPath -ItemType \"Directory\" | Out-Null\n    }\n    \n    # Check for wildcard\n    if ($SourcePath.EndsWith(\"/*\") -or $SourcePath.EndsWith(\"\\*\"))\n    {\n\t\t# Add recurse argument\n\t\t$copyArguments.Add(\"Recurse\", $true)\n    }\n    \n    # Force overwrite\n    $copyArguments.Add(\"Force\", $true)\n    \n    # Copy files\n    Copy-Item @copyArguments\n}\n\nFunction Execute-Command\n{\n\tparam (\n    \t$commandPath,\n        $commandArguments,\n        $workingDir\n    )\n\n\t$gitExitCode = 0\n    $executionResults = $null\n\n  Try {\n    $pinfo = New-Object System.Diagnostics.ProcessStartInfo\n    $pinfo.FileName = $commandPath\n    $pinfo.WorkingDirectory = $workingDir\n    $pinfo.RedirectStandardError = $true\n    $pinfo.RedirectStandardOutput = $true\n    $pinfo.UseShellExecute = $false\n    $pinfo.Arguments = $commandArguments\n    $p = New-Object System.Diagnostics.Process\n    $p.StartInfo = $pinfo\n    $p.Start() | Out-Null\n    $executionResults = [pscustomobject]@{\n        stdout = $p.StandardOutput.ReadToEnd()\n        stderr = $p.StandardError.ReadToEnd()\n        ExitCode = $p.ExitCode\n    }\n    $p.WaitForExit()\n    $gitExitCode = [int]$p.ExitCode\n    \n    if ($gitExitCode -ge 2) \n    {\n\t\t# Fail the step\n        throw\n    }\n    \n    return $executionResults\n  }\n  Catch {\n    # Check exit code\n    Write-Error -Message \"$($executionResults.stderr)\" -ErrorId $gitExitCode\n    exit $gitExitCode\n  }\n\n}\n\nFunction Get-GitExecutable\n{\n\t# Define parameters\n    param (\n    \t$WorkingDirectory\n    )\n      \n    # Define variables\n    $gitExe = \"PortableGit-2.41.0.3-64-bit.7z.exe\"\n    $gitDownloadUrl = \"https://github.com/git-for-windows/git/releases/download/v2.41.0.windows.3/$gitExe\"\n    $gitDownloadArguments = @{}\n    $gitDownloadArguments.Add(\"Uri\", $gitDownloadUrl)\n    $gitDownloadArguments.Add(\"OutFile\", \"$WorkingDirectory/git/$gitExe\")\n    \n    # This makes downloading faster\n    $ProgressPreference = 'SilentlyContinue'\n    \n    # Check to see if git subfolder exists\n    if ((Test-Path -Path \"$WorkingDirectory/git\") -eq $false)\n    {\n    \t# Create subfolder\n        New-Item -Path \"$WorkingDirectory/git\"  -ItemType Directory\n    }\n    \n    # Check PowerShell version\n    if ($PSVersionTable.PSVersion.Major -lt 6)\n    {\n    \t# Use basic parsing is required\n        $gitDownloadArguments.Add(\"UseBasicParsing\", $true)\n    }\n    \n    # Download Git\n    Write-Host \"Downloading Git ...\"\n    Invoke-WebRequest @gitDownloadArguments\n    \n    # Extract Git\n    $gitExtractArguments = @()\n    $gitExtractArguments += \"-o\"\n    $gitExtractArguments += \"$WorkingDirectory\\git\"\n    $gitExtractArguments += \"-y\"\n    $gitExtractArguments += \"-bd\"\n\n    Write-Host \"Extracting Git download ...\"\n    & \"$WorkingDirectory\\git\\$gitExe\" $gitExtractArguments\n\n    # Wait until unzip action is complete\n    while ($null -ne (Get-Process | Where-Object {$_.ProcessName -eq ($gitExe.Substring(0, $gitExe.LastIndexOf(\".\")))}))\n    {\n        Start-Sleep 5\n    }\n    \n    # Add bin folder to path\n    $env:PATH = \"$WorkingDirectory\\git\\bin$([IO.Path]::PathSeparator)\" + $env:PATH\n    \n    # Disable promopt for credential helper\n    Invoke-Git -GitCommand \"config\" -AdditionalArguments @(\"--system\", \"--unset\", \"credential.helper\")\n}\n\n# Get variables\n$gitUrl = $OctopusParameters['Template.Git.Repo.Url']\n$gitUser = $OctopusParameters['Template.Git.User.Name']\n$gitPassword = $OctopusParameters['Template.Git.User.Password']\n$sourceItems = $OctopusParameters['Template.Git.Source.Path']\n$destinationPath = $OctopusParameters['Template.Git.Destination.Path']\n$gitTag = $OctopusParameters['Template.Git.Tag']\n$gitSource = $null\n$gitDestination = $null\n\n# Check to see if it's Windows\nif ($IsWindows -and $OctopusParameters['Octopus.Workerpool.Name'] -eq \"Hosted Windows\")\n{\n\t# Dynamic worker don't have git, download portable version and add to path for execution\n    Write-Host \"Detected usage of Windows Dynamic Worker ...\"\n    Get-GitExecutable -WorkingDirectory $PWD\n}\n\n# Clone repository\n$folderName = Invoke-Git -GitRepositoryUrl $gitUrl -GitUsername $gitUser -GitPassword $gitPassword -GitCommand \"clone\" -GitFolder \"$($PWD)/default\"\n\n# Check for tag\nif (![String]::IsNullOrWhitespace($gitTag))\n{\n\t$gitDestination = $folderName\n    $gitSource = Invoke-Git -GitRepositoryUrl $gitUrl -GitUsername $gitUser -GitPassword $gitPassword -GitCommand \"clone\" -GitFolder \"$($PWD)/tags/$gitTag\" -AdditionalArguments @(\"-b\", \"$gitTag\")\n}\nelse\n{\n\t$gitSource = $folderName\n    $gitDestination = $folderName\n}\n\n# Copy files from source to destination\nCopy-Files -SourcePath \"$($gitSource)$($sourceItems)\" -DestinationPath \"$($gitDestination)$($destinationPath)\"\n\n# Set user\n$gitAuthorName = $OctopusParameters['Octopus.Deployment.CreatedBy.DisplayName']\n$gitAuthorEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n\n# Check to see if user is system\nif ([string]::IsNullOrWhitespace($gitAuthorEmail) -and $gitAuthorName -eq \"System\")\n{\n\t# Initiated by the Octopus server via automated process, put something in for the email address\n    $gitAuthorEmail = \"system@octopus.local\"\n}\n\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.name\", $gitAuthorName) -GitFolder \"$($folderName)\" | Out-Null\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.email\", $gitAuthorEmail) -GitFolder \"$($folderName)\" | Out-Null\n\n# Commit changes\nInvoke-Git -GitCommand \"add\" -GitFolder \"$folderName\" -AdditionalArguments @(\".\") | Out-Null\nInvoke-Git -GitCommand \"commit\" -GitFolder \"$folderName\" -AdditionalArguments @(\"-m\", \"`\"Commit from #{Octopus.Project.Name} release version #{Octopus.Release.Number}`\"\") | Out-Null\n\n# Push the changes back to git\nInvoke-Git -GitCommand \"push\" -GitFolder \"$folderName\" | Out-Null\n\n"
+  },
+  "Parameters": [
+    {
+      "Id": "674d5325-aa93-4779-a734-cee8e5690f17",
+      "Name": "Template.Git.Repo.Url",
+      "Label": "Git Repository URL",
+      "HelpText": "The URL used for the `git clone` operation.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f2d07c9c-85fc-485e-8057-5577efd9a26d",
+      "Name": "Template.Git.User.Name",
+      "Label": "Git Username",
+      "HelpText": "Username of the credentials to use to log into git.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "597ae9a5-1ef4-4062-a435-2d9bb1fb16a2",
+      "Name": "Template.Git.User.Password",
+      "Label": "Git User Password",
+      "HelpText": "Password for the git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "5c080713-029f-4f9b-8037-234c7dd579bc",
+      "Name": "Template.Git.Source.Path",
+      "Label": "Source Path",
+      "HelpText": "Relative path to the folder or items to copy.  This field can take wildcards, eg - `/MyPath/*`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f9a2141a-bcfa-4e53-862b-429b4f9892d9",
+      "Name": "Template.Git.Destination.Path",
+      "Label": "Destination Path",
+      "HelpText": "Relative path to the folder to copy items to.  This is the folder name only.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "5fa438c9-2aa7-476f-ae79-bd77cdc22ccc",
+      "Name": "Template.Git.Tag",
+      "Label": "Tag",
+      "HelpText": "**(Optional)** Checkout the code for `SourcePath` from a specific tag.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-09-12T15:29:34.628Z",
+    "OctopusVersion": "2023.4.2661",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/git-clone-copy-push.json
+++ b/step-templates/git-clone-copy-push.json
@@ -79,6 +79,6 @@
     "OctopusVersion": "2023.4.2661",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "twerthi",
+  "Category": "git"
 }

--- a/step-templates/git-create-pull-request.json
+++ b/step-templates/git-create-pull-request.json
@@ -1,0 +1,85 @@
+{
+  "Id": "a24c6354-5612-4e2c-a0ff-9b5a329fc0e9",
+  "Name": "Git - Create Pull Request",
+  "Description": "Create a Pull or Merge Request for the repository",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\n# Fix ANSI Color on PWSH Core issues when displaying objects\nif ($PSEdition -eq \"Core\") {\n    $PSStyle.OutputRendering = \"PlainText\"\n}\n\n# Get variables\n$gitUrl = $OctopusParameters['Template.Git.Repo.Url']\n$gitUser = $OctopusParameters['Template.Git.User.Name']\n$gitPassword = $OctopusParameters['Template.Git.User.Password']\n$gitSourceBranch = $OctopusParameters['Template.Git.Source.Branch']\n$gitDestinationBranch = $OctopusParameters['Template.Git.Destination.Branch']\n$gitTech = $OctopusParameters['Template.Git.Repository.Technology']\n\n# Convert url into uri object\n$gitUri = [System.Uri]$gitUrl\n\nswitch ($gitTech)\n{\n    \"ado\"\n    {\n\n\t\t# Parse url\n        $gitOrganization = $gitUri.AbsolutePath\n        $gitOrganization = $gitOrganization.Substring(1)\n\t\t$gitOrganization = $gitOrganization.Substring(0, $gitOrganization.IndexOf(\"/\"))\n        \n        # Encode personal access token\n        $encodedPAT = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(\"`:$gitPassword\"))\n        \n        # Construct Headers\n        $header = @{\n        \tAuthorization = \"Basic $encodedPAT\"\n        }\n                \n        $gitProject = $gitUri.AbsolutePath.Replace($gitOrganization, \"\").Replace(\"//\", \"\")\n        $gitProject = $gitProject.Substring(0, $gitProject.IndexOf(\"/\"))\n        \n\t\t# Create pull request\n        $jsonBody = @{\n        \tsourceRefName = \"refs/heads/\" + $gitSourceBranch\n            targetRefName = \"refs/heads/\" + $gitDestinationBranch\n            title = \"PR from Octopus Deploy\"\n            description = \"PR from #{Octopus.Project.Name} release version #{Octopus.Release.Number}\"\n        }\n        \n        # Construct API call\n        $adoApiUrl = \"{0}://{1}:{2}/{3}/{4}/_apis/git/repositories/{4}/pullrequests\" -f $gitUri.Scheme, $gitUri.Host, $gitUri.Port, $gitOrganization, $gitProject\n        Invoke-RestMethod -Method Post -Uri ($adoApiUrl + \"?api-version=7.0\") -Body ($jsonBody | ConvertTo-Json -Depth 10) -Headers $header -ContentType \"application/json\"\n    }\n    \"bitbucket\"\n    {\n\t\t# Parse url\n        $gitOrganization = $gitUri.AbsolutePath\n        $gitOrganization = $gitOrganization.Substring(1)\n\t\t$gitOrganization = $gitOrganization.Substring(0, $gitOrganization.IndexOf(\"/\"))\n        $gitProject = $gitUri.AbsolutePath.Replace($gitOrganization, \"\").Replace(\"//\", \"\")\n        \n        # Check to see if Repo Name ends with .git\n        if ($gitProject.EndsWith(\".git\"))\n        {\n        \t# Strip off the last part\n            $gitProject = $gitProject.Replace(\".git\", \"\")\n        }\n\n        # Construct Headers\n        $header = @{\n        \tAuthorization = \"Bearer $gitPassword\"\n        }\n        \n        # Construct API url\n        $bitbucketApiUrl = \"{0}://api.{1}:{2}/2.0/repositories/{3}/{4}/pullrequests\" -f $gitUri.Scheme, $gitUri.Host, $gitUri.Port, $gitOrganization, $gitProject\n        \n\t\t# Construct json body\n        $jsonBody = @{\n        \ttitle = \"PR from Octopus Deploy\"\n            source = @{\n            \tbranch = @{\n                \tname = $gitSourceBranch\n                }\n            }\n            destination = @{\n            \tbranch = @{\n                \tname = $gitDestinationBranch\n                }\n            }\n        }\n        \n        # Create PR\n        Invoke-RestMethod -Method Post -Uri $bitbucketApiUrl -Headers $header -Body ($jsonBody | ConvertTo-Json -Depth 10) -ContentType \"application/json\"\n    }\n    \"github\"\n    {\n        # Parse URL\n        $gitRepoOwner = $gitUri.AbsolutePath.Substring(1, $gitUri.AbsolutePath.LastIndexOf(\"/\") - 1)\n        $gitRepoName = $gitUri.AbsolutePath.Substring($gitUri.AbsolutePath.LastIndexOf(\"/\") + 1 )\n        \n        # Check to see if Repo Name ends with .git\n        if ($gitRepoName.EndsWith(\".git\"))\n        {\n        \t# Strip off the last part\n            $gitRepoName = $gitRepoName.Replace(\".git\", \"\")\n        }\n        \n        # Construct API endpoint\n        $githubApiUrl = \"{0}://api.{1}:{2}/repos/{3}/{4}/pulls\" -f $gitUri.Scheme, $gitUri.Host, $gitUri.Port, $gitRepoOwner, $gitRepoName\n        \n        # Construct Headers\n        $header = @{\n        \tAuthorization = \"Bearer $gitPassword\"\n            Accept = \"application/vnd.github+json\"\n            \"X-Github-Api-Version\" = \"2022-11-28\"\n        }\n        \n        # Construct body\n        $jsonBody = @{\n        \ttitle = \"PR from Octopus Deploy\"\n            body = \"PR from #{Octopus.Project.Name} release version #{Octopus.Release.Number}\"\n            head = $gitSourceBranch\n            base = $gitDestinationBranch\n        }\n        \n        # Create the pull request\n        Invoke-RestMethod -Method Post -Uri $gitHubApiUrl -Headers $header -Body ($jsonBody | ConvertTo-Json -Depth 10)\n    }\n    \"gitlab\"\n    {\n\t\t# Get project name\n        $gitlabProjectName = $gitUrl.SubString($gitUrl.LastIndexOf(\"/\") + 1)\n        \n        # Parse uri\n        $gitlabApiUrl = \"{0}://{1}:{2}/api/v4/users/{3}/projects\" -f $gitUri.Scheme, $gitUri.Host, $gitUri.Port, $gitUser\n        \n        # Check to see if it ends in .git\n        if ($gitlabProjectName.EndsWith(\".git\"))\n        {\n        \t# Strip that part off\n            $gitlabProjectName = $gitlabProjectName.Replace(\".git\", \"\")\n        }\n        \n        # Create header\n        $header = @{ \"PRIVATE-TOKEN\" = $gitPassword }\n        \n        # Get the project\n        $gitlabProject = (Invoke-RestMethod -Method Get -Uri $gitlabApiUrl -Headers $header) | Where-Object {$_.Name -eq $gitlabProjectName}\n        \n        # Create the merge request\n         $gitlabApiUrl = \"{0}://{1}:{2}/api/v4/projects/{3}/merge_requests?source_branch={4}&target_branch={5}&target_project_id={3}&title={6}\" -f $gitUri.Scheme, $gitUri.Host, $gitUri.Port, $gitlabProject.id, $gitSourceBranch, $gitDestinationBranch, \"PR from #{Octopus.Project.Name} release version #{Octopus.Release.Number}\"\n        Invoke-RestMethod -Method Post -Uri $gitlabApiUrl -Headers $header\n    }\n}\n\n<#\n# Set user\n$gitAuthorName = $OctopusParameters['Octopus.Deployment.CreatedBy.DisplayName']\n$gitAuthorEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n\n# Check to see if user is system\nif ([string]::IsNullOrWhitespace($gitAuthorEmail) -and $gitAuthorName -eq \"System\")\n{\n\t# Initiated by the Octopus server via automated process, put something in for the email address\n    $gitAuthorEmail = \"system@octopus.local\"\n}\n\n# Configure user information\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.name\", $gitAuthorName) #-GitFolder \"$($PWD)/$($folderName)\"\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.email\", $gitAuthorEmail) #-GitFolder \"$($PWD)/$($folderName)\"\n\n\n# Push the new tag\nInvoke-Git -Gitcommand \"request-pull\" -AdditionalArguments @(\"$gitSourceBranch\", $gitUrl, \"$gitDestinationBranch\") -GitFolder \"$($PWD)/$($folderName)\"    \n#>"
+  },
+  "Parameters": [
+    {
+      "Id": "674d5325-aa93-4779-a734-cee8e5690f17",
+      "Name": "Template.Git.Repo.Url",
+      "Label": "Git Repository URL",
+      "HelpText": "The URL used for the `git clone` operation.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f2d07c9c-85fc-485e-8057-5577efd9a26d",
+      "Name": "Template.Git.User.Name",
+      "Label": "Git Username",
+      "HelpText": "Username of the credentials to use to log into git.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "597ae9a5-1ef4-4062-a435-2d9bb1fb16a2",
+      "Name": "Template.Git.User.Password",
+      "Label": "Git User Password",
+      "HelpText": "Password for the git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "7cfa6ba5-76c6-4b15-a30c-593e2cd8f914",
+      "Name": "Template.Git.Source.Branch",
+      "Label": "Source Branch",
+      "HelpText": "The source branch name to compare the repository with.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2b0ee0d3-8542-4db2-87fc-52ee41e63cc6",
+      "Name": "Template.Git.Destination.Branch",
+      "Label": "Destination Branch",
+      "HelpText": "The destination branch to create the pull/merge request against.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "74d8fc6d-2a4c-49ad-b7f8-248dcf44fc0f",
+      "Name": "Template.Git.Repository.Technology",
+      "Label": "Source Control Technology",
+      "HelpText": "Select which source control technology to create the request on.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "ado|Azure DevOps\nbitbucket|BitBucket\ngithub|GitHub\ngitlab|GitLab"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-09-12T15:32:53.416Z",
+    "OctopusVersion": "2023.4.2661",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/git-create-pull-request.json
+++ b/step-templates/git-create-pull-request.json
@@ -80,6 +80,6 @@
     "OctopusVersion": "2023.4.2661",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "twerthi",
+  "Category": "git"
 }

--- a/step-templates/git-tag-repository.json
+++ b/step-templates/git-tag-repository.json
@@ -70,6 +70,6 @@
     "OctopusVersion": "2023.4.2661",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "twerthi",
+  "Category": "git"
 }

--- a/step-templates/git-tag-repository.json
+++ b/step-templates/git-tag-repository.json
@@ -1,0 +1,75 @@
+{
+  "Id": "dd76dee1-f5b1-4974-a5ae-bde643cf67af",
+  "Name": "Git - Tag repository",
+  "Description": "Tags a git repository with the specified tag",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "Function Invoke-Git\n{\n\t# Define parameters\n    param (\n    \t$GitRepositoryUrl,\n        $GitFolder,\n        $GitUsername,\n        $GitPassword,\n        $GitCommand,\n        $AdditionalArguments,\n        $SupressOutput = $false\n    )\n    \n    # Get current work folder\n    $workDirectory = Get-Location\n    \n    # Create arguments array\n    $gitArguments = @()\n    $gitArguments += $GitCommand\n    \n    # Check for url\n    if (![string]::IsNullOrWhitespace($GitRepositoryUrl))\n    {\n      # Convert url to URI object\n      $gitUri = [System.Uri]$GitRepositoryUrl\n      $gitUrl = \"{0}://{1}:{2}@{3}:{4}{5}\" -f $gitUri.Scheme, $GitUsername, $GitPassword, $gitUri.Host, $gitUri.Port, $gitUri.PathAndQuery\n      $gitArguments += $gitUrl\n\n      # Get the newly created folder name\n      $gitFolderName = $GitRepositoryUrl.SubString($GitRepositoryUrl.LastIndexOf(\"/\") + 1)\n      if ($gitFolderName.Contains(\".git\"))\n      {\n          $gitFolderName = $gitFolderName.SubString(0, $gitFolderName.IndexOf(\".\"))\n      }\n    }\n   \n    \n    # Check for additional arguments\n    if ($null -ne $AdditionalArguments)\n    {\n \t\t# Add the additional arguments\n        $gitArguments += $AdditionalArguments\n    }\n    \n    # Execute git command\n    $results = Execute-Command \"git\" $gitArguments $GitFolder\n    \n    # Check to see if output is supposed to be suppressed\n    if ($SupressOutput -ne $true)\n    {\n    \tWrite-Host $results.stdout\n    }\n\n\t# Always display error messages\n    Write-Host $results.stderr\n    \n    # Store results into file\n    Add-Content -Path \"$PWD/$($GitCommand).txt\" -Value $results.stdout\n    \n    # Return the foldername\n   \treturn $gitFolderName\n}\n\n# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\nFunction Execute-Command\n{\n\tparam (\n    \t$commandPath,\n        $commandArguments,\n        $workingDir\n    )\n\n\t$gitExitCode = 0\n    $executionResults = $null\n\n  Try {\n    $pinfo = New-Object System.Diagnostics.ProcessStartInfo\n    $pinfo.FileName = $commandPath\n    $pinfo.WorkingDirectory = $workingDir\n    $pinfo.RedirectStandardError = $true\n    $pinfo.RedirectStandardOutput = $true\n    $pinfo.UseShellExecute = $false\n    $pinfo.Arguments = $commandArguments\n    $p = New-Object System.Diagnostics.Process\n    $p.StartInfo = $pinfo\n    $p.Start() | Out-Null\n    $executionResults = [pscustomobject]@{\n        stdout = $p.StandardOutput.ReadToEnd()\n        stderr = $p.StandardError.ReadToEnd()\n        ExitCode = $p.ExitCode\n    }\n    $p.WaitForExit()\n    $gitExitCode = [int]$p.ExitCode\n    \n    if ($gitExitCode -ge 2) \n    {\n\t\t# Fail the step\n        throw\n    }\n    \n    return $executionResults\n  }\n  Catch {\n    # Check exit code\n    Write-Error -Message \"$($executionResults.stderr)\" -ErrorId $gitExitCode\n    exit $gitExitCode\n  }\n\n}\n\n\n# Get variables\n$gitUrl = $OctopusParameters['Template.Git.Repo.Url']\n$gitUser = $OctopusParameters['Template.Git.User.Name']\n$gitPassword = $OctopusParameters['Template.Git.User.Password']\n$gitTag = $OctopusParameters['Template.Git.Tag']\n$gitAction = $OctopusParameters['Template.Git.Action']\n\n# Clone repository\n$folderName = Invoke-Git -GitRepositoryUrl $gitUrl -GitUsername $gitUser -GitPassword $gitPassword -GitCommand \"clone\"\n\n# Set user\n$gitAuthorName = $OctopusParameters['Octopus.Deployment.CreatedBy.DisplayName']\n$gitAuthorEmail = $OctopusParameters['Octopus.Deployment.CreatedBy.EmailAddress']\n\n# Check to see if user is system\nif ([string]::IsNullOrWhitespace($gitAuthorEmail) -and $gitAuthorName -eq \"System\")\n{\n\t# Initiated by the Octopus server via automated process, put something in for the email address\n    $gitAuthorEmail = \"system@octopus.local\"\n}\n\n# Configure user information\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.name\", $gitAuthorName) -GitFolder \"$($PWD)/$($folderName)\"\nInvoke-Git -GitCommand \"config\" -AdditionalArguments @(\"user.email\", $gitAuthorEmail) -GitFolder \"$($PWD)/$($folderName)\"\n\n# Record existing tags, if any\nInvoke-Git -GitCommand \"tag\" -GitFolder \"$($PWD)/$($folderName)\" -SupressOutput $true\n\n# Check the file\n$existingTags = Get-Content \"$PWD/tag.txt\"\n\nif (![String]::IsNullOrWhitespace($existingTags))\n{\n\t# Parse\n    $existingTags = $existingTags.Split(\"`n\",[System.StringSplitOptions]::RemoveEmptyEntries)\n    \n    # Check to see if tag already exists\n    if ($null -ne ($existingTags | Where-Object {$_ -eq $gitTag}))\n    {\n\t\t# Check the selected action\n        switch ($gitAction)\n        {\n        \t\"delete\"\n            {\n                # Delete the tag locally\n                Write-Host \"Deleting tag $gitTag from cloned repository ...\"\n                Invoke-Git -GitCommand \"tag\" -AdditionalArguments @(\"--delete\", \"$gitTag\") -GitFolder \"$($PWD)/$($folderName)\"\n                \n                # Delete the tag on remote\n                Write-Host \"Deleting tag from remote repository ...\"\n                Invoke-Git -GitCommand \"push\" -AdditionalArguments @(\":refs/tags/$gitTag\") -GitFolder \"$($PWD)/$($folderName)\" -GitRepositoryUrl $gitUrl -GitUsername $gitUser -GitPassword $gitPassword\n                \n                break\n            }\n            \"ignore\"\n            {\n            \t# Ignore and continue\n                Write-Host \"$gitTag already exists on $gitUrl.  Selected action is Ignore, exiting.\"\n                \n                exit 0\n            }\n            \"fail\"\n            {\n\t\t\t\t# Error, tag already exists\n        \t\tWrite-Error \"Error: $gitTag already exists on $gitUrl!\"\n            }\n        }\n    }\n}\n\n# Tag the repo\nInvoke-Git -GitCommand \"tag\" -AdditionalArguments @(\"-a\", $gitTag, \"-m\", \"`\"Tag from #{Octopus.Project.Name} release version #{Octopus.Release.Number}`\"\") -GitFolder \"$($PWD)/$($folderName)\"\n\n# Push the new tag\nInvoke-Git -Gitcommand \"push\" -AdditionalArguments @(\"--tags\") -GitFolder \"$($PWD)/$($folderName)\""
+  },
+  "Parameters": [
+    {
+      "Id": "674d5325-aa93-4779-a734-cee8e5690f17",
+      "Name": "Template.Git.Repo.Url",
+      "Label": "Git Repository URL",
+      "HelpText": "The URL used for the `git clone` operation.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f2d07c9c-85fc-485e-8057-5577efd9a26d",
+      "Name": "Template.Git.User.Name",
+      "Label": "Git Username",
+      "HelpText": "Username of the credentials to use to log into git.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "597ae9a5-1ef4-4062-a435-2d9bb1fb16a2",
+      "Name": "Template.Git.User.Password",
+      "Label": "Git User Password",
+      "HelpText": "Password for the git credential.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "7cfa6ba5-76c6-4b15-a30c-593e2cd8f914",
+      "Name": "Template.Git.Tag",
+      "Label": "Tag",
+      "HelpText": "The tag name to tag the repository with.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b7ae407f-f926-4478-af72-74397025e4b6",
+      "Name": "Template.Git.Action",
+      "Label": "Action if tag already exists",
+      "HelpText": "Select the action if the tag already exsists.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "delete|Delete and recreate\nfail|Fail\nignore|Ignore"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-09-12T15:33:15.238Z",
+    "OctopusVersion": "2023.4.2661",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}


### PR DESCRIPTION


_Before submitting your PR, please delete everything above the line below._

---

# Background

These are new templates to help our Enterprise story.

# Results

Adding the ability to do different Git activities from within Octopus.

## Before

They didn't exist.

## After

They do now!

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes the fact they didn't previously exist :)
