### PR TITLE
Update ReadyRoll template format to enable import in newer Octopus versions

### DIFF
--- a/step-templates/readyroll-deploy-database-package.json
+++ b/step-templates/readyroll-deploy-database-package.json
@@ -26,7 +26,7 @@
         "Id": "43af2bc5-668d-482f-a23b-1e46189fcd69",
         "Name": "PackageName",
         "Label": "Package to deploy",
-        "HelpText": "The ID of the NuGet package you want to deploy. This matches the NuGet package ID from the NuSpec file in your ReadyRoll project.",
+        "HelpText": "The package you want to deploy. If using NuGet, this matches the package ID from the NuSpec file in your ReadyRoll project.",
         "DefaultValue": "",
         "DisplaySettings": {
           "Octopus.ControlType": "Package"

--- a/step-templates/readyroll-deploy-database-package.json
+++ b/step-templates/readyroll-deploy-database-package.json
@@ -1,80 +1,95 @@
 {
   "Id": "14e87c33-b34a-429f-be2c-e44d3d631649",
   "Name": "ReadyRoll - Deploy Database Package",
-  "Description": "Deploy database changes packaged with Redgate's [ReadyRoll](http://www.ready-roll.com/). Requires the Microsoft SQL Command Line Utilities 11 or later to be installed on the tentacle.\r\n\r\n*Version date: 14th January, 2016*",
+  "Description": "Deploy database changes packaged with Redgate's [ReadyRoll](http://www.ready-roll.com/). Requires the Microsoft SQL Command Line Utilities 11 or later to be installed on the tentacle.\n\n*Version date: 14th January, 2016*",
   "ActionType": "Octopus.TentaclePackage",
-  "Version": 2,
-  "Properties": {
-    "Octopus.Action.EnabledFeatures": "",
-    "Octopus.Action.Package.AutomaticallyRunConfigurationTransformationFiles": "False",
-    "Octopus.Action.Package.AutomaticallyUpdateAppSettingsAndConnectionStrings": "False",
-    "Octopus.Action.Package.DownloadOnTentacle": "False",
-    "Octopus.Action.Package.NuGetFeedId": "feeds-builtin",
-    "Octopus.Action.Package.NuGetPackageId": "#{PackageName}"
-  },
-  "SensitiveProperties": {},
-  "Parameters": [
-    {
-      "Name": "PackageName",
-      "Label": "Package to deploy",
-      "HelpText": "The ID of the NuGet package you want to deploy. This matches the NuGet package ID from the NuSpec file in your ReadyRoll project.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+  "Version": 3,
+  "CommunityActionTemplateId": null,
+    "Packages": [
+      {
+        "Id": "536b0ad2-6439-4e6a-aff0-64ba07a33733",
+        "Name": "",
+        "PackageId": null,
+        "FeedId": null,
+        "AcquisitionLocation": "Server",
+        "Properties": {
+          "SelectionMode": "deferred",
+          "PackageParameterName": "PackageName"
+        }
       }
+    ],
+    "Properties": {
+      "Octopus.Action.Package.DownloadOnTentacle": "False"
     },
-    {
-      "Name": "DatabaseServer",
-      "Label": "Target SQL Server instance",
-      "HelpText": "The fully qualified SQL Server instance name for the target database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+    "Parameters": [
+      {
+        "Id": "43af2bc5-668d-482f-a23b-1e46189fcd69",
+        "Name": "PackageName",
+        "Label": "Package to deploy",
+        "HelpText": "The ID of the NuGet package you want to deploy. This matches the NuGet package ID from the NuSpec file in your ReadyRoll project.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Package"
+        }
+      },
+      {
+        "Id": "c7d2a8f5-0b33-4b1d-94cd-0f0f11ecf9d1",
+        "Name": "DatabaseServer",
+        "Label": "Target SQL Server instance",
+        "HelpText": "The fully qualified SQL Server instance name for the target database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "a0c8e52f-e7f2-4859-9769-f749f6705a08",
+        "Name": "DatabaseName",
+        "Label": "Target database name",
+        "HelpText": "The name of the database to deploy to. ReadyRoll will create a new database if it does not exist.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "8c448c0e-27c8-4572-8a96-0e9dad5c8091",
+        "Name": "UseWindowsAuth",
+        "Label": "Use Windows Authentication",
+        "HelpText": "If you check this field, Windows authentication will be used to connect, using the account that runs the Tentacle service. Otherwise, SQL Server authentication will be used and you will need to specify a username and password below.",
+        "DefaultValue": "True",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Checkbox"
+        }
+      },
+      {
+        "Id": "53358be8-b6fb-4dce-b107-a501c5ef5b1e",
+        "Name": "DatabaseUsername",
+        "Label": "Username",
+        "HelpText": "The SQL Server username used to connect to the database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "60688c6e-db91-4a6f-971f-e52901d7b732",
+        "Name": "DatabasePassword",
+        "Label": "Password",
+        "HelpText": "The SQL Server password used to connect to the database.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
       }
+    ],
+    "LastModifiedBy": "harrisonmeister",
+    "LastModifiedOn": "2021-07-26T16:50:00.000+00:00",
+    "StepPackageId": "Octopus.TentaclePackage",
+    "$Meta": {
+      "ExportedAt": "2023-11-15T14:12:59.832Z",
+      "OctopusVersion": "2024.1.1169",
+      "Type": "ActionTemplate"
     },
-    {
-      "Name": "DatabaseName",
-      "Label": "Target database name",
-      "HelpText": "The name of the database to deploy to. ReadyRoll will create a new database if it does not exist.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "UseWindowsAuth",
-      "Label": "Use Windows Authentication",
-      "HelpText": "If you check this field, Windows authentication will be used to connect, using the account that runs the Tentacle service. Otherwise, SQL Server authentication will be used and you will need to specify a username and password below.",
-      "DefaultValue": "True",
-      "DisplaySettings": {
-        "Octopus.ControlType": "Checkbox"
-      }
-    },
-    {
-      "Name": "DatabaseUsername",
-      "Label": "Username",
-      "HelpText": "The SQL Server username used to connect to the database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Name": "DatabasePassword",
-      "Label": "Password",
-      "HelpText": "The SQL Server password used to connect to the database.",
-      "DefaultValue": null,
-      "DisplaySettings": {
-        "Octopus.ControlType": "Sensitive"
-      }
-    }
-  ],
-  "LastModifiedOn": "2021-07-26T16:50:00.000+00:00",
-  "LastModifiedBy": "bobjwalker",
-  "$Meta": {
-    "ExportedAt": "2016-01-12T11:24:46.388+00:00",
-    "OctopusVersion": "3.2.15",
-    "Type": "ActionTemplate"
-  },
   "Category": "readyroll"
 }


### PR DESCRIPTION
# Background

Customer reported issues when importing the step template into a Space ([private link](https://octopus.zendesk.com/agent/tickets/160235))

**Note:** Only the format of the step has been updated. The step is essentially a wrapper for Redgate's Ready Roll software. No testing has been performed to ensure the new step works with a Ready roll package.

# Results

The step can be imported

## Before

![image](https://github.com/OctopusDeploy/Library/assets/1418993/ab0d2660-5629-4833-9241-d961a23ed573)

## After

![image](https://github.com/OctopusDeploy/Library/assets/1418993/6655e336-54ac-41bd-a2e1-0096d6d89964)

