### PR TITLE
Added a step to create a github repo secret

### DIFF
--- a/step-templates/github-create-secret.json
+++ b/step-templates/github-create-secret.json
@@ -1,0 +1,75 @@
+{
+  "Id": "74cc43c5-be61-470a-be38-ae44fc82c945",
+  "Name": "GitHub - Create Repo Secret",
+  "Description": "This step creates a secret in a GitHub repo.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Python",
+    "Octopus.Action.Script.ScriptBody": "# https://gist.github.com/comdotlinux/9a53bb00767a16d6646464c4b8249094\n\n# This script forks a GitHub repo. It creates a token from a GitHub App installation to avoid\n# having to use a regular user account.\nimport subprocess\nimport sys\n\n# Install our own dependencies\nsubprocess.check_call([sys.executable, '-m', 'pip', 'install', 'jwt', '--disable-pip-version-check'])\nsubprocess.check_call([sys.executable, '-m', 'pip', 'install', 'pynacl', '--disable-pip-version-check'])\n\nimport requests\nimport json\nimport subprocess\nimport sys\nimport os\nimport urllib.request\nimport base64\nimport re\nimport jwt\nimport time\nimport argparse\nimport urllib3\nfrom base64 import b64encode\nfrom typing import TypedDict\nfrom nacl import public, encoding\n\n# Disable insecure http request warnings\nurllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)\n\n# If this script is not being run as part of an Octopus step, setting variables is a noop\nif 'set_octopusvariable' not in globals():\n    def set_octopusvariable(variable, value):\n        pass\n\n# If this script is not being run as part of an Octopus step, return variables from environment variables.\n# Periods are replaced with underscores, and the variable name is converted to uppercase\nif \"get_octopusvariable\" not in globals():\n    def get_octopusvariable(variable):\n        return os.environ[re.sub('\\\\.', '_', variable.upper())]\n\n# If this script is not being run as part of an Octopus step, print directly to std out.\nif 'printverbose' not in globals():\n    def printverbose(msg):\n        print(msg)\n\n\ndef printverbose_noansi(output):\n    \"\"\"\n    Strip ANSI color codes and print the output as verbose\n    :param output: The output to print\n    \"\"\"\n    output_no_ansi = re.sub(r'\\x1b\\[[0-9;]*m', '', output)\n    printverbose(output_no_ansi)\n\n\ndef get_octopusvariable_quiet(variable):\n    \"\"\"\n    Gets an octopus variable, or an empty string if it does not exist.\n    :param variable: The variable name\n    :return: The variable value, or an empty string if the variable does not exist\n    \"\"\"\n    try:\n        return get_octopusvariable(variable)\n    except:\n        return ''\n\n\ndef execute(args, cwd=None, env=None, print_args=None, print_output=printverbose_noansi, raise_on_non_zero=False,\n            append_to_path=None):\n    \"\"\"\n        The execute method provides the ability to execute external processes while capturing and returning the\n        output to std err and std out and exit code.\n    \"\"\"\n\n    my_env = os.environ.copy() if env is None else env\n\n    if append_to_path is not None:\n        my_env[\"PATH\"] = append_to_path + os.pathsep + my_env['PATH']\n\n    process = subprocess.Popen(args,\n                               stdout=subprocess.PIPE,\n                               stderr=subprocess.PIPE,\n                               stdin=open(os.devnull),\n                               text=True,\n                               cwd=cwd,\n                               env=my_env)\n    stdout, stderr = process.communicate()\n    retcode = process.returncode\n\n    if not retcode == 0 and raise_on_non_zero:\n        raise Exception('command returned exit code ' + retcode)\n\n    if print_args is not None:\n        print_output(' '.join(args))\n\n    if print_output is not None:\n        print_output(stdout)\n        print_output(stderr)\n\n    return stdout, stderr, retcode\n\n\ndef init_argparse():\n    parser = argparse.ArgumentParser(\n        usage='%(prog)s [OPTION]',\n        description='Fork a GitHub repo'\n    )\n\n    parser.add_argument('--secret-name', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.GitHub.Secret.Name') or get_octopusvariable_quiet(\n                            'GitHub.Secret.Name'))\n    parser.add_argument('--secret-value', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.GitHub.Secret.Value') or get_octopusvariable_quiet(\n                            'GitHub.Secret.Value'))\n\n    parser.add_argument('--repo', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.Git.Url.Repo') or get_octopusvariable_quiet(\n                            'Git.Url.Repo') or get_octopusvariable_quiet('Octopus.Project.Name'))\n    parser.add_argument('--git-organization', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.Git.Url.Organization') or get_octopusvariable_quiet(\n                            'Git.Url.Organization'))\n    parser.add_argument('--github-app-id', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.GitHub.App.Id') or get_octopusvariable_quiet('GitHub.App.Id'))\n    parser.add_argument('--github-app-installation-id', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.GitHub.App.InstallationId') or get_octopusvariable_quiet(\n                            'GitHub.App.InstallationId'))\n    parser.add_argument('--github-app-private-key', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.GitHub.App.PrivateKey') or get_octopusvariable_quiet(\n                            'GitHub.App.PrivateKey'))\n    parser.add_argument('--git-password', action='store',\n                        default=get_octopusvariable_quiet(\n                            'CreateGitHubSecret.Git.Credentials.Password') or get_octopusvariable_quiet(\n                            'Git.Credentials.Password'),\n                        help='The git password. This takes precedence over the --github-app-id,  --github-app-installation-id, and --github-app-private-key')\n\n    return parser.parse_known_args()\n\n\ndef generate_github_token(github_app_id, github_app_private_key, github_app_installation_id):\n    # Generate the tokens used by git and the GitHub API\n    app_id = github_app_id\n    signing_key = jwt.jwk_from_pem(github_app_private_key.encode('utf-8'))\n\n    payload = {\n        # Issued at time\n        'iat': int(time.time()),\n        # JWT expiration time (10 minutes maximum)\n        'exp': int(time.time()) + 600,\n        # GitHub App's identifier\n        'iss': app_id\n    }\n\n    # Create JWT\n    jwt_instance = jwt.JWT()\n    encoded_jwt = jwt_instance.encode(payload, signing_key, alg='RS256')\n\n    # Create access token\n    url = 'https://api.github.com/app/installations/' + github_app_installation_id + '/access_tokens'\n    headers = {\n        'Authorization': 'Bearer ' + encoded_jwt,\n        'Accept': 'application/vnd.github+json',\n        'X-GitHub-Api-Version': '2022-11-28'\n    }\n    request = urllib.request.Request(url, headers=headers, method='POST')\n    response = urllib.request.urlopen(request)\n    response_json = json.loads(response.read().decode())\n    return response_json['token']\n\n\ndef generate_auth_header(token):\n    auth = base64.b64encode(('x-access-token:' + token).encode('ascii'))\n    return 'Basic ' + auth.decode('ascii')\n\n\ndef verify_new_repo(token, cac_org, new_repo):\n    # Attempt to view the new repo\n    try:\n        url = 'https://api.github.com/repos/' + cac_org + '/' + new_repo\n        headers = {\n            'Accept': 'application/vnd.github+json',\n            'Authorization': 'Bearer ' + token,\n            'X-GitHub-Api-Version': '2022-11-28'\n        }\n        request = urllib.request.Request(url, headers=headers)\n        urllib.request.urlopen(request)\n        return True\n    except:\n        return False\n\n\ndef encrypt(public_key_for_repo: str, secret_value_input: str) -> str:\n    \"\"\"Encrypt a Unicode string using the public key.\"\"\"\n    sealed_box = public.SealedBox(public.PublicKey(public_key_for_repo.encode(\"utf-8\"), encoding.Base64Encoder()))\n    encrypted = sealed_box.encrypt(secret_value_input.encode(\"utf-8\"))\n    return b64encode(encrypted).decode(\"utf-8\")\n\n\ndef get_public_key(gh_base_url: str, gh_owner: str, gh_repo: str, gh_auth_token: str) -> (str, str):\n    public_key_endpoint: str = f\"{gh_base_url}/{gh_owner}/{gh_repo}/actions/secrets/public-key\"\n    headers: TypedDict[str, str] = {\"Authorization\": f\"Bearer {gh_auth_token}\"}\n    response = requests.get(url=public_key_endpoint, headers=headers)\n    if response.status_code != 200:\n        raise IOError(\n            f\"Could not get public key for repository {gh_owner}/{gh_repo}. The Response code was {response.status_code}\")\n\n    public_key_json = response.json()\n    return public_key_json['key_id'], public_key_json['key']\n\n\ndef set_secret(gh_base_url: str, gh_owner: str, gh_repo: str, gh_auth_token: str, public_key_id: str, secret_key: str,\n               encrypted_secret_value: str):\n    secret_creation_url = f\"{gh_base_url}/{gh_owner}/{gh_repo}/actions/secrets/{secret_key}\"\n    secret_creation_body = {\"key_id\": public_key_id, \"encrypted_value\": encrypted_secret_value}\n    headers: TypedDict[str, str] = {\"Authorization\": f\"Bearer {gh_auth_token}\", \"Content-Type\": \"application/json\"}\n\n    secret_creation_response = requests.put(url=secret_creation_url, json=secret_creation_body, headers=headers)\n    if secret_creation_response.status_code == 201 or secret_creation_response.status_code == 204:\n        print(\"--Secret Created / Updated!--\")\n    else:\n        print(f\"-- Error creating / updating github secret, the reason was : {secret_creation_response.reason}\")\n\n\nparser, _ = init_argparse()\n\nif not parser.git_password.strip() and not (\n        parser.github_app_id.strip() and parser.github_app_private_key.strip() and parser.github_app_installation_id.strip()):\n    print(\"You must supply the GitHub token, or the GitHub App ID and private key and installation ID\")\n    sys.exit(1)\n\nif not parser.git_organization.strip():\n    print(\"You must define the organization\")\n    sys.exit(1)\n\nif not parser.repo.strip():\n    print(\"You must define the repo name\")\n    sys.exit(1)\n\ntoken = generate_github_token(parser.github_app_id, parser.github_app_private_key,\n                              parser.github_app_installation_id) if len(\n    parser.git_password.strip()) == 0 else parser.git_password.strip()\n\nif not parser.git_password.strip() and not (\n        parser.github_app_id.strip() and parser.github_app_private_key.strip() and parser.github_app_installation_id.strip()):\n    print(\"You must supply the GitHub token, or the GitHub App ID and private key and installation ID\")\n    sys.exit(1)\n\nif not parser.git_organization.strip():\n    print(\"You must define the organization\")\n    sys.exit(1)\n\nif not parser.repo.strip():\n    print(\"You must define the repo name\")\n    sys.exit(1)\n\nif not parser.secret_name.strip():\n    print(\"You must define the secret name\")\n    sys.exit(1)\n    \nif not verify_new_repo(token, parser.git_organization, parser.repo):\n    print(\"Could not find the repo\")\n    sys.exit(1)\n\nkey_id, public_key = get_public_key('https://api.github.com/repos', parser.git_organization, parser.repo,\n                                    token)\nencrypted_secret: str = encrypt(public_key_for_repo=public_key, secret_value_input=parser.secret_value)\nset_secret(gh_base_url='https://api.github.com/repos', gh_owner=parser.git_organization, gh_repo=parser.repo,\n           gh_auth_token=token, public_key_id=key_id, secret_key=parser.secret_name,\n           encrypted_secret_value=encrypted_secret)\n"
+  },
+  "Parameters": [
+    {
+      "Id": "6470d539-d137-42dd-bff2-9ebc1955b2a7",
+      "Name": "CreateGitHubSecret.GitHub.Secret.Name",
+      "Label": "Secret Name",
+      "HelpText": "The name of the GitHub secret.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2ead2e13-1a01-4360-9585-f920181880a1",
+      "Name": "CreateGitHubSecret.GitHub.Secret.Value",
+      "Label": "Secret Value",
+      "HelpText": "The secret value.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "643b6230-5cca-4ca2-8340-9624ed721b9b",
+      "Name": "CreateGitHubSecret.Git.Url.Repo",
+      "Label": "GitHub Repo Name",
+      "HelpText": "The GitHub repo name i.e. `myrepo` in the URL`https://github.com/owner/myrepo`.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8c506ad7-f8b9-458c-a53b-23a19984c413",
+      "Name": "CreateGitHubSecret.Git.Url.Organization",
+      "Label": "Github Owner",
+      "HelpText": "The GitHub repo owner or organization i.e. `owner` in the URL `https://github.com/owner/myrepo`.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "a457faef-6cd8-4c1b-ad23-306b03419794",
+      "Name": "CreateGitHubSecret.Git.Credentials.Password",
+      "Label": "GitHub Access Token",
+      "HelpText": "The GitHub access token",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-10-19T01:48:54.675Z",
+    "OctopusVersion": "2023.4.6357",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "mcasperson",
+  "Category": "github"
+}


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

The PR adds a step that creates a secret in a GitHub repo.


# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
