### PR TITLE
We no longer need to set whether to ignore CaC values or not.

### DIFF
--- a/step-templates/octopus-serialize-project-to-terraform.json
+++ b/step-templates/octopus-serialize-project-to-terraform.json
@@ -84,16 +84,6 @@
       }
     },
     {
-      "Id": "08ea147b-0fb6-4d90-b8a6-a97eaecd77bf",
-      "Name": "SerializeProject.Exported.Project.IgnoreCacValues",
-      "Label": "Ignore CaC Values",
-      "HelpText": "Select this option when exporting a Config-as-Code enabled project. This option configures Terraform to ignore changes to values managed by Config-as-Code, or exclude them from the export, including non-secret variables, the deployment process, and project versioning settings.",
-      "DefaultValue": "False",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
       "Id": "aec82033-cae1-4a18-a315-c70468f71539",
       "Name": "Exported.Project.IgnoredLibraryVariableSet",
       "Label": "Ignored Library Variables Sets",


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

Octoterra used to set the `ignoreCacManagedValues` argument to `false` by default. This default value was not sensible though, and newer versions set it to true by default. This change means the step template no longer needs to expose this option, and the parameter has been removed.

# Results

<!-- Describe the result of the change -->

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
