### PR TITLE
Rename old+new Library WebApp deploy steps and enable retries

### DIFF
--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -61,7 +61,7 @@ step "clear-staging-slot" {
 }
 
 step "deploy-octopus-library" {
-    name = "Deploy Octopus.Library "
+    name = "Deploy Octopus.Library via WebDeploy"
     properties = {
         Octopus.Action.TargetRoles = "octopus-library"
     }
@@ -100,7 +100,7 @@ step "deploy-octopus-library" {
 }
 
 step "deploy-octopus-library-new-app-service-step" {
-    name = "Deploy Octopus.Library (new App Service Step)"
+    name = "Deploy Octopus.Library"
     properties = {
         Octopus.Action.TargetRoles = "octopus-library"
     }
@@ -108,6 +108,7 @@ step "deploy-octopus-library-new-app-service-step" {
     action "deploy-octopus-library-new-app-service-step-1" {
         action_type = "Octopus.AzureAppService"
         properties = {
+            Octopus.Action.AutoRetry.MaximumCount = "3"
             Octopus.Action.Azure.DeploymentSlot = "#{AzureSlotName}"
             Octopus.Action.Azure.DeploymentType = "Package"
             Octopus.Action.EnabledFeatures = "Octopus.Features.JsonConfigurationVariables,Octopus.Features.ConfigurationTransforms,Octopus.Features.SubstituteInFiles"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -66,7 +66,7 @@ step "deploy-octopus-library" {
         Octopus.Action.TargetRoles = "octopus-library"
     }
 
-    action "deploy-octopus-library-1" {
+    action "deploy-octopus-library-via-webdeploy" {
         action_type = "Octopus.AzureWebApp"
         is_disabled = true
         properties = {
@@ -105,7 +105,7 @@ step "deploy-octopus-library-new-app-service-step" {
         Octopus.Action.TargetRoles = "octopus-library"
     }
 
-    action "deploy-octopus-library-new-app-service-step-1" {
+    action "deploy-octopus-library" {
         action_type = "Octopus.AzureAppService"
         properties = {
             Octopus.Action.AutoRetry.MaximumCount = "3"


### PR DESCRIPTION
Summary of changes:

1. Updates the older (currently disabled WebDeploy) step that used to deploy the Library to Azure to rename it to highlight it did the deploy via WebDeploy
2. The new step used to have the name `(new App Service Step)` added to the end, this PR removes that.
3. Enables retries on the new Azure App Service step (a couple of deploys have resulted in `409 conflict`)
4. Updates the slugs for the steps

