### PR TITLE
Update microsoft-teams-post-a-message.json

### DIFF
--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -3,7 +3,7 @@
   "Name": "Microsoft Teams - Post a message",
   "Description": "Posts a message to Microsoft Teams using a general webhook.",
   "ActionType": "Octopus.Script",
-  "Version": 23,
+  "Version": 24,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -56,7 +56,7 @@
       "Id": "2d51e4e8-1f81-444f-934f-21a3051e7423",
       "Name": "Timeout",
       "Label": "Timeout in seconds",
-      "HelpText": "The maximum timout in seconds for each request.",
+      "HelpText": "The maximum timeout in seconds for each request.",
       "DefaultValue": "60",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"


### PR DESCRIPTION
fix typo in Timeout HelpText

---

# Background

<!-- Why does this PR exist? -->

# Results

<!-- Describe the result of the change -->

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
