### PR TITLE
Added workflows for slack notifications

### DIFF
--- a/.github/workflows/issues-slack.yaml
+++ b/.github/workflows/issues-slack.yaml
@@ -1,0 +1,21 @@
+name: Slack Issue Notification
+'on':
+  issues:
+    types: [opened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SE_TOOL_REQUESTS_WEBHOOK }}
+          SLACK_CHANNEL: se-tool-requests
+          SLACK_COLOR: good
+          SLACK_MESSAGE: |
+            ${{ github.event.issue.title }}
+            ${{ github.event.issue.url }}
+          SLACK_TITLE: 'Community Step Template Library Issue Created'
+          SLACK_USERNAME: 'Slack Notification Workflow'
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: true

--- a/.github/workflows/pr-slack.yaml
+++ b/.github/workflows/pr-slack.yaml
@@ -1,0 +1,21 @@
+name: Slack Pull request Notification
+'on':
+  pull_request_target:
+    types: [opened]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SE_TOOL_REQUESTS_WEBHOOK }}
+          SLACK_CHANNEL: se-tool-requests
+          SLACK_COLOR: good
+          SLACK_MESSAGE: |
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.url }}
+          SLACK_TITLE: 'Community Step Template Library PR Created'
+          SLACK_USERNAME: 'Slack Notification Workflow'
+          SLACK_FOOTER: ''
+          MSG_MINIMAL: true


### PR DESCRIPTION
This PR adds notifications to the solutions engineering slack channel when an issue is opened or a PR is raised.

# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
