### PR TITLE
Prevent concurrent deployments

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -192,7 +192,7 @@ step "confirm-changes-on-staging-slot" {
     action "confirm-changes-on-staging-slot-1" {
         action_type = "Octopus.Manual"
         properties = {
-            Octopus.Action.Manual.BlockConcurrentDeployments = "False"
+            Octopus.Action.Manual.BlockConcurrentDeployments = "True"
             Octopus.Action.Manual.Instructions = <<-EOT
                 Confirm the changes in this release on [Staging](https://library-prod-webapp-staging.azurewebsites.net/)
                 


### PR DESCRIPTION
Update process such that any pending manual intervention of the Slot Swap must be resolved before a new deployment can be started.

This is to prevent future occurrences of [a recent outage](https://status.octopus.com/incidents/f13s3jdp0znr) where conflicting deployments were run and took down `library.octopus.com`.