### PR TITLE
Simplify pester

### DIFF
--- a/step-templates/tests/Invoke-PesterTests.ps1
+++ b/step-templates/tests/Invoke-PesterTests.ps1
@@ -1,11 +1,10 @@
-$ErrorActionPreference = "Stop"
-Set-StrictMode -Version "Latest"
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
 
-# Paths for script directories
-$thisScript = $MyInvocation.MyCommand.Path
-$thisFolder = [System.IO.Path]::GetDirectoryName($thisScript)
-$rootFolder = [System.IO.Path]::GetDirectoryName($thisFolder)
-$parentFolder = [System.IO.Path]::GetDirectoryName($rootFolder)
+$thisScript = $MyInvocation.MyCommand.Path;
+$thisFolder = [System.IO.Path]::GetDirectoryName($thisScript);
+$rootFolder = [System.IO.Path]::GetDirectoryName($thisFolder);
+$parentFolder = [System.IO.Path]::GetDirectoryName($rootFolder);
 
 # Unpack any tests that are not present
 $testableScripts = Get-ChildItem -Path $thisFolder -Filter "*.ScriptBody.ps1"
@@ -17,7 +16,7 @@ foreach ($script in $testableScripts) {
         $converter = [System.IO.Path]::Combine($toolsFolder, "Converter.ps1")
         & $converter -operation unpack -searchpattern $searchpattern
     }
-    . $filename
+    . $filename;
 }
 
 # Attempt to use local Pester module, fallback to global if not found

--- a/step-templates/tests/Invoke-PesterTests.ps1
+++ b/step-templates/tests/Invoke-PesterTests.ps1
@@ -22,11 +22,13 @@ foreach ($script in $testableScripts) {
 # Attempt to use local Pester module, fallback to global if not found
 try {
     $packagesFolder = [System.IO.Path]::Combine($rootFolder, "packages")
-    Import-Module -Name ([System.IO.Path]::Combine($packagesFolder, "Pester\tools\Pester")) -ErrorAction Stop
+    $pester3Path = [System.IO.Path]::Combine($packagesFolder, "Pester\tools\Pester")
+    # Import the specific version of Pester 3.4.0
+    Import-Module -Name $pester3Path -RequiredVersion 3.4.0 -ErrorAction Stop
 } catch {
-    Write-Host "Using globally installed Pester module."
-    Import-Module Pester -ErrorAction Stop
-}
+    Write-Host "Using globally installed Pester module version 3.4.0."
+    # Specify the exact version of Pester 3.x you have installed
+    Import-Module -Name Pester -RequiredVersion 3.4.0 -ErrorAction Stop}
 
 # Find and run all Pester test files in the tests directory
 $testFiles = Get-ChildItem -Path "$thisFolder" -Filter "*.tests.ps1" -Recurse

--- a/step-templates/tests/sql-backup-database.ScriptBody.Tests.ps1
+++ b/step-templates/tests/sql-backup-database.ScriptBody.Tests.ps1
@@ -1,8 +1,7 @@
 $ErrorActionPreference = "Stop";
 Set-StrictMode -Version "Latest";
 
-# Assuming ApplyRetentionPolicy function is defined in a script file named 'ApplyRetentionPolicy.ps1'
-# . '.\ApplyRetentionPolicy.ps1'
+. "$PSScriptRoot\..\sql-backup-database.ScriptBody.ps1"
 
 function SetupTestEnvironment {
   param(

--- a/step-templates/tests/windows-scheduled-task-create.ScriptBody.Tests.ps1
+++ b/step-templates/tests/windows-scheduled-task-create.ScriptBody.Tests.ps1
@@ -1,6 +1,8 @@
 $ErrorActionPreference = "Stop";
 Set-StrictMode -Version "Latest";
 
+. "$PSScriptRoot\..\windows-scheduled-task-create.ScriptBody.ps1"
+
 Describe "Create-ScheduledTask" {
 
     Mock -CommandName "Invoke-CommandLine" `


### PR DESCRIPTION
**Background**

Previously when new test files were created, the testableScripts array needed to be modified, meaning that new tests would always generate a diff in the Invoke-PesterTests.ps1 file as well

With this small change,  Invoke-PesterTests.ps1 will just test all *.Tests.ps1 files it finds, so it should no longer need to be updated as new tests are created.

**Pre-requisites**
[✔] Id should be a GUID that is not 00000000-0000-0000-0000-000000000000
NOTE If you are modifying an existing step template, please make sure that you do not modify the Id property (updating the Id will break the Library sync functionality in Octopus).
[✔] Version should be incremented, otherwise the integration with Octopus won't update the step template correctly
[✔] Parameter names should not start with $
[✔] Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus (see https://github.com/OctopusDeploy/Issues/issues/2126). For example, use an abbreviated name of the step template or the category of the step template).
[✔] LastModifiedBy field must be present, and (optionally) updated with the correct author
[✔] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
[NA] If a new Category has been created:
[✔] An image with the name {categoryname}.png must be present under the step-templates/logos folder
[NA] The switch in the humanize function in [gulpfile.babel.js](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a case statement corresponding to it