### PR TITLE
Add Azure octoterra Terraform steps

### DIFF
--- a/step-templates/octopus-add-runbook-to-project-azure.json
+++ b/step-templates/octopus-add-runbook-to-project-azure.json
@@ -134,7 +134,7 @@
     {
       "Id": "7c816136-7917-4b7d-9a5a-580c6466c713",
       "Name": "OctoterraApply.Azure.Storage.Container",
-      "Label": "Azure Stroage Container",
+      "Label": "Azure Storage Container",
       "HelpText": "The name of the Azure storage account container used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
       "DefaultValue": "",
       "DisplaySettings": {

--- a/step-templates/octopus-add-runbook-to-project-azure.json
+++ b/step-templates/octopus-add-runbook-to-project-azure.json
@@ -178,6 +178,6 @@
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
 }

--- a/step-templates/octopus-add-runbook-to-project-azure.json
+++ b/step-templates/octopus-add-runbook-to-project-azure.json
@@ -145,7 +145,7 @@
       "Id": "b793155e-76c5-4781-a075-d1c5182c3b5f",
       "Name": "OctoterraApply.Azure.Storage.Key",
       "Label": "Azure Storage Key",
-      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the runbook and a prefix to indicate the type of resource: `Runbook_#{Octopus.Action.Package.PackageId}`.",
+      "HelpText": "The file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the runbook and a prefix to indicate the type of resource: `Runbook_#{Octopus.Action.Package.PackageId}`.",
       "DefaultValue": "Runbook_#{Octopus.Action.Package.PackageId}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"

--- a/step-templates/octopus-add-runbook-to-project-azure.json
+++ b/step-templates/octopus-add-runbook-to-project-azure.json
@@ -1,0 +1,183 @@
+{
+  "Id": "9b206752-5a8c-40dd-84a8-94f08a42955c",
+  "Name": "Octopus - Add Runbook to Project (Azure Backend)",
+  "Description": "This step exposes the fields required to deploy a runbook serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform to a project.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "ActionType": "Octopus.TerraformApply",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "093b1515-15a9-4446-8dc2-6297018a77e7",
+      "Name": "",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "SelectionMode": "deferred",
+        "PackageParameterName": "OctoterraApply.Terraform.Package.Id"
+      }
+    }
+  ],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "False",
+    "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
+    "Octopus.Action.Terraform.GoogleCloudAccount": "False",
+    "Octopus.Action.Terraform.AzureAccount": "True",
+    "Octopus.Action.Terraform.ManagedAccount": "None",
+    "Octopus.Action.Terraform.AllowPluginDownloads": "True",
+    "Octopus.Action.Script.ScriptSource": "Package",
+    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "False",
+    "Octopus.Action.Terraform.PlanJsonOutput": "False",
+    "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
+    "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"resource_group_name=#{OctoterraApply.Azure.Storage.ResourceGroup}\" -backend-config=\"storage_account_name=#{OctoterraApply.Azure.Storage.AccountName}\" -backend-config=\"container_name=#{OctoterraApply.Azure.Storage.Container}\" -backend-config=\"key=#{OctoterraApply.Azure.Storage.Key}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} -var=octopus_space_id=#{OctoterraApply.Octopus.SpaceID} \"-var=parent_project_name=#{OctoterraApply.Octopus.Project}\" #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Package.DownloadOnTentacle": "False",
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.Terraform.TemplateDirectory": "space_population",
+    "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf",
+    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Account"
+  },
+  "Parameters": [
+    {
+      "Id": "78dee77f-10a8-465c-9134-cda7edb6e794",
+      "Name": "OctoterraApply.Terraform.Workspace.Name",
+      "Label": "Terraform Workspace",
+      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}`. Leave this as the default value unless you have a specific reason to change it.",
+      "DefaultValue": "#{OctoterraApply.Octopus.SpaceID}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6c05bc2b-1326-4e6b-a6ea-16d09d6a6abe",
+      "Name": "OctoterraApply.Terraform.Package.Id",
+      "Label": "Terraform Module Package",
+      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_population` directory.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "ecadd361-bdf6-45d5-92bb-2dba7ebf4163",
+      "Name": "OctoterraApply.Octopus.ServerUrl",
+      "Label": "Octopus Server URL",
+      "HelpText": "The Octopus server URL.",
+      "DefaultValue": "#{Octopus.Web.ServerUri}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "c43aff0c-1321-42d6-a08b-a22426239e30",
+      "Name": "OctoterraApply.Octopus.ApiKey",
+      "Label": "Octopus API key",
+      "HelpText": "The Octopus API key. See the [documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating an API key.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "4b669ef2-11e3-4ead-b613-60b9832ec23e",
+      "Name": "OctoterraApply.Octopus.SpaceID",
+      "Label": "Octopus Space ID",
+      "HelpText": "The Space ID to deploy the Terraform module into. The [Octopus - Lookup Space ID](https://library.octopus.com/step-templates/324f747e-e2cd-439d-a660-774baf4991f2/actiontemplate-octopus-lookup-space-id) step can be used to convert a space name to an ID.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b54953d9-a441-485c-97f8-937ba0e77c32",
+      "Name": "OctoterraApply.Octopus.Project",
+      "Label": "Octopus Project Name",
+      "HelpText": "The name of the project to import the runbook into",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f827567a-9807-4d3a-b16e-2845112d1873",
+      "Name": "OctoterraApply.Azure.Account",
+      "Label": "Azure Account Variable",
+      "HelpText": "The Azure account variable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AzureAccount"
+      }
+    },
+    {
+      "Id": "b2d855be-4f8f-4c7c-9e28-49c5539c1df5",
+      "Name": "OctoterraApply.Azure.Storage.ResourceGroup",
+      "Label": "Azure Backend Resource Group",
+      "HelpText": "The name of the resource group holding the Azure storage account. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d3098333-99ac-463f-83eb-f66aca3d1055",
+      "Name": "OctoterraApply.Azure.Storage.AccountName",
+      "Label": "Azure Storage Account Name",
+      "HelpText": "The name of the Azure storage account used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "7c816136-7917-4b7d-9a5a-580c6466c713",
+      "Name": "OctoterraApply.Azure.Storage.Container",
+      "Label": "Azure Stroage Container",
+      "HelpText": "The name of the Azure storage account container used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b793155e-76c5-4781-a075-d1c5182c3b5f",
+      "Name": "OctoterraApply.Azure.Storage.Key",
+      "Label": "Azure Storage Key",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the runbook and a prefix to indicate the type of resource: `Runbook_#{Octopus.Action.Package.PackageId}`.",
+      "DefaultValue": "Runbook_#{Octopus.Action.Package.PackageId}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "213f14e9-3856-419f-9de1-1e0e755c82db",
+      "Name": "OctoterraApply.Terraform.AdditionalApplyParams",
+      "Label": "Terraform Additional Apply Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform apply` command. This field can be left blank. See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/apply) for details on the `apply` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "24e0186c-bb65-4c77-b9d8-4f4d19523621",
+      "Name": "OctoterraApply.Terraform.AdditionalInitParams",
+      "Label": "Terraform Additional Init Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform init` command. This field can be left blank.  See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/init) for details on the `init` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.TerraformApply",
+  "$Meta": {
+    "ExportedAt": "2023-12-20T23:32:58.875Z",
+    "OctopusVersion": "2024.1.5406",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -135,7 +135,7 @@
       "Id": "e34b942b-f99b-48d1-9989-6810a2d0a71b",
       "Name": "OctoterraApply.Azure.Storage.Key",
       "Label": "Azure Storage Key",
-      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "HelpText": "The file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
       "DefaultValue": "Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -1,5 +1,5 @@
 {
-  "Id": "fabaed9d-555c-425d-9510-43c167103cb3",
+  "Id": "38bd9594-c935-49c1-a6cb-b706c1f9bbc9",
   "Name": "Octopus - Populate Octoterra Space (Azure Backend)",
   "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
@@ -135,8 +135,8 @@
       "Id": "e34b942b-f99b-48d1-9989-6810a2d0a71b",
       "Name": "OctoterraApply.Azure.Storage.Key",
       "Label": "Azure Storage Key",
-      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the space and a prefix to indicate the type of resource: `Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
-      "DefaultValue": "Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the project and a prefix to indicate the type of resource: `Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "DefaultValue": "Project_#{Octopus.Project.Name | Replace \"[^A-Za-z0-9]\" \"_\"}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
@@ -164,7 +164,7 @@
   ],
   "StepPackageId": "Octopus.TerraformApply",
   "$Meta": {
-    "ExportedAt": "2023-12-20T23:00:51.038Z",
+    "ExportedAt": "2023-12-20T23:05:24.808Z",
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -1,7 +1,7 @@
 {
   "Id": "c15be981-3138-47c8-a935-ab388b7840be",
   "Name": "Octopus - Populate Octoterra Space (Azure Backend)",
-  "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
   "Version": 1,
   "CommunityActionTemplateId": null,
@@ -168,6 +168,6 @@
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
 }

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -124,7 +124,7 @@
     {
       "Id": "514db3ac-89a7-4537-abfc-cf7bf7c6ac8c",
       "Name": "OctoterraApply.Azure.Storage.Container",
-      "Label": "Azure Stroage Container",
+      "Label": "Azure Storage Container",
       "HelpText": "The name of the Azure storage account container used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
       "DefaultValue": "",
       "DisplaySettings": {

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -1,7 +1,7 @@
 {
-  "Id": "c9c5a6a2-0ce7-4d7a-8eb5-111ac44df24e",
-  "Name": "Octopus - Create Octoterra Space (Azure Backend)",
-  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "Id": "fabaed9d-555c-425d-9510-43c167103cb3",
+  "Name": "Octopus - Populate Octoterra Space (Azure Backend)",
+  "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
   "Version": 1,
   "CommunityActionTemplateId": null,
@@ -20,7 +20,7 @@
   ],
   "GitDependencies": [],
   "Properties": {
-    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "False",
+    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "True",
     "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
     "Octopus.Action.Terraform.GoogleCloudAccount": "False",
     "Octopus.Action.Terraform.AzureAccount": "True",
@@ -31,57 +31,38 @@
     "Octopus.Action.Terraform.PlanJsonOutput": "False",
     "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
     "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"resource_group_name=#{OctoterraApply.Azure.Storage.ResourceGroup}\" -backend-config=\"storage_account_name=#{OctoterraApply.Azure.Storage.AccountName}\" -backend-config=\"container_name=#{OctoterraApply.Azure.Storage.Container}\" -backend-config=\"key=#{OctoterraApply.Azure.Storage.Key}\" #{if OctoterraApply.Terraform.AdditionalInitParams}#{OctoterraApply.Terraform.AdditionalInitParams}#{/if}",
-    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} \"-var=octopus_space_name=#{OctoterraApply.Octopus.Space.NewName}\" -var=octopus_space_managers=#{OctoterraApply.Octopus.Space.Managers} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} -var=octopus_space_id=#{OctoterraApply.Octopus.SpaceID} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
     "Octopus.Action.Package.DownloadOnTentacle": "False",
     "Octopus.Action.RunOnServer": "true",
     "Octopus.Action.AwsAccount.UseInstanceRole": "False",
     "Octopus.Action.Aws.AssumeRole": "False",
-    "Octopus.Action.Terraform.TemplateDirectory": "space_creation",
-    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Account"
+    "Octopus.Action.Terraform.TemplateDirectory": "space_population",
+    "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf",
+    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Storage.AccountName"
   },
   "Parameters": [
     {
-      "Id": "281f1167-aa9b-4061-9550-2c4a08d20256",
-      "Name": "OctoterraApply.Octopus.Space.NewName",
-      "Label": "Octopus Space Name",
-      "HelpText": "The name of the new space to create. The default value assumes that the step is run against a tenant, and the tenant name matches the space.",
-      "DefaultValue": "#{Octopus.Deployment.Tenant.Name}",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "ec7890fd-6a73-49a1-b4c4-f53e5a76e0dd",
-      "Name": "OctoterraApply.Octopus.Space.Managers",
-      "Label": "Octopus Space Managers",
-      "HelpText": "The name of a team to assign as the space manager.",
-      "DefaultValue": "teams-administrators",
-      "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
-      }
-    },
-    {
-      "Id": "ea73512f-aab0-4fdc-8381-ad37a3f31220",
+      "Id": "fc203025-f9f8-421d-a4d8-963347555a7b",
       "Name": "OctoterraApply.Terraform.Workspace.Name",
       "Label": "Terraform Workspace",
       "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}`. Leave this as the default value unless you have a specific reason to change it.",
-      "DefaultValue": "#{OctoterraApply.Octopus.Space.NewName  | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DefaultValue": "#{OctoterraApply.Octopus.SpaceID}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"
       }
     },
     {
-      "Id": "d675cd1e-4306-4b8c-91fc-7090377dc34c",
+      "Id": "f3581f20-f65f-4819-9060-aca5d0e5dc85",
       "Name": "OctoterraApply.Terraform.Package.Id",
       "Label": "Terraform Module Package",
-      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_creation` and `space_population` directories.",
+      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_population` directory.",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "Package"
       }
     },
     {
-      "Id": "1d039630-0602-4491-b906-e29b45876411",
+      "Id": "6e9b0c07-703a-4c1f-a5f6-83084fb676d8",
       "Name": "OctoterraApply.Octopus.ServerUrl",
       "Label": "Octopus Server URL",
       "HelpText": "The Octopus server URL.",
@@ -91,7 +72,7 @@
       }
     },
     {
-      "Id": "0eab90d6-c7a0-482c-a386-e254a477c291",
+      "Id": "09c3a07e-1c63-4342-8b7f-1d596cc26c11",
       "Name": "OctoterraApply.Octopus.ApiKey",
       "Label": "Octopus API key",
       "HelpText": "The Octopus API key. See the [documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating an API key.",
@@ -101,7 +82,17 @@
       }
     },
     {
-      "Id": "dd0fe15d-c377-45d2-86b8-61d326e7e411",
+      "Id": "a320bade-7813-4326-8335-b99ffe525871",
+      "Name": "OctoterraApply.Octopus.SpaceID",
+      "Label": "Octopus Space ID",
+      "HelpText": "The Space ID to deploy the Terraform module into. The [Octopus - Lookup Space ID](https://library.octopus.com/step-templates/324f747e-e2cd-439d-a660-774baf4991f2/actiontemplate-octopus-lookup-space-id) step can be used to convert a space name to an ID.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "19fef90b-d94d-4a45-8cc5-6da4925a4b23",
       "Name": "OctoterraApply.Azure.Account",
       "Label": "Azure Account Variable",
       "HelpText": "The Azure account variable.",
@@ -151,7 +142,7 @@
       }
     },
     {
-      "Id": "05715061-fda9-48b1-8bec-960b9fa56e89",
+      "Id": "eef59864-851c-4f6a-bb55-f4a58e1ca2b2",
       "Name": "OctoterraApply.Terraform.AdditionalApplyParams",
       "Label": "Terraform Additional Apply Params",
       "HelpText": "This field can be used to define additional parameters passed to the `terraform apply` command. This field can be left blank. See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/apply) for details on the `apply` command.",
@@ -161,7 +152,7 @@
       }
     },
     {
-      "Id": "e6ffdabd-5009-4e55-aab8-eeafc2291e47",
+      "Id": "dae7e399-1bdc-49c2-90d1-b7b2560b379a",
       "Name": "OctoterraApply.Terraform.AdditionalInitParams",
       "Label": "Terraform Additional Init Params",
       "HelpText": "This field can be used to define additional parameters passed to the `terraform init` command. This field can be left blank.  See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/init) for details on the `init` command.",
@@ -173,7 +164,7 @@
   ],
   "StepPackageId": "Octopus.TerraformApply",
   "$Meta": {
-    "ExportedAt": "2023-12-20T22:22:32.372Z",
+    "ExportedAt": "2023-12-20T23:00:51.038Z",
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },

