### PR TITLE
Octoterra Terraform Module Deployment Step

### DIFF
--- a/step-templates/octopus-apply-octoterra-module-s3.json
+++ b/step-templates/octopus-apply-octoterra-module-s3.json
@@ -1,0 +1,163 @@
+{
+  "Id": "2e989e4e-c22f-4a55-bff6-399a99e07e5f",
+  "Name": "Octopus - Deploy Octoterra Project (S3 Backend)",
+  "Description": "This step exposes the field required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "ActionType": "Octopus.TerraformApply",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "093b1515-15a9-4446-8dc2-6297018a77e7",
+      "Name": "",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "SelectionMode": "deferred",
+        "PackageParameterName": "OctoterraApply.Terraform.Package.Id"
+      }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "True",
+    "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
+    "Octopus.Action.Terraform.GoogleCloudAccount": "False",
+    "Octopus.Action.Terraform.AzureAccount": "False",
+    "Octopus.Action.Terraform.ManagedAccount": "AWS",
+    "Octopus.Action.Terraform.AllowPluginDownloads": "True",
+    "Octopus.Action.Script.ScriptSource": "Package",
+    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "True",
+    "Octopus.Action.Terraform.PlanJsonOutput": "False",
+    "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
+    "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"bucket=#{OctoterraApply.AWS.S3.BucketName}\" -backend-config=\"region=#{OctoterraApply.AWS.S3.BucketRegion}\" -backend-config=\"key=#{OctoterraApply.AWS.S3.BucketKey}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} -var=octopus_space_id=#{OctoterraApply.Octopus.SpaceID} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Package.DownloadOnTentacle": "False",
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.AwsAccount.Variable": "OctoterraApply.AWS.Account",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.Aws.Region": "#{OctoterraApply.AWS.S3.BucketRegion}",
+    "Octopus.Action.Terraform.TemplateDirectory": "space_population",
+    "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf"
+  },
+  "Parameters": [
+    {
+      "Id": "27254625-8cfd-4918-b16b-68ac26a25d37",
+      "Name": "OctoterraApply.Terraform.Workspace.Name",
+      "Label": "Terraform Workspace",
+      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space name: `#{Octopus.Space.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`",
+      "DefaultValue": "#{Octopus.Space.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6c8ac9fd-24e2-4358-a582-0b3104857c56",
+      "Name": "OctoterraApply.Terraform.Package.Id",
+      "Label": "Terraform Module Package",
+      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_population` directory.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "2c9f6df2-0097-4a40-b649-314eaf3f2fcc",
+      "Name": "OctoterraApply.Octopus.ServerUrl",
+      "Label": "Octopus Server URL",
+      "HelpText": "The Octopus server URL.",
+      "DefaultValue": "#{Octopus.Web.ServerUri}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d48bd55c-2b47-41c7-bc4d-9b308a87c0bc",
+      "Name": "OctoterraApply.Octopus.ApiKey",
+      "Label": "Octopus API key",
+      "HelpText": "The Octopus API key. See the [documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating an API key.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "72953e6d-1a45-4ee1-9878-620dd3a01655",
+      "Name": "OctoterraApply.Octopus.SpaceID",
+      "Label": "Octopus Space ID",
+      "HelpText": "The Space ID to deploy the Terraform module into. The [Octopus - Lookup Space ID](https://library.octopus.com/step-templates/324f747e-e2cd-439d-a660-774baf4991f2/actiontemplate-octopus-lookup-space-id) step can be used to convert a space name to an ID.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8e6960a1-5933-4324-88a8-7a8fc144d272",
+      "Name": "OctoterraApply.AWS.Account",
+      "Label": "AWS Account Variable",
+      "HelpText": "The AWS account variable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    },
+    {
+      "Id": "cf0a0548-fe36-42d2-a008-ec6020a1062d",
+      "Name": "OctoterraApply.AWS.S3.BucketName",
+      "Label": "AWS S3 Bucket Name",
+      "HelpText": "The name of the S3 bucket used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "28c46172-2154-461e-aabd-1c1c30591297",
+      "Name": "OctoterraApply.AWS.S3.BucketRegion",
+      "Label": "AWS S3 Bucket Region",
+      "HelpText": "The AWS region hosting the S3 bucket. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b36ce7f6-deb9-4252-a2c9-790b2d10ddaf",
+      "Name": "OctoterraApply.AWS.S3.BucketKey",
+      "Label": "AWS S3 Bucket Key",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project: `#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "DefaultValue": "#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "74bccb6c-0959-4183-ad25-d83d9a6356b3",
+      "Name": "OctoterraApply.Terraform.AdditionalApplyParams",
+      "Label": "Terraform Additional Apply Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform apply` command. This field can be left blank. See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/apply) for details on the `apply` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8ff57a5d-9a31-4360-9c1f-06ccf2fb1d21",
+      "Name": "OctoterraApply.Terraform.AdditionalInitParams",
+      "Label": "Terraform Additional Init Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform init` command. This field can be left blank.  See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/init) for details on the `init` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.TerraformApply",
+  "$Meta": {
+    "ExportedAt": "2023-10-11T09:06:57.132Z",
+    "OctopusVersion": "2023.4.5160",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
+}

--- a/step-templates/octopus-apply-octoterra-module-s3.json
+++ b/step-templates/octopus-apply-octoterra-module-s3.json
@@ -1,7 +1,7 @@
 {
   "Id": "14d51af4-1c3d-4d41-9044-4304111d0cd8",
   "Name": "Octopus - Deploy Octoterra Project (S3 Backend)",
-  "Description": "This step exposes the field required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
   "Version": 1,
   "CommunityActionTemplateId": null,

--- a/step-templates/octopus-apply-octoterra-module-s3.json
+++ b/step-templates/octopus-apply-octoterra-module-s3.json
@@ -1,5 +1,5 @@
 {
-  "Id": "2e989e4e-c22f-4a55-bff6-399a99e07e5f",
+  "Id": "14d51af4-1c3d-4d41-9044-4304111d0cd8",
   "Name": "Octopus - Deploy Octoterra Project (S3 Backend)",
   "Description": "This step exposes the field required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
@@ -26,7 +26,7 @@
     "Octopus.Action.Terraform.ManagedAccount": "AWS",
     "Octopus.Action.Terraform.AllowPluginDownloads": "True",
     "Octopus.Action.Script.ScriptSource": "Package",
-    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "True",
+    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "False",
     "Octopus.Action.Terraform.PlanJsonOutput": "False",
     "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
     "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"bucket=#{OctoterraApply.AWS.S3.BucketName}\" -backend-config=\"region=#{OctoterraApply.AWS.S3.BucketRegion}\" -backend-config=\"key=#{OctoterraApply.AWS.S3.BucketKey}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
@@ -154,7 +154,7 @@
   ],
   "StepPackageId": "Octopus.TerraformApply",
   "$Meta": {
-    "ExportedAt": "2023-10-11T09:06:57.132Z",
+    "ExportedAt": "2023-10-11T09:11:08.244Z",
     "OctopusVersion": "2023.4.5160",
     "Type": "ActionTemplate"
   },


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

This PR is a complement to the [Octopus - Serialize Project to Terraform](https://library.octopus.com/step-templates/e9526501-09d5-490f-ac3f-5079735fe041/actiontemplate-octopus-serialize-project-to-terraform) step and allows the Terraform module created by octoterra to be deployed. This step configures an S3 Terraform backend.

# Results

![image](https://github.com/OctopusDeploy/Library/assets/160104/c09d3ff9-2db5-4e31-b6ef-222bac2f9102)


# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
