### PR TITLE
Add Octolint a Space step

### DIFF
--- a/step-templates/octopus-octolint-a-space.json
+++ b/step-templates/octopus-octolint-a-space.json
@@ -1,0 +1,57 @@
+{
+    "Id": "48e2b213-324a-43be-8fa1-f8e08a2bb547",
+    "Name": "Octolint a Space",
+    "Description": "Run the [octolint tool](https://github.com/OctopusSolutionsEngineering/OctopusRecommendationEngine) against a Space to get a usage recommendation report.\n\nThis step requires a worker or execution container that has docker installed.",
+    "ActionType": "Octopus.Script",
+    "Version": 1,
+    "CommunityActionTemplateId": null,
+    "Packages": [],
+    "GitDependencies": [],
+    "Properties": {
+      "Octopus.Action.RunOnServer": "true",
+      "Octopus.Action.Script.ScriptSource": "Inline",
+      "Octopus.Action.Script.Syntax": "PowerShell",
+      "Octopus.Action.Script.ScriptBody": "$server = $OctopusParameters[\"Octolint.Octopus.ServerUri\"]\n$apiKey = $OctopusParameters[\"Octolint.Octopus.ApiKey\"]\n$spaceName = $OctopusParameters[\"Octolint.Octopus.SpaceName\"]\n\ndocker pull octopussamples/octolint\ndocker run --rm octopussamples/octolint -url \"$server\" -apiKey \"$apiKey\" -space \"$spaceName\" -verboseErrors"
+    },
+    "Parameters": [
+      {
+        "Id": "5d03c192-1126-4912-986e-799098fcf4a7",
+        "Name": "Octolint.Octopus.ServerUri",
+        "Label": "Octopus Server URI",
+        "HelpText": "The URI of the Octopus Server. For use on the same server, #{Octopus.Web.ServerUri} will work.",
+        "DefaultValue": "#{Octopus.Web.ServerUri}",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      },
+      {
+        "Id": "58392cba-5d54-4ba1-9447-388b0bc439fb",
+        "Name": "Octolint.Octopus.ApiKey",
+        "Label": "Octopus Server API Key",
+        "HelpText": "The API key with [read permissions](https://github.com/OctopusSolutionsEngineering/OctopusRecommendationEngine#permissions) to the space being linted.",
+        "DefaultValue": "",
+        "DisplaySettings": {
+          "Octopus.ControlType": "Sensitive"
+        }
+      },
+      {
+        "Id": "b51e59f4-86ca-423d-87a0-f29faa1cd159",
+        "Name": "Octolint.Octopus.SpaceName",
+        "Label": "Octopus Space Name",
+        "HelpText": "The name of the Space being linted.",
+        "DefaultValue": "#{Octopus.Space.Name}",
+        "DisplaySettings": {
+          "Octopus.ControlType": "SingleLineText"
+        }
+      }
+    ],
+    "StepPackageId": "Octopus.Script",
+    "$Meta": {
+      "ExportedAt": "2024-01-12T16:25:50.307Z",
+      "OctopusVersion": "2024.1.6809",
+      "Type": "ActionTemplate"
+    },
+    "Author": "ryanrousseau",
+    "LastModifiedBy": "ryanrousseau",
+    "Category": "octopus"
+  }


### PR DESCRIPTION
# Background

To create a step template Octopus users can use to run Octolint within their instance.

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