--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -1,5 +1,5 @@
 {
-  "Id": "38bd9594-c935-49c1-a6cb-b706c1f9bbc9",
+  "Id": "c15be981-3138-47c8-a935-ab388b7840be",
   "Name": "Octopus - Populate Octoterra Space (Azure Backend)",
   "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
@@ -11,7 +11,7 @@
       "Name": "",
       "PackageId": null,
       "FeedId": null,
-      "AcquisitionLocation": "Server",
+      "AcquisitionLocation": null,
       "Properties": {
         "SelectionMode": "deferred",
         "PackageParameterName": "OctoterraApply.Terraform.Package.Id"
@@ -38,7 +38,7 @@
     "Octopus.Action.Aws.AssumeRole": "False",
     "Octopus.Action.Terraform.TemplateDirectory": "space_population",
     "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf",
-    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Storage.AccountName"
+    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Account"
   },
   "Parameters": [
     {
@@ -164,7 +164,7 @@
   ],
   "StepPackageId": "Octopus.TerraformApply",
   "$Meta": {
-    "ExportedAt": "2023-12-20T23:05:24.808Z",
+    "ExportedAt": "2023-12-20T23:12:15.992Z",
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },

--- a/step-templates/octopus-create-octoterra-space-azure.json
+++ b/step-templates/octopus-create-octoterra-space-azure.json
@@ -1,7 +1,7 @@
 {
   "Id": "c9c5a6a2-0ce7-4d7a-8eb5-111ac44df24e",
   "Name": "Octopus - Create Octoterra Space (Azure Backend)",
-  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (Azure Backend)` step.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
   "Version": 1,
   "CommunityActionTemplateId": null,
@@ -144,7 +144,7 @@
       "Id": "e34b942b-f99b-48d1-9989-6810a2d0a71b",
       "Name": "OctoterraApply.Azure.Storage.Key",
       "Label": "Azure Storage Key",
-      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the space and a prefix to indicate the type of resource: `Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "HelpText": "The file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the space and a prefix to indicate the type of resource: `Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
       "DefaultValue": "Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"

--- a/step-templates/octopus-create-octoterra-space-azure.json
+++ b/step-templates/octopus-create-octoterra-space-azure.json
@@ -1,0 +1,182 @@
+{
+  "Id": "c9c5a6a2-0ce7-4d7a-8eb5-111ac44df24e",
+  "Name": "Octopus - Create Octoterra Space (Azure Backend)",
+  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "ActionType": "Octopus.TerraformApply",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "093b1515-15a9-4446-8dc2-6297018a77e7",
+      "Name": "",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "SelectionMode": "deferred",
+        "PackageParameterName": "OctoterraApply.Terraform.Package.Id"
+      }
+    }
+  ],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.GoogleCloud.UseVMServiceAccount": "False",
+    "Octopus.Action.GoogleCloud.ImpersonateServiceAccount": "False",
+    "Octopus.Action.Terraform.GoogleCloudAccount": "False",
+    "Octopus.Action.Terraform.AzureAccount": "True",
+    "Octopus.Action.Terraform.ManagedAccount": "None",
+    "Octopus.Action.Terraform.AllowPluginDownloads": "True",
+    "Octopus.Action.Script.ScriptSource": "Package",
+    "Octopus.Action.Terraform.RunAutomaticFileSubstitution": "False",
+    "Octopus.Action.Terraform.PlanJsonOutput": "False",
+    "Octopus.Action.Terraform.Workspace": "#{OctoterraApply.Terraform.Workspace.Name}",
+    "Octopus.Action.Terraform.AdditionalInitParams": "-backend-config=\"resource_group_name=#{OctoterraApply.Azure.Storage.ResourceGroup}\" -backend-config=\"storage_account_name=#{OctoterraApply.Azure.Storage.AccountName}\" -backend-config=\"container_name=#{OctoterraApply.Azure.Storage.Container}\" -backend-config=\"key=#{OctoterraApply.Azure.Storage.Key}\"",
+    "Octopus.Action.Terraform.AdditionalActionParams": "-var=octopus_server=#{OctoterraApply.Octopus.ServerUrl} -var=octopus_apikey=#{OctoterraApply.Octopus.ApiKey} \"-var=octopus_space_name=#{OctoterraApply.Octopus.Space.NewName}\" -var=octopus_space_managers=#{OctoterraApply.Octopus.Space.Managers} #{if OctoterraApply.Terraform.AdditionalApplyParams}#{OctoterraApply.Terraform.AdditionalApplyParams}#{/if}",
+    "Octopus.Action.Package.DownloadOnTentacle": "False",
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.Terraform.TemplateDirectory": "space_creation",
+    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Account"
+  },
+  "Parameters": [
+    {
+      "Id": "281f1167-aa9b-4061-9550-2c4a08d20256",
+      "Name": "OctoterraApply.Octopus.Space.NewName",
+      "Label": "Octopus Space Name",
+      "HelpText": "The name of the new space to create. The default value assumes that the step is run against a tenant, and the tenant name matches the space.",
+      "DefaultValue": "#{Octopus.Deployment.Tenant.Name}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ec7890fd-6a73-49a1-b4c4-f53e5a76e0dd",
+      "Name": "OctoterraApply.Octopus.Space.Managers",
+      "Label": "Octopus Space Managers",
+      "HelpText": "The name of a team to assign as the space manager.",
+      "DefaultValue": "teams-administrators",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "ea73512f-aab0-4fdc-8381-ad37a3f31220",
+      "Name": "OctoterraApply.Terraform.Workspace.Name",
+      "Label": "Terraform Workspace",
+      "HelpText": "The name of the Terraform workspace. This must be unique for every project this module is deployed to. The default value is based on the space ID that the module is applied to: `#{OctoterraApply.Octopus.SpaceID}`. Leave this as the default value unless you have a specific reason to change it.",
+      "DefaultValue": "#{OctoterraApply.Octopus.Space.NewName  | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d675cd1e-4306-4b8c-91fc-7090377dc34c",
+      "Name": "OctoterraApply.Terraform.Package.Id",
+      "Label": "Terraform Module Package",
+      "HelpText": "The package created by [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport). It must include the `space_creation` and `space_population` directories.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "1d039630-0602-4491-b906-e29b45876411",
+      "Name": "OctoterraApply.Octopus.ServerUrl",
+      "Label": "Octopus Server URL",
+      "HelpText": "The Octopus server URL.",
+      "DefaultValue": "#{Octopus.Web.ServerUri}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "0eab90d6-c7a0-482c-a386-e254a477c291",
+      "Name": "OctoterraApply.Octopus.ApiKey",
+      "Label": "Octopus API key",
+      "HelpText": "The Octopus API key. See the [documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating an API key.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "dd0fe15d-c377-45d2-86b8-61d326e7e411",
+      "Name": "OctoterraApply.Azure.Account",
+      "Label": "Azure Account Variable",
+      "HelpText": "The Azure account variable.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AzureAccount"
+      }
+    },
+    {
+      "Id": "9442e8fb-056b-4a24-a129-adfe9726ea8d",
+      "Name": "OctoterraApply.Azure.Storage.ResourceGroup",
+      "Label": "Azure Backend Resource Group",
+      "HelpText": "The name of the resource group holding the Azure storage account. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "d3098333-99ac-463f-83eb-f66aca3d1055",
+      "Name": "OctoterraApply.Azure.Storage.AccountName",
+      "Label": "Azure Storage Account Name",
+      "HelpText": "The name of the Azure storage account used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "514db3ac-89a7-4537-abfc-cf7bf7c6ac8c",
+      "Name": "OctoterraApply.Azure.Storage.Container",
+      "Label": "Azure Stroage Container",
+      "HelpText": "The name of the Azure storage account container used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e34b942b-f99b-48d1-9989-6810a2d0a71b",
+      "Name": "OctoterraApply.Azure.Storage.Key",
+      "Label": "Azure Storage Key",
+      "HelpText": "The S3 file used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/s3) for details on using S3 as a backend. The combination of the workspace name and this key must be unique. \n\nThe default value is the name of the space and a prefix to indicate the type of resource: `Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}`.",
+      "DefaultValue": "Space_#{OctoterraApply.Octopus.Space.NewName | Replace \"[^A-Za-z0-9]\" \"_\"}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "05715061-fda9-48b1-8bec-960b9fa56e89",
+      "Name": "OctoterraApply.Terraform.AdditionalApplyParams",
+      "Label": "Terraform Additional Apply Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform apply` command. This field can be left blank. See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/apply) for details on the `apply` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e6ffdabd-5009-4e55-aab8-eeafc2291e47",
+      "Name": "OctoterraApply.Terraform.AdditionalInitParams",
+      "Label": "Terraform Additional Init Params",
+      "HelpText": "This field can be used to define additional parameters passed to the `terraform init` command. This field can be left blank.  See the [Terraform documentation](https://developer.hashicorp.com/terraform/cli/commands/init) for details on the `init` command.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.TerraformApply",
+  "$Meta": {
+    "ExportedAt": "2023-12-20T22:22:32.372Z",
+    "OctopusVersion": "2024.1.5406",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "Your GitHub Username",
+  "Category": "other"
+}

--- a/step-templates/octopus-create-octoterra-space-azure.json
+++ b/step-templates/octopus-create-octoterra-space-azure.json
@@ -133,7 +133,7 @@
     {
       "Id": "514db3ac-89a7-4537-abfc-cf7bf7c6ac8c",
       "Name": "OctoterraApply.Azure.Storage.Container",
-      "Label": "Azure Stroage Container",
+      "Label": "Azure Storage Container",
       "HelpText": "The name of the Azure storage account container used to hold the Terraform state. See the [Terraform documentation](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm) for details on using Azure storage accounts as a backend.",
       "DefaultValue": "",
       "DisplaySettings": {

--- a/step-templates/octopus-create-octoterra-space-azure.json
+++ b/step-templates/octopus-create-octoterra-space-azure.json
@@ -1,7 +1,7 @@
 {
   "Id": "c9c5a6a2-0ce7-4d7a-8eb5-111ac44df24e",
   "Name": "Octopus - Create Octoterra Space (Azure Backend)",
-  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
+  "Description": "This step exposes the fields required to create the initial blank space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform. The new space is then populated using the `Octopus - Populate Octoterra Space (S3 Backend)` step.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
   "Version": 1,
   "CommunityActionTemplateId": null,
@@ -177,6 +177,6 @@
     "OctopusVersion": "2024.1.5406",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "Your GitHub Username",
-  "Category": "other"
+  "LastModifiedBy": "mcasperson",
+  "Category": "octopus"
 }


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

This PR adds Azure versions of the octoterra terrafrom apply steps that currently exist for S3:

* Octopus - Create Octoterra Space (Azure Backend)
* Octopus - Populate Octoterra Space (Azure Backend)
* Octopus - Add Runbook to Project (Azure Backend)

# Results

![image](https://github.com/OctopusDeploy/Library/assets/160104/95a1c413-1500-4ed5-95df-2196f2c2052e)


# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it