### PR TITLE
Update deployment process

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -194,7 +194,9 @@ step "confirm-changes-on-staging-slot" {
         properties = {
             Octopus.Action.Manual.BlockConcurrentDeployments = "True"
             Octopus.Action.Manual.Instructions = <<-EOT
-                Confirm the changes in this release on [Staging](https://library-prod-webapp-staging.azurewebsites.net/)
+                Confirm the changes in this release on [Staging](https://library-prod-webapp-staging.azurewebsites.net/).
+                
+                If you get an error, try running the `Restart Azure web app - Staging Slot` runbook.
                 
                 ### Release notes
                 


### PR DESCRIPTION
Sometimes the staging slot fails to load correctly. This PR adds instructions to the deployment process to let people know there is a runbook that can be run to solve the issue.
