### PR TITLE
Added a step to export a single runbook

### DIFF
--- a/step-templates/octopus-add-runbook-to-project.json
+++ b/step-templates/octopus-add-runbook-to-project.json
@@ -1,0 +1,173 @@
+{
+  "Id": "8b8b0386-78f8-42c2-baea-2fdb9a57c32d",
+  "Name": "Octopus - Add Runbook to Project (S3 Backend)",
+  "Description": "This step exposes the fields required to deploy a runbook serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform to a project.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "ActionType": "Octopus.TerraformApply",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "093b1515-15a9-4446-8dc2-6297018a77e7",
+      "Name": "",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "SelectionMode": "deferred",
+        "PackageParameterName": "OctoterraApply.Terraform.Package.Id"
+      }
+    }
+  ],
+  "Properties": {
+    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "False",
+    "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
+    "Octopus.Action.Terraform.GoogleCloudAccount": "False",
+    "Octopus.Action.Terraform.AzureAccount": "False",
+    "Octopus.Action.Terraform.ManagedAccount": "AWS",
+    "Octopus.Action.Terraform.AllowPluginDownloads": "True",
+    "Octopus.Action.Script.ScriptSource": "Package",
+    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "False",
+    "Octopus.Action.Terraform.PlanJsonOutput": "False",
+    "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
+    "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"bucket=#{OctoterraApply.AWS.S3.BucketName}\" -backend-config=\"region=#{OctoterraApply.AWS.S3.BucketRegion}\" -backend-config=\"key=#{OctoterraApply.AWS.S3.BucketKey}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} -var=octopus_space_id=#{OctoterraApply.Octopus.SpaceID} \"-var=parent_project_name=#{OctoterraApply.Octopus.Project}\" #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Package.DownloadOnTentacle": "False",
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.AwsAccount.Variable": "OctoterraApply.AWS.Account",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.Aws.Region": "#{OctoterraApply.AWS.S3.BucketRegion}",
+    "Octopus.Action.Terraform.TemplateDirectory": "space_population",
+    "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf"
+  },
+  "Parameters": [
+    {
+      "Id": "95860b77-2c38-492c-bb84-ca1fbb4e4b72",
+      "Name": "OctoterraApply.Terraform.Workspace.Name",
+      "Label": "Terraform Workspace",
+      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}`. Leave this as the default value unless you have a specific reason to change it.",
+      "DefaultValue": "#{OctoterraApply.Octopus.SpaceID}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1acabadc-d1d6-477a-88ff-ae5a302a9d77",
+      "Name": "OctoterraApply.Terraform.Package.Id",
+      "Label": "Terraform Module Package",
+      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_population` directory.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "1092f0a5-3e57-4009-9ed7-ee93e36e40cb",
+      "Name": "OctoterraApply.Octopus.ServerUrl",
+      "Label": "Octopus Server URL",
+      "HelpText": "The Octopus server URL.",
+      "DefaultValue": "#{Octopus.Web.ServerUri}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "03191aa9-d41f-4ae8-96ca-a35da790043a",
+      "Name": "OctoterraApply.Octopus.ApiKey",
+      "Label": "Octopus API key",
+      "HelpText": "The Octopus API key. See the [documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating an API key.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "59c7c097-7fd8-46e7-996c-64f74a80ef02",
+      "Name": "OctoterraApply.Octopus.SpaceID",
+      "Label": "Octopus Space ID",
+      "HelpText": "The Space ID to deploy the Terraform module into. The [Octopus - Lookup Space ID](https://library.octopus.com/step-templates/324f747e-e2cd-439d-a660-774baf4991f2/actiontemplate-octopus-lookup-space-id) step can be used to convert a space name to an ID.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ea0dd836-7490-45c6-8e5c-321569e8d07d",
+      "Name": "OctoterraApply.Octopus.Project",
+      "Label": "Octopus Project Name",
+      "HelpText": "The name of the project to import the runbook into",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "bc23db0c-381b-4796-9350-0f5a3cba0a66",
+      "Name": "OctoterraApply.AWS.Account",
+      "Label": "AWS Account Variable",
+      "HelpText": "The AWS account variable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    },
+    {
+      "Id": "553c3ed3-11cf-4b54-bd78-847062e64828",
+      "Name": "OctoterraApply.AWS.S3.BucketName",
+      "Label": "AWS S3 Bucket Name",
+      "HelpText": "The name of the S3 bucket used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f21cd6e6-82c2-4b5f-8739-8e0a02be8deb",
+      "Name": "OctoterraApply.AWS.S3.BucketRegion",
+      "Label": "AWS S3 Bucket Region",
+      "HelpText": "The AWS region hosting the S3 bucket. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "107214e9-b237-4255-894a-95163b28c1fe",
+      "Name": "OctoterraApply.AWS.S3.BucketKey",
+      "Label": "AWS S3 Bucket Key",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "DefaultValue": "Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "a4548b85-2a8c-4ab2-a604-ab1e9f7ef5ea",
+      "Name": "OctoterraApply.Terraform.AdditionalApplyParams",
+      "Label": "Terraform Additional Apply Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform apply` command. This field can be left blank. See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/apply) for details on the `apply` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "fc28012d-5e51-4907-bae4-552697226fde",
+      "Name": "OctoterraApply.Terraform.AdditionalInitParams",
+      "Label": "Terraform Additional Init Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform init` command. This field can be left blank.  See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/init) for details on the `init` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.TerraformApply",
+  "$Meta": {
+    "ExportedAt": "2023-11-09T01:10:53.027Z",
+    "OctopusVersion": "2024.1.895",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
+}

--- a/step-templates/octopus-add-runbook-to-project.json
+++ b/step-templates/octopus-add-runbook-to-project.json
@@ -136,7 +136,7 @@
       "Name": "OctoterraApply.AWS.S3.BucketKey",
       "Label": "AWS S3 Bucket Key",
       "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
-      "DefaultValue": "Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DefaultValue": "#{Octopus.Action.Package.PackageId}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }

--- a/step-templates/octopus-serialize-runbook-to-terraform.json
+++ b/step-templates/octopus-serialize-runbook-to-terraform.json
@@ -1,0 +1,105 @@
+{
+  "Id": "07b966c3-130c-4f13-ae0f-5105af5b97a1",
+  "Name": "Octopus - Serialize Runbook to Terraform",
+  "Description": "Serialize an Octopus runbook as a Terraform module and upload the resulting package to the Octopus built in feed.\n\nNote the exported runbooks do not include project variables, so any project that the exported runbook is attached to must already have all project and library variables defined.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "Properties": {
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.Script.ScriptBody": "import argparse\nimport os\nimport re\nimport socket\nimport subprocess\nimport sys\nfrom datetime import datetime\nfrom urllib.parse import urlparse\nfrom itertools import chain\nimport platform\nfrom urllib.request import urlretrieve\nimport zipfile\n\n# If this script is not being run as part of an Octopus step, return variables from environment variables.\n# Periods are replaced with underscores, and the variable name is converted to uppercase\nif \"get_octopusvariable\" not in globals():\n    def get_octopusvariable(variable):\n        return os.environ[re.sub('\\\\.', '_', variable.upper())]\n\n# If this script is not being run as part of an Octopus step, print directly to std out.\nif \"printverbose\" not in globals():\n    def printverbose(msg):\n        print(msg)\n\n\ndef printverbose_noansi(output):\n    \"\"\"\n    Strip ANSI color codes and print the output as verbose\n    :param output: The output to print\n    \"\"\"\n    output_no_ansi = re.sub('\\x1b\\[[0-9;]*m', '', output)\n    printverbose(output_no_ansi)\n\n\ndef get_octopusvariable_quiet(variable):\n    \"\"\"\n    Gets an octopus variable, or an empty string if it does not exist.\n    :param variable: The variable name\n    :return: The variable value, or an empty string if the variable does not exist\n    \"\"\"\n    try:\n        return get_octopusvariable(variable)\n    except:\n        return ''\n\n\ndef execute(args, cwd=None, env=None, print_args=None, print_output=printverbose_noansi):\n    \"\"\"\n        The execute method provides the ability to execute external processes while capturing and returning the\n        output to std err and std out and exit code.\n    \"\"\"\n    process = subprocess.Popen(args,\n                               stdout=subprocess.PIPE,\n                               stderr=subprocess.PIPE,\n                               text=True,\n                               cwd=cwd,\n                               env=env)\n    stdout, stderr = process.communicate()\n    retcode = process.returncode\n\n    if print_args is not None:\n        print_output(' '.join(args))\n\n    if print_output is not None:\n        print_output(stdout)\n        print_output(stderr)\n\n    return stdout, stderr, retcode\n\n\ndef is_windows():\n    return platform.system() == 'Windows'\n\n\ndef init_argparse():\n    parser = argparse.ArgumentParser(\n        usage='%(prog)s [OPTION] [FILE]...',\n        description='Serialize an Octopus project to a Terraform module'\n    )\n    parser.add_argument('--ignore-all-changes',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.Exported.Project.IgnoreAllChanges') or get_octopusvariable_quiet(\n                            'Exported.Project.IgnoreAllChanges') or 'false',\n                        help='Set to true to set the \"lifecycle.ignore_changes\" ' +\n                             'setting on each exported resource to \"all\"')\n    parser.add_argument('--terraform-backend',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.ThisInstance.Terraform.Backend') or get_octopusvariable_quiet(\n                            'ThisInstance.Terraform.Backend') or 'pg',\n                        help='Set this to the name of the Terraform backend to be included in the generated module.')\n    parser.add_argument('--server-url',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.ThisInstance.Server.Url') or get_octopusvariable_quiet(\n                            'ThisInstance.Server.Url'),\n                        help='Sets the server URL that holds the project to be serialized.')\n    parser.add_argument('--api-key',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.ThisInstance.Api.Key') or get_octopusvariable_quiet(\n                            'ThisInstance.Api.Key'),\n                        help='Sets the Octopus API key.')\n    parser.add_argument('--space-id',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.Exported.Space.Id') or get_octopusvariable_quiet(\n                            'Exported.Space.Id') or get_octopusvariable_quiet('Octopus.Space.Id'),\n                        help='Set this to the space ID containing the project to be serialized.')\n    parser.add_argument('--project-name',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.Exported.Project.Name') or get_octopusvariable_quiet(\n                            'Exported.Project.Name') or get_octopusvariable_quiet(\n                            'Octopus.Project.Name'),\n                        help='Set this to the name of the project to be serialized.')\n    parser.add_argument('--runbook-name',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.Exported.Runbook.Name') or get_octopusvariable_quiet(\n                            'Exported.Runbook.Name'),\n                        help='Set this to the name of the project to be serialized.')\n    parser.add_argument('--upload-space-id',\n                        action='store',\n                        default=get_octopusvariable_quiet(\n                            'SerializeProject.Octopus.UploadSpace.Id') or get_octopusvariable_quiet(\n                            'Octopus.UploadSpace.Id') or get_octopusvariable_quiet('Octopus.Space.Id'),\n                        help='Set this to the space ID of the Octopus space where ' +\n                             'the resulting package will be uploaded to.')\n\n    return parser.parse_known_args()\n\n\ndef ensure_octo_cli_exists():\n    if is_windows():\n        print(\"Checking for the Octopus CLI\")\n        try:\n            stdout, _, exit_code = execute(['octo', 'help'])\n            printverbose(stdout)\n            if not exit_code == 0:\n                raise \"Octo CLI not found\"\n        except:\n            print(\"Downloading the Octopus CLI\")\n            urlretrieve('https://download.octopusdeploy.com/octopus-tools/9.0.0/OctopusTools.9.0.0.win-x64.zip',\n                        'OctopusTools.zip')\n            with zipfile.ZipFile('OctopusTools.zip', 'r') as zip_ref:\n                zip_ref.extractall(os.getcwd())\n\n\ndef check_docker_exists():\n    try:\n        stdout, _, exit_code = execute(['docker', 'version'])\n        printverbose(stdout)\n        if not exit_code == 0:\n            raise \"Docker not found\"\n    except:\n        print('Docker must be installed: https://docs.docker.com/get-docker/')\n        sys.exit(1)\n\n\ncheck_docker_exists()\nensure_octo_cli_exists()\nparser, _ = init_argparse()\n\n# Variable precondition checks\nif len(parser.server_url) == 0:\n    print(\"--server-url, ThisInstance.Server.Url, or SerializeProject.ThisInstance.Server.Url must be defined\")\n    sys.exit(1)\n\nif len(parser.api_key) == 0:\n    print(\"--api-key, ThisInstance.Api.Key, or ThisInstance.Api.Key must be defined\")\n    sys.exit(1)\n    \noctoterra_image = 'octopussamples/octoterra-windows' if is_windows() else 'octopussamples/octoterra'\noctoterra_mount = 'C:/export' if is_windows() else '/export'  \n\nprint(\"Pulling the Docker images\")\nexecute(['docker', 'pull', octoterra_image])\n\nif not is_windows():\n    execute(['docker', 'pull', 'octopusdeploy/octo'])\n\n# Find out the IP address of the Octopus container\nparsed_url = urlparse(parser.server_url)\noctopus = socket.getaddrinfo(parsed_url.hostname, '80')[0][4][0]\n\nprint(\"Octopus hostname: \" + parsed_url.hostname)\nprint(\"Octopus IP: \" + octopus.strip())\n\nos.mkdir(os.getcwd() + '/export')\n\nexport_args = ['docker', 'run',\n               '--rm',\n               '--add-host=' + parsed_url.hostname + ':' + octopus.strip(),\n               '-v', os.getcwd() + '/export:' + octoterra_mount,\n               octoterra_image,\n               # the url of the instance\n               '-url', parser.server_url,\n               # the api key used to access the instance\n               '-apiKey', parser.api_key,\n               # add a postgres backend to the generated modules\n               '-terraformBackend', parser.terraform_backend,\n               # dump the generated HCL to the console\n               '-console',\n               # dump the project from the current space\n               '-space', parser.space_id,\n               # the name of the project to serialize\n               '-projectName', parser.project_name,\n               # the name of the runbook to serialize\n               '-runbookName', parser.runbook_name,\n               # ignoreProjectChanges can be set to ignore all changes to the project, variables, runbooks etc\n               '-ignoreProjectChanges=' + parser.ignore_all_changes,\n               # for any secret variables, add a default value set to the octostache value of the variable\n               # e.g. a secret variable called \"database\" has a default value of \"#{database}\"\n               '-defaultSecretVariableValues',\n               # detach any step templates, allowing the exported project to be used in a new space\n               '-detachProjectTemplates',\n               # Capture the octopus endpoint, space ID, and space name as output vars. This is useful when\n               # querying th Terraform state file to know which space and instance the resources were\n               # created in. The scripts used to update downstream projects in bulk work by querying the\n               # Terraform state, finding all the downstream projects, and using the space name to only process\n               # resources that match the current tenant (because space names and tenant names are the same).\n               # The output variables added by this option are octopus_server, octopus_space_id, and\n               # octopus_space_name.\n               '-includeOctopusOutputVars',\n               # Where steps do not explicitly define a worker pool and reference the default one, this\n               # option explicitly exports the default worker pool by name. This means if two spaces have\n               # different default pools, the exported project still uses the pool that the original project\n               # used.\n               '-lookUpDefaultWorkerPools',\n               # These tenants are linked to the project to support some management runbooks, but should not\n               # be exported\n               '-excludeAllTenants',\n               # The directory where the exported files will be saved\n               '-dest', octoterra_mount]\n\nprint(\"Exporting Terraform module\")\n_, _, octoterra_exit = execute(export_args)\n\nif not octoterra_exit == 0:\n    print(\"Octoterra failed. Please check the logs for more information.\")\n    sys.exit(1)\n\ndate = datetime.now().strftime('%Y.%m.%d.%H%M%S')\n\nprint(\"Creating Terraform module package\")\nif is_windows():\n    execute(['octo',\n             'pack',\n             '--format', 'zip',\n             '--id', re.sub('[^0-9a-zA-Z]', '_', parser.project_name + \"_\" + parser.runbook_name),\n             '--version', date,\n             '--basePath', os.getcwd() + '\\\\export',\n             '--outFolder', 'C:\\\\export'])\nelse:\n    _, _, _ = execute(['docker', 'run',\n                            '--rm',\n                            '--add-host=' + parsed_url.hostname + ':' + octopus.strip(),\n                            '-v', os.getcwd() + \"/export:/export\",\n                            'octopusdeploy/octo',\n                            'pack',\n                            '--format', 'zip',\n                            '--id', re.sub('[^0-9a-zA-Z]', '_', parser.project_name + \"_\" + parser.runbook_name),\n                            '--version', date,\n                            '--basePath', '/export',\n                            '--outFolder', '/export'])\n\nprint(\"Uploading Terraform module package\")\nif is_windows():\n    _, _, _ = execute(['octo',\n                            'push',\n                            '--apiKey', parser.api_key,\n                            '--server', parser.server_url,\n                            '--space', parser.upload_space_id,\n                            '--package', 'C:\\\\export\\\\' +\n                            re.sub('[^0-9a-zA-Z]', '_', parser.project_name + \"_\" + parser.runbook_name) + '.' + date + '.zip',\n                            '--replace-existing'])\nelse:\n    _, _, _ = execute(['docker', 'run',\n                            '--rm',\n                            '--add-host=' + parsed_url.hostname + ':' + octopus.strip(),\n                            '-v', os.getcwd() + \"/export:/export\",\n                            'octopusdeploy/octo',\n                            'push',\n                            '--apiKey', parser.api_key,\n                            '--server', parser.server_url,\n                            '--space', parser.upload_space_id,\n                            '--package', '/export/' +\n                            re.sub('[^0-9a-zA-Z]', '_', parser.project_name + \"_\" + parser.runbook_name) + '.' + date + '.zip',\n                            '--replace-existing'])\n\nprint(\"##octopus[stdout-default]\")\n\nprint(\"Done\")\n",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Python"
+  },
+  "Parameters": [
+    {
+      "Id": "070f2882-2911-4297-b9e3-2da81abf6e70",
+      "Name": "SerializeProject.Exported.Project.IgnoreAllChanges",
+      "Label": "Ignore All Changes",
+      "HelpText": "Selecting this option creates a Terraform module with the \"lifecycle.ignore_changes\" option set to \"all\". This allows the resources to be created if they do not exist, but won't update them if the module is reapplied.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "4cb3da75-7449-4adb-b81a-e87dff371a27",
+      "Name": "SerializeProject.ThisInstance.Terraform.Backend",
+      "Label": "Terraform Backend",
+      "HelpText": "The [backed](https://developer.hashicorp.com/terraform/language/settings/backends/configuration) to define in the Terraform module.",
+      "DefaultValue": "s3",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "aa3df492-845a-4889-a7fc-c9c6f3a95a30",
+      "Name": "SerializeProject.ThisInstance.Server.Url",
+      "Label": "Octopus Server URL",
+      "HelpText": "The URL of the Octopus Server hosting the project to be serialized.",
+      "DefaultValue": "#{Octopus.Web.ServerUri}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e92dbdff-dd5a-4c95-91a1-40c0ccbb3b3f",
+      "Name": "SerializeProject.ThisInstance.Api.Key",
+      "Label": "Octopus API Key",
+      "HelpText": "The Octopus API Key",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "c906ecbd-f304-48b8-83ea-fe75008c37df",
+      "Name": "SerializeProject.Exported.Space.Id",
+      "Label": "Octopus Space ID",
+      "HelpText": "The Space ID containing the project to be exported",
+      "DefaultValue": "#{Octopus.Space.Id}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "fae1f2e4-9be5-4380-9fd3-409a1a538b37",
+      "Name": "SerializeProject.Exported.Project.Name",
+      "Label": "Octopus Project Name",
+      "HelpText": "The name of the project containing the runbook.",
+      "DefaultValue": "#{Octopus.Project.Name}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "a711f201-fa2f-4b32-9205-13f396c253d7",
+      "Name": "SerializeProject.Exported.Runbook.Name",
+      "Label": "Octopus Runbook Name",
+      "HelpText": "The name of the runbook to serialize.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "27b222da-690c-4da3-8c60-d06bc7d3505b",
+      "Name": "SerializeProject.Octopus.UploadSpace.Id",
+      "Label": "Octopus Upload Space ID",
+      "HelpText": "The ID of the space to upload the Terraform package to. Leave this blank to upload to the space defined in the `Octopus Space ID` parameter.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2023-11-08T23:36:23.610Z",
+    "OctopusVersion": "2024.1.895",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
+}


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

This PR defines a step that can be used to export a single runbook.

# Results

![image](https://github.com/OctopusDeploy/Library/assets/160104/c29fe719-776a-4203-bc9b-31263a76129c)

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
