### PR TITLE
Added step to find updates between downstream and upstream projects

### DIFF
--- a/step-templates/octopus-find-cac-updates.json
+++ b/step-templates/octopus-find-cac-updates.json
@@ -1,0 +1,131 @@
+{
+  "Id": "05210515-1a52-45d9-8be3-16caef808326",
+  "Name": "Octopus - Find CaC Updates (S3 Backend)",
+  "Description": "This step queries each workspace in the Terraform state for downstream Octopus CaC enabled projects, extracts the Git repo associated with the CaC project, and determines if there are any changes to merge into the downstream project from the upstream project.\n\nThis indicates if changes to an upstream project are available to be merged into a downstream project, either automatically, or after resolving merge conflicts.",
+  "ActionType": "Octopus.AwsRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "OctopusUseBundledTooling": "False",
+    "Octopus.Action.Script.ScriptBody": "# Check to see if $IsWindows is available\nif ($null -eq $IsWindows) {\n    Write-Host \"Determining Operating System...\"\n    $IsWindows = ([System.Environment]::OSVersion.Platform -eq \"Win32NT\")\n    $IsLinux = ([System.Environment]::OSVersion.Platform -eq \"Unix\")\n}\n\nFunction Get-GitExecutable\n{\n\t# Define parameters\n    param (\n    \t$WorkingDirectory\n    )\n\n    # Define variables\n    $gitExe = \"PortableGit-2.41.0.3-64-bit.7z.exe\"\n    $gitDownloadUrl = \"https://github.com/git-for-windows/git/releases/download/v2.41.0.windows.3/$gitExe\"\n    $gitDownloadArguments = @{}\n    $gitDownloadArguments.Add(\"Uri\", $gitDownloadUrl)\n    $gitDownloadArguments.Add(\"OutFile\", \"$WorkingDirectory/git/$gitExe\")\n\n    # This makes downloading faster\n    $ProgressPreference = 'SilentlyContinue'\n\n    # Check to see if git subfolder exists\n    if ((Test-Path -Path \"$WorkingDirectory/git\") -eq $false)\n    {\n    \t# Create subfolder\n        New-Item -Path \"$WorkingDirectory/git\"  -ItemType Directory | Out-Null\n    }\n\n    # Check PowerShell version\n    if ($PSVersionTable.PSVersion.Major -lt 6)\n    {\n    \t# Use basic parsing is required\n        $gitDownloadArguments.Add(\"UseBasicParsing\", $true)\n    }\n\n    # Download Git\n    Write-Host \"Downloading Git ...\"\n    Invoke-WebRequest @gitDownloadArguments\n\n    # Extract Git\n    $gitExtractArguments = @()\n    $gitExtractArguments += \"-o\"\n    $gitExtractArguments += \"$WorkingDirectory\\git\"\n    $gitExtractArguments += \"-y\"\n    $gitExtractArguments += \"-bd\"\n\n    Write-Host \"Extracting Git download ...\"\n    & \"$WorkingDirectory\\git\\$gitExe\" $gitExtractArguments\n\n    # Wait until unzip action is complete\n    while ($null -ne (Get-Process | Where-Object {$_.ProcessName -eq ($gitExe.Substring(0, $gitExe.LastIndexOf(\".\")))}))\n    {\n        Start-Sleep 5\n    }\n\n    # Add bin folder to path\n    $env:PATH = \"$WorkingDirectory\\git\\bin$([IO.Path]::PathSeparator)\" + $env:PATH\n\n    # Disable promopt for credential helper\n    Invoke-CustomCommand \"git\" @(\"config\", \"--system\", \"--unset\", \"credential.helper\") | Write-Results\n}\n\nFunction Invoke-CustomCommand\n{\n    Param (\n        $commandPath,\n        $commandArguments,\n        $workingDir = (Get-Location),\n        $path = @()\n    )\n\n    $path += $env:PATH\n    $newPath = $path -join [IO.Path]::PathSeparator\n\n    $pinfo = New-Object System.Diagnostics.ProcessStartInfo\n    $pinfo.FileName = $commandPath\n    $pinfo.WorkingDirectory = $workingDir\n    $pinfo.RedirectStandardError = $true\n    $pinfo.RedirectStandardOutput = $true\n    $pinfo.UseShellExecute = $false\n    $pinfo.Arguments = $commandArguments\n    $pinfo.EnvironmentVariables[\"PATH\"] = $newPath\n    $p = New-Object System.Diagnostics.Process\n    $p.StartInfo = $pinfo\n    $p.Start() | Out-Null\n\n    # Capture output during process execution so we don't hang\n    # if there is too much output.\n    # Microsoft documents a C# solution here:\n    # https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.redirectstandardoutput?view=net-7.0&redirectedfrom=MSDN#remarks\n    # This code is based on https://stackoverflow.com/a/74748844\n    $stdOut = [System.Text.StringBuilder]::new()\n    $stdErr = [System.Text.StringBuilder]::new()\n    do\n    {\n        if (!$p.StandardOutput.EndOfStream)\n        {\n            $stdOut.AppendLine($p.StandardOutput.ReadLine())\n        }\n        if (!$p.StandardError.EndOfStream)\n        {\n            $stdErr.AppendLine($p.StandardError.ReadLine())\n        }\n\n        Start-Sleep -Milliseconds 10\n    }\n    while (-not $p.HasExited)\n\n    # Capture any standard output generated between our last poll and process end.\n    while (!$p.StandardOutput.EndOfStream)\n    {\n        $stdOut.AppendLine($p.StandardOutput.ReadLine())\n    }\n\n    # Capture any error output generated between our last poll and process end.\n    while (!$p.StandardError.EndOfStream)\n    {\n        $stdErr.AppendLine($p.StandardError.ReadLine())\n    }\n\n    $p.WaitForExit()\n\n    $executionResults = [pscustomobject]@{\n        StdOut = $stdOut.ToString()\n        StdErr = $stdErr.ToString()\n        ExitCode = $p.ExitCode\n    }\n\n    return $executionResults\n\n}\n\nfunction Write-Results\n{\n    [cmdletbinding()]\n    param (\n        [Parameter(Mandatory=$True,ValuefromPipeline=$True)]\n        $results\n    )\n\n    if (![String]::IsNullOrWhiteSpace($results.StdOut))\n    {\n        Write-Verbose $results.StdOut\n    }\n}\n\nfunction Write-TerraformBackend {\n    Set-Content -Path 'backend.tf' -Value @\"\nterraform {\n        backend \"s3\" {}\n        required_providers {\n          octopusdeploy = { source = \"OctopusDeployLabs/octopusdeploy\", version = \"0.13.2\" }\n        }\n    }\n\"@\n}\n\n$username = $OctopusParameters[\"FindConflicts.Git.Credentials.Username\"]\n$password = $OctopusParameters[\"FindConflicts.Git.Credentials.Password\"]\n$protocol = $OctopusParameters[\"FindConflicts.Git.Url.Protocol\"]\n$gitHost = $OctopusParameters[\"FindConflicts.Git.Url.Host\"]\n$org = $OctopusParameters[\"FindConflicts.Git.Url.Organization\"]\n$repo = $OctopusParameters[\"FindConflicts.Git.Url.Template\"]\n$region = $OctopusParameters[\"FindConflicts.Terraform.Backend.S3Region\"]\n$key = $OctopusParameters[\"FindConflicts.Terraform.Backend.S3Key\"]\n$bucket = $OctopusParameters[\"FindConflicts.Terraform.Backend.S3Bucket\"]\n\n$templateRepoUrl = $protocol + \"://\" + $gitHost + \"/\" + $org + \"/\" + $repo + \".git\"\n$templateRepo = $protocol + \"://\" + $username + \":\" + $password + \"@\" + $gitHost + \"/\" + $org + \"/\" + $repo + \".git\"\n$branch = \"main\"\n\n# Check to see if it's Windows\nif ($IsWindows -and $OctopusParameters['Octopus.Workerpool.Name'] -eq \"Hosted Windows\")\n{\n\t# Dynamic worker don't have git, download portable version and add to path for execution\n    Write-Host \"Detected usage of Windows Dynamic Worker ...\"\n    Get-GitExecutable -WorkingDirectory $PWD\n}\n\nWrite-TerraformBackend\n\nInvoke-CustomCommand \"git\" @(\"config\", \"--global\", \"user.email\", \"octopus@octopus.com\") | Write-Results\nInvoke-CustomCommand \"git\" @(\"config\", \"--global\", \"user.name\", \"Octopus Server\") | Write-Results\n\nInvoke-CustomCommand \"terraform\" @(\"init\", \"-no-color\", \"-backend-config=`\"bucket=$bucket`\"\", \"-backend-config=`\"region=$region`\"\", \"-backend-config=`\"key=$key`\"\") | Write-Results\n\nWrite-Host \"- Up to date\"\nWrite-Host \"> Can automatically merge\"\nWrite-Host \"× Merge conflict\"\nWrite-Host \"Verbose logs contain instructions for resolving merge conflicts.\"\n\n$workspaces = Invoke-CustomCommand \"terraform\" @(\"workspace\", \"list\")\n\nWrite-Results $workspaces\n\n$parsedWorkspaces = $workspaces.StdOut.Replace(\"*\", \"\").Split(\"`n\")\n\n$downstreamCount = 0\nforeach ($workspace in $parsedWorkspaces)\n{\n    $trimmedWorkspace = $workspace.Trim()\n\n    if ($trimmedWorkspace -eq \"default\" -or $trimmedWorkspace -eq \"\")\n    {\n        continue\n    }\n\n    Write-Verbose \"Processing workspace $trimmedWorkspace\"\n\n    Invoke-CustomCommand \"terraform\" @(\"workspace\", \"select\", $trimmedWorkspace) | Write-Results\n\n    $state = Invoke-CustomCommand \"terraform\" @(\"show\", \"-json\")\n\n    # state might include sensitive values, so don't print it unless there was an error\n\n    if (-not $state.ExitCode -eq 0)\n    {\n        Write-Results $state\n        Exit 1\n    }\n\n    $parsedState = $state.StdOut | ConvertFrom-Json\n\n    $resources = $parsedState.values.root_module.resources | Where-Object {\n        $_.type -eq \"octopusdeploy_project\"\n    }\n\n    # The outputs allow us to contact the downstream instance)\n    $spaceId = Invoke-CustomCommand \"terraform\" @(\"output\", \"-raw\", \"octopus_space_id\")\n    $spaceName = Invoke-CustomCommand \"terraform\" @(\"output\", \"-raw\", \"octopus_space_name\")\n    $space = if ([string]::IsNullOrWhitespace($spaceName.StdOut))\n    {\n        $spaceId.StdOut.Trim()\n    }\n    else\n    {\n        $spaceName.StdOut.Trim()\n    }\n\n    foreach ($resource in $resources)\n    {\n        $url = $resource.values.git_library_persistence_settings.url.Trim()\n        $spaceId = $resource.values.space_id.Trim()\n        $name = $resource.values.name.Trim()\n\n        if (-not [string]::IsNullOrWhitespace($url))\n        {\n            $downstreamCount++\n\n            mkdir $trimmedWorkspace | Out-Null\n\n            Invoke-CustomCommand \"git\" @(\"clone\", $url, $trimmedWorkspace) | Write-Results\n            Invoke-CustomCommand \"git\" @(\"remote\", 'add', 'upstream', $templateRepo) $trimmedWorkspace | Write-Results\n            Invoke-CustomCommand \"git\" @(\"fetch\", \"--all\") $trimmedWorkspace | Write-Results\n            Invoke-CustomCommand \"git\" @(\"checkout\", \"-b\", \"upstream-$branch\", \"upstream/$branch\") $trimmedWorkspace | Write-Results\n\n            if (-not($branch -eq \"master\" -or $branch -eq \"main\"))\n            {\n                Invoke-CustomCommand \"git\" @(\"checkout\", \"-b\", $branch, \"origin/$branch\") $trimmedWorkspace | Write-Results\n            }\n            else\n            {\n                Invoke-CustomCommand \"git\" @(\"checkout\", $branch) $trimmedWorkspace | Write-Results\n            }\n\n            $mergeBase = Invoke-CustomCommand \"git\" @(\"merge-base\", $branch, \"upstream-$branch\") $trimmedWorkspace\n\n            Write-Results $mergeBase\n\n            $mergeSourceCurrentCommit = Invoke-CustomCommand \"git\" @(\"rev-parse\", \"upstream-$branch\") $trimmedWorkspace\n\n            Write-Results $mergeSourceCurrentCommit\n\n            $mergeResult = Invoke-CustomCommand \"git\" @(\"merge\", \"--no-commit\", \"--no-ff\", \"upstream-$branch\") $trimmedWorkspace\n\n            Write-Results $mergeResult\n\n            if ($mergeBase.StdOut -eq $mergeSourceCurrentCommit.StdOut)\n            {\n                Write-Host \"$space `\"$name`\" $url -\"\n            }\n            elseif (-not$mergeResult.ExitCode -eq 0)\n            {\n                Write-Host \"$space `\"$name`\" $url ×\"\n                Write-Verbose \"To resolve the conflicts, run the following commands:\"\n                Write-Verbose \"mkdir cac\"\n                Write-Verbose \"cd cac\"\n                Write-Verbose \"git clone $url .\"\n                Write-Verbose \"git remote add upstream $templateRepoUrl\"\n                Write-Verbose \"git fetch --all\"\n                Write-Verbose \"git checkout -b upstream-$branch upstream/$branch\"\n                if (-not($branch -eq \"master\" -or $branch -eq \"main\"))\n                {\n                    Write-Verbose \"git checkout -b $branch origin/$branch\"\n                }\n                else\n                {\n                    Write-Verbose \"git checkout $branch\"\n                    Write-Verbose \"git merge-base $branch upstream-$branch\"\n                    Write-Verbose \"git merge --no-commit --no-ff upstream-$branch\"\n                }\n            }\n            else\n            {\n                Write-Host \"$space `\"$name`\" $url >\"\n            }\n        }\n        else {\n            Write-Verbose \"`\"$name`\" is not a CaC project\"\n        }\n    }\n}",
+    "Octopus.Action.Aws.Region": "#{FindConflicts.Terraform.Backend.S3Region}",
+    "Octopus.Action.AwsAccount.Variable": "#{FindConflicts.Terraform.Aws.Account}"
+  },
+  "Parameters": [
+    {
+      "Id": "1eea75a0-74c7-4af9-8569-a9e9ece1bd55",
+      "Name": "FindConflicts.Git.Credentials.Username",
+      "Label": "Git Username",
+      "HelpText": "The git repo username. When using GitHub with an access token, the value is `x-access-token`.",
+      "DefaultValue": "x-access-token",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1cf36824-079a-4cf1-b67c-36f07933f642",
+      "Name": "FindConflicts.Git.Credentials.Password",
+      "Label": "Git Password",
+      "HelpText": "The git repo password or access token.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e6a7414d-8d84-4fb8-9149-2a87f20502bf",
+      "Name": "FindConflicts.Git.Url.Protocol",
+      "Label": "Git Protocol",
+      "HelpText": "The git repo protocol.",
+      "DefaultValue": "https",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "https|HTTPS\nhttp|HTTP"
+      }
+    },
+    {
+      "Id": "f5d0d829-ef6c-4e06-b115-7b2845339544",
+      "Name": "FindConflicts.Git.Url.Host",
+      "Label": "Git Hostname",
+      "HelpText": "The git repo host name.",
+      "DefaultValue": "github.com",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8b6e78e2-07fa-4783-9f9a-c23f5295f146",
+      "Name": "FindConflicts.Git.Url.Organization",
+      "Label": "Git Organization",
+      "HelpText": "The git repo owner or organization i.e. `owner` in the url `https://github.com/owner/repo`.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1e99c543-9e80-41b2-9384-8cbefd5c3ee6",
+      "Name": "FindConflicts.Git.Url.Template",
+      "Label": "Git Template Repo",
+      "HelpText": "The repo holding the upstream, or template, CaC project i.e. `repo` in the url `https://github.com/owner/repo`.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b0131561-4928-4dfb-85a9-a1282ac4a1be",
+      "Name": "FindConflicts.Terraform.Backend.S3Region",
+      "Label": "AWS Region",
+      "HelpText": "The AWS region hosting the S3 bucket persisting the Terraform state.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "652fa73d-99fa-4c81-9ef8-2e79d985222d",
+      "Name": "FindConflicts.Terraform.Backend.S3Key",
+      "Label": "S3 Key",
+      "HelpText": "The name of the file in the S3 bucket hosting the Terraform state.",
+      "DefaultValue": "Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "7102a4ab-0f05-4b97-be26-8361b23df361",
+      "Name": "FindConflicts.Terraform.Backend.S3Bucket",
+      "Label": "S3 Bucket",
+      "HelpText": "The name of the S3 bucket hosting the Terraform state.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "7015ee07-f265-41d4-863a-d1f13fcfbc68",
+      "Name": "FindConflicts.Terraform.Aws.Account",
+      "Label": "AWS Account",
+      "HelpText": "The AWS account used to access the S3 bucket.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.AwsRunScript",
+  "$Meta": {
+    "ExportedAt": "2023-11-16T20:09:13.659Z",
+    "OctopusVersion": "2024.1.1838",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
+}


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

This PR adds a step that displays the differences between downstream and upstream CaC projects. This is part of the enterprise patterns strategy.

# Results

![image](https://github.com/OctopusDeploy/Library/assets/160104/6835b491-6cd4-48e3-9e0f-ad1caa2aef03)


# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
