### PR TITLE
Updates to Library deployment to use new azure app service step

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -32,8 +32,8 @@ step "notify-octopus-library-on-slack" {
     }
 }
 
-step "clear-staging-slot-az" {
-    name = "Clear Staging slot - az"
+step "clear-staging-slot" {
+    name = "Clear Staging slot"
 
     action {
         action_type = "Octopus.AzurePowerShell"
@@ -212,8 +212,8 @@ step "confirm-changes-on-staging-slot" {
     }
 }
 
-step "swap-staging-slot-to-production-az" {
-    name = "Swap Staging slot to Production  - az"
+step "swap-staging-slot-to-production" {
+    name = "Swap Staging slot to Production"
 
     action {
         action_type = "Octopus.AzurePowerShell"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -115,8 +115,14 @@ step "deploy-octopus-library-new-app-service-step" {
             Octopus.Action.Package.FeedId = "octopus-server-built-in"
             Octopus.Action.Package.PackageId = "Octopus.Library"
             Octopus.Action.SubstituteInFiles.TargetFiles = "views\\index.pug"
+            OctopusUseBundledTooling = "False"
         }
         worker_pool = "hosted-windows"
+
+        container {
+            feed = "registered-dockerhub"
+            image = "octopusdeploy/worker-tools:windows.ltsc2022"
+        }
 
         packages {
             acquisition_location = "Server"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -32,30 +32,6 @@ step "notify-octopus-library-on-slack" {
     }
 }
 
-step "clear-staging-slot" {
-    condition = "Always"
-    name = "Clear Staging slot"
-    start_trigger = "StartWithPrevious"
-
-    action "clear-staging-slot-1" {
-        action_type = "Octopus.AzurePowerShell"
-        is_disabled = true
-        properties = {
-            Octopus.Action.Azure.AccountId = "team-steps-production-service-principal"
-            Octopus.Action.RunOnServer = "false"
-            Octopus.Action.Script.ScriptBody = <<-EOT
-                #Remove the staging slot if it exists
-                Remove-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
-                
-                #Create the staging slot
-                New-AzureRmWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging
-                EOT
-            Octopus.Action.Script.ScriptSource = "Inline"
-            Octopus.Action.Script.Syntax = "PowerShell"
-        }
-    }
-}
-
 step "clear-staging-slot-az" {
     name = "Clear Staging slot - az"
 
@@ -232,22 +208,6 @@ step "confirm-changes-on-staging-slot" {
                 #{Octopus.Release.Notes}
                 EOT
             Octopus.Action.RunOnServer = "false"
-        }
-    }
-}
-
-step "swap-staging-slot-to-production" {
-    name = "Swap Staging slot to Production"
-
-    action "swap-staging-slot-to-production-1" {
-        action_type = "Octopus.AzurePowerShell"
-        is_disabled = true
-        properties = {
-            Octopus.Action.Azure.AccountId = "team-steps-production-service-principal"
-            Octopus.Action.RunOnServer = "false"
-            Octopus.Action.Script.ScriptBody = "Switch-AzureRmWebAppSlot -SourceSlotName Staging -DestinationSlotName Production -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName}"
-            Octopus.Action.Script.ScriptSource = "Inline"
-            Octopus.Action.Script.Syntax = "PowerShell"
         }
     }
 }

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -4,7 +4,6 @@ step "notify-octopus-library-on-slack" {
 
     action "notify-octopus-library-on-slack-1" {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-404"
             Octopus.Action.Template.Version = "12"
             OctopusUseBundledTooling = "False"
@@ -39,7 +38,6 @@ step "clear-staging-slot" {
         action_type = "Octopus.AzurePowerShell"
         properties = {
             Octopus.Action.Azure.AccountId = "team-steps-production-service-principal"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 #Remove the staging slot if it exists
                 Remove-AzWebAppSlot -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName} -Slot Staging -Force
@@ -69,6 +67,7 @@ step "deploy-octopus-library" {
 
     action "deploy-octopus-library-1" {
         action_type = "Octopus.AzureWebApp"
+        is_disabled = true
         properties = {
             Octopus.Action.Azure.DeploymentSlot = "#{AzureSlotName}"
             Octopus.Action.Azure.PreserveAppData = "True"
@@ -78,7 +77,6 @@ step "deploy-octopus-library" {
             Octopus.Action.Package.DownloadOnTentacle = "False"
             Octopus.Action.Package.FeedId = "octopus-server-built-in"
             Octopus.Action.Package.PackageId = "Octopus.Library"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.SubstituteInFiles.TargetFiles = "views\\index.pug"
             OctopusUseBundledTooling = "False"
         }
@@ -108,7 +106,6 @@ step "deploy-octopus-library-new-app-service-step" {
 
     action "deploy-octopus-library-new-app-service-step-1" {
         action_type = "Octopus.AzureAppService"
-        is_disabled = true
         properties = {
             Octopus.Action.Azure.DeploymentSlot = "#{AzureSlotName}"
             Octopus.Action.Azure.DeploymentType = "Package"
@@ -116,10 +113,9 @@ step "deploy-octopus-library-new-app-service-step" {
             Octopus.Action.Package.DownloadOnTentacle = "False"
             Octopus.Action.Package.FeedId = "octopus-server-built-in"
             Octopus.Action.Package.PackageId = "Octopus.Library"
-            Octopus.Action.RunOnServer = "false"
             Octopus.Action.SubstituteInFiles.TargetFiles = "views\\index.pug"
         }
-        worker_pool_variable = ""
+        worker_pool = "hosted-windows"
 
         packages {
             acquisition_location = "Server"
@@ -137,7 +133,6 @@ step "http-invoke-url" {
 
     action "http-invoke-url-1" {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-102"
             Octopus.Action.Template.Version = "2"
             OctopusUseBundledTooling = "False"
@@ -157,7 +152,6 @@ step "notify-octopus-library-of-manual-intervention" {
 
     action "notify-octopus-library-of-manual-intervention-1" {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-404"
             Octopus.Action.Template.Version = "12"
             OctopusUseBundledTooling = "False"
@@ -219,7 +213,6 @@ step "swap-staging-slot-to-production" {
         action_type = "Octopus.AzurePowerShell"
         properties = {
             Octopus.Action.Azure.AccountId = "team-steps-production-service-principal"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = "Switch-AzWebAppSlot -SourceSlotName Staging -DestinationSlotName Production -ResourceGroupName #{AzureResourceGroupName} -Name #{AzureSiteName}"
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
@@ -240,7 +233,6 @@ step "http-invoke-url-production" {
 
     action "http-invoke-url-production-1" {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-102"
             Octopus.Action.Template.Version = "2"
             OctopusUseBundledTooling = "False"
@@ -265,7 +257,6 @@ step "github-create-release" {
             gitHubApiKey = "#{GitHubApiKey}"
             gitHubRepository = "#{GitHubRepository}"
             gitHubUsername = "#{GitHubOwner}"
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-61"
             Octopus.Action.Template.Version = "4"
             OctopusUseBundledTooling = "False"
@@ -289,7 +280,6 @@ step "github-clean-vnext-milestone" {
     action "github-clean-vnext-milestone-1" {
         action_type = "Octopus.Script"
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Script.ScriptBody = <<-EOT
                 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                 
@@ -359,7 +349,6 @@ step "notify-octopus-library-of-deployment-result" {
 
     action "notify-octopus-library-of-deployment-result-1" {
         properties = {
-            Octopus.Action.RunOnServer = "true"
             Octopus.Action.Template.Id = "ActionTemplates-404"
             Octopus.Action.Template.Version = "12"
             OctopusUseBundledTooling = "False"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -33,6 +33,7 @@ step "notify-octopus-library-on-slack" {
 
 step "clear-staging-slot" {
     name = "Clear Staging slot"
+    start_trigger = "StartWithPrevious"
 
     action {
         action_type = "Octopus.AzurePowerShell"

--- a/.octopus/schema_version.ocl
+++ b/.octopus/schema_version.ocl
@@ -1,1 +1,1 @@
-version = 6
+version = 7


### PR DESCRIPTION
Updates to the deployment process for the library:

- Removed disabled slot steps that used AzureRM cmdlets
- Renamed slot steps to remove reference to az
- Disabled the WebDeploy step and enabled the new Azure App Service step
- Allow the staging slot clear step to run in parallel with the notification step at the start
- Updated the new step to mirror the old webdeploy step to use an execution container over bundled tooling

Previously the Azure App Service step timedout after ~100 seconds when deploying. This timeout has been increased, so it'd be a good test to see if this now works. If not, we can revert [that specific commit] (c4ae4cce00d32eeed84a3749a5105615bf974d0c)