### PR TITLE
Fix to allow saving and save-as-copy

### DIFF
--- a/step-templates/octopus-create-octoterra-space-s3.json
+++ b/step-templates/octopus-create-octoterra-space-s3.json
@@ -3,7 +3,7 @@
   "Name": "Octopus - Create Octoterra Space (S3 Backend)",
   "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [
     {

--- a/step-templates/octopus-create-octoterra-space-s3.json
+++ b/step-templates/octopus-create-octoterra-space-s3.json
@@ -30,7 +30,7 @@
     "Octopus.Action.Terraform.PlanJsonOutput": "False",
     "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
     "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"bucket=#{OctoterraApply.AWS.S3.BucketName}\" -backend-config=\"region=#{OctoterraApply.AWS.S3.BucketRegion}\" -backend-config=\"key=#{OctoterraApply.AWS.S3.BucketKey}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
-    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} -var=octopus_space_name=#{OctoterraApply.Octopus.Space.NewName} -var=octopus_space_managers=#{OctoterraApply.Octopus.Space.Managers} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} \"-var=octopus_space_name=#{OctoterraApply.Octopus.Space.NewName}\" -var=octopus_space_managers=#{OctoterraApply.Octopus.Space.Managers} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
     "Octopus.Action.Package.DownloadOnTentacle": "False",
     "Octopus.Action.RunOnServer": "true",
     "Octopus.Action.AwsAccount.UseInstanceRole": "False",

--- a/step-templates/octopus-create-octoterra-space-s3.json
+++ b/step-templates/octopus-create-octoterra-space-s3.json
@@ -21,8 +21,8 @@
   "Properties": {
     "Octopus.Action.GoogleCloud.UseVMServiceAccount": "False",
     "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
-    "Octopus.Action.Terraform.GoogleCloudAccount": "True",
-    "Octopus.Action.Terraform.AzureAccount": "True",
+    "Octopus.Action.Terraform.GoogleCloudAccount": "False",
+    "Octopus.Action.Terraform.AzureAccount": "False",
     "Octopus.Action.Terraform.ManagedAccount": "AWS",
     "Octopus.Action.Terraform.AllowPluginDownloads": "True",
     "Octopus.Action.Script.ScriptSource": "Package",
@@ -37,9 +37,7 @@
     "Octopus.Action.AwsAccount.Variable": "OctoterraApply.AWS.Account",
     "Octopus.Action.Aws.AssumeRole": "False",
     "Octopus.Action.Aws.Region": "#{OctoterraApply.AWS.S3.BucketRegion}",
-    "Octopus.Action.Terraform.TemplateDirectory": "space_creation",
-    "Octopus.Action.AzureAccount.Variable": "",
-    "Octopus.Action.GoogleCloudAccount.Variable": ""
+    "Octopus.Action.Terraform.TemplateDirectory": "space_creation"
   },
   "Parameters": [
     {


### PR DESCRIPTION
# Background

This update fixes 2 issues:

1. Unable to save deployment process with step added
GoogleCloudAccount and AzureAcccount variables were set to 'true.' The fields are not exposed, so the user cannot set them to the "No" radio button for each one in the UI. 
Updated values to 'false.'

2. Unable to import/save as copy
There were two properties that existed but had empty string values: Package.PackageId and Package.FeedId. This caused a 'tiny types' error.
Removed the properties.

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it