### PR TITLE
Update worker pool

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -14,7 +14,7 @@ step "notify-octopus-library-on-slack" {
             ssn_IconUrl = "http://octopusdeploy.com/content/resources/favicon.png"
             ssn_Message = <<-EOT
                 Release `#{Octopus.Release.Number}` to *#{Octopus.Environment.Name}*
-
+                
                 #{if Octopus.Release.Notes}
                 *Release notes*
                 ```#{Octopus.Release.Notes}```
@@ -46,7 +46,7 @@ step "clear-staging-slot" {
             Octopus.Action.Script.ScriptBody = <<-EOT
                 #Remove the staging slot if it exists
                 Remove-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
-
+                
                 #Create the staging slot
                 New-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging
                 EOT
@@ -67,10 +67,10 @@ step "clear-staging-slot-az" {
             Octopus.Action.Script.ScriptBody = <<-EOT
                 #Remove the staging slot if it exists
                 Remove-AzWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
-
+                
                 #Create the staging slot
                 New-AzWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging
-
+                
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
@@ -106,11 +106,11 @@ step "deploy-octopus-library" {
             Octopus.Action.SubstituteInFiles.TargetFiles = "views\\index.pug"
             OctopusUseBundledTooling = "False"
         }
-        worker_pool = "hosted-ubuntu"
+        worker_pool = "hosted-windows"
 
         container {
             feed = "registered-dockerhub"
-            image = "octopusdeploy/worker-tools:ubuntu.22.04"
+            image = "octopusdeploy/worker-tools:windows.ltsc2022"
         }
 
         packages {
@@ -191,15 +191,15 @@ step "notify-octopus-library-of-manual-intervention" {
             ssn_IconUrl = "http://octopusdeploy.com/content/resources/favicon.png"
             ssn_Message = <<-EOT
                 Confirm the changes in this release on https://library-prod-webapp-staging.azurewebsites.net/
-
+                
                 #{if Octopus.Release.Notes}
                 *Release notes*
-
+                
                 ```
                 #{Octopus.Release.Notes}
                 ```
                 #{/if}
-
+                
                 <#{Octopus.Web.ServerUri}#{Octopus.Web.DeploymentLink}|Action manual intervention>
                 EOT
             ssn_Title = "Confirm changes on Staging slot"
@@ -224,11 +224,11 @@ step "confirm-changes-on-staging-slot" {
             Octopus.Action.Manual.BlockConcurrentDeployments = "True"
             Octopus.Action.Manual.Instructions = <<-EOT
                 Confirm the changes in this release on [Staging](https://library-prod-webapp-staging.azurewebsites.net/).
-
+                
                 If you get an error, try running the `Restart Azure web app - Staging Slot` runbook.
-
+                
                 ### Release notes
-
+                
                 #{Octopus.Release.Notes}
                 EOT
             Octopus.Action.RunOnServer = "false"
@@ -332,7 +332,7 @@ step "github-clean-vnext-milestone" {
             Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
+                
                 $githubUri = "https://api.github.com"
                 $githubHeaders = @{
                         Authorization = 'Basic ' + [Convert]::ToBase64String(
@@ -340,8 +340,8 @@ step "github-clean-vnext-milestone" {
                         );
                 }
                 $issuesUri = "$githubUri/repos/$GitHubOwner/$GitHubRepository/issues"
-
-
+                
+                
                 $issueRequest = @{
                     "state" = "closed";
                     "milestone" = "*"
@@ -353,7 +353,7 @@ step "github-clean-vnext-milestone" {
                     Headers = $githubHeaders;
                     ContentType = 'application/json';
                 }
-
+                
                 $closedIssues = Invoke-RestMethod @closedIssuesRequest
                 $closedIssues | % {
                     $issueNumber = $_.number
@@ -368,7 +368,7 @@ step "github-clean-vnext-milestone" {
                         ContentType = 'application/json';
                         Body = (ConvertTo-Json $issueUpdate -Compress)
                     }
-
+                
                     try
                     {
                         $response = Invoke-RestMethod @issueUpdateRequest
@@ -378,7 +378,7 @@ step "github-clean-vnext-milestone" {
                         break
                     }
                 }
-
+                
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -14,7 +14,7 @@ step "notify-octopus-library-on-slack" {
             ssn_IconUrl = "http://octopusdeploy.com/content/resources/favicon.png"
             ssn_Message = <<-EOT
                 Release `#{Octopus.Release.Number}` to *#{Octopus.Environment.Name}*
-                
+
                 #{if Octopus.Release.Notes}
                 *Release notes*
                 ```#{Octopus.Release.Notes}```
@@ -46,7 +46,7 @@ step "clear-staging-slot" {
             Octopus.Action.Script.ScriptBody = <<-EOT
                 #Remove the staging slot if it exists
                 Remove-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
-                
+
                 #Create the staging slot
                 New-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging
                 EOT
@@ -67,10 +67,10 @@ step "clear-staging-slot-az" {
             Octopus.Action.Script.ScriptBody = <<-EOT
                 #Remove the staging slot if it exists
                 Remove-AzWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
-                
+
                 #Create the staging slot
                 New-AzWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging
-                
+
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
@@ -191,15 +191,15 @@ step "notify-octopus-library-of-manual-intervention" {
             ssn_IconUrl = "http://octopusdeploy.com/content/resources/favicon.png"
             ssn_Message = <<-EOT
                 Confirm the changes in this release on https://library-prod-webapp-staging.azurewebsites.net/
-                
+
                 #{if Octopus.Release.Notes}
                 *Release notes*
-                
+
                 ```
                 #{Octopus.Release.Notes}
                 ```
                 #{/if}
-                
+
                 <#{Octopus.Web.ServerUri}#{Octopus.Web.DeploymentLink}|Action manual intervention>
                 EOT
             ssn_Title = "Confirm changes on Staging slot"
@@ -224,11 +224,11 @@ step "confirm-changes-on-staging-slot" {
             Octopus.Action.Manual.BlockConcurrentDeployments = "True"
             Octopus.Action.Manual.Instructions = <<-EOT
                 Confirm the changes in this release on [Staging](https://library-prod-webapp-staging.azurewebsites.net/).
-                
+
                 If you get an error, try running the `Restart Azure web app - Staging Slot` runbook.
-                
+
                 ### Release notes
-                
+
                 #{Octopus.Release.Notes}
                 EOT
             Octopus.Action.RunOnServer = "false"
@@ -332,7 +332,7 @@ step "github-clean-vnext-milestone" {
             Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-                
+
                 $githubUri = "https://api.github.com"
                 $githubHeaders = @{
                         Authorization = 'Basic ' + [Convert]::ToBase64String(
@@ -340,8 +340,8 @@ step "github-clean-vnext-milestone" {
                         );
                 }
                 $issuesUri = "$githubUri/repos/$GitHubOwner/$GitHubRepository/issues"
-                
-                
+
+
                 $issueRequest = @{
                     "state" = "closed";
                     "milestone" = "*"
@@ -353,7 +353,7 @@ step "github-clean-vnext-milestone" {
                     Headers = $githubHeaders;
                     ContentType = 'application/json';
                 }
-                
+
                 $closedIssues = Invoke-RestMethod @closedIssuesRequest
                 $closedIssues | % {
                     $issueNumber = $_.number
@@ -368,7 +368,7 @@ step "github-clean-vnext-milestone" {
                         ContentType = 'application/json';
                         Body = (ConvertTo-Json $issueUpdate -Compress)
                     }
-                
+
                     try
                     {
                         $response = Invoke-RestMethod @issueUpdateRequest
@@ -378,7 +378,7 @@ step "github-clean-vnext-milestone" {
                         break
                     }
                 }
-                
+
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"


### PR DESCRIPTION

---

# Background

Fixing Octopus Library build process.

# Results

<!-- Describe the result of the change -->

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
