### PR TITLE
Tweak the add runbook ti project parameters

### DIFF
--- a/step-templates/octopus-add-runbook-to-project.json
+++ b/step-templates/octopus-add-runbook-to-project.json
@@ -38,7 +38,7 @@
     "Octopus.Action.Aws.AssumeRole": "False",
     "Octopus.Action.Aws.Region": "#{OctoterraApply.AWS.S3.BucketRegion}",
     "Octopus.Action.Terraform.TemplateDirectory": "space_population",
-    "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf"
+    "Octopus.Action.Terraform.FileSubstitution": ""
   },
   "Parameters": [
     {

--- a/step-templates/octopus-add-runbook-to-project.json
+++ b/step-templates/octopus-add-runbook-to-project.json
@@ -3,7 +3,7 @@
   "Name": "Octopus - Add Runbook to Project (S3 Backend)",
   "Description": "This step exposes the fields required to deploy a runbook serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform to a project.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -45,8 +45,8 @@
       "Id": "95860b77-2c38-492c-bb84-ca1fbb4e4b72",
       "Name": "OctoterraApply.Terraform.Workspace.Name",
       "Label": "Terraform Workspace",
-      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}`. Leave this as the default value unless you have a specific reason to change it.",
-      "DefaultValue": "#{OctoterraApply.Octopus.SpaceID}",
+      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID and project name that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}_#{OctoterraApply.Octopus.Project | Replace \"[^A-Za-z0-9]\" \"_\"}`. Leave this as the default value unless you have a specific reason to change it.",
+      "DefaultValue": "#{OctoterraApply.Octopus.SpaceID}_#{OctoterraApply.Octopus.Project | Replace \"[^A-Za-z0-9]\" \"_\"}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
@@ -135,8 +135,8 @@
       "Id": "107214e9-b237-4255-894a-95163b28c1fe",
       "Name": "OctoterraApply.AWS.S3.BucketKey",
       "Label": "AWS S3 Bucket Key",
-      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
-      "DefaultValue": "#{Octopus.Action.Package.PackageId}",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the runbook (based on the name of the package) and a prefix to indicate the type of resource: `Runbook_#{Octopus.Action.Package.PackageId}`.",
+      "DefaultValue": "Runbook_#{Octopus.Action.Package.PackageId}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

Some tweaks to the default variables are required for this step to work with multiple runbook deployments:
* The workspace needs to be unique per space and project (not just per space)
* The default bucket key needs a prefix of `Runbooks_`
* Runbooks do not export any secret variables, so there is no need to define the file substitution feature

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it