### PR TITLE
Fix case where existing environments are reused

### DIFF
--- a/step-templates/octopus-reference-architecture-eks.json
+++ b/step-templates/octopus-reference-architecture-eks.json
@@ -3,7 +3,7 @@
   "Name": "Octopus - EKS Reference Architecture",
   "Description": "This step populates an Octopus space with the environments, feeds, accounts, lifecycles, projects, and runbooks required to deploy a sample application to an AWS EKS Kubernetes cluster. These resources combine to form a reference architecture teams can use to bootstrap an Octopus space with best practices and example projects. It is recommended that you run this step with the `octopuslabs/terraform-workertools` [container image](https://octopus.com/docs/projects/steps/execution-containers-for-workers). \n\nThat this step assumes it is run on a cloud Octopus instance, or the default worker runs Linux, has Docker installed, and has PowerShell Core installed.\n\nThe step will not update existing projects, environments etc. If you wish to recreate these resource with the latest configuration, for example if this step is updated and you wish to see the latest settings, you must manually delete or rename the resources to be recreated.",
   "ActionType": "Octopus.TerraformApply",
-  "Version": 8,
+  "Version": 9,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

When the Terraform module uses existing environments, the sort order is not known. This PR adds a small check to ensure the sleep time is not less than 0.

# Results

<!-- Describe the result of the change -->

## Before
![image](https://github.com/OctopusDeploy/Library/assets/160104/341ce46d-9f07-49c2-9776-f9a4211545d7)




# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
