### PR TITLE
Upgrade to use new Raygun API

### DIFF
--- a/step-templates/raygun-api-register-deployment.json
+++ b/step-templates/raygun-api-register-deployment.json
@@ -1,9 +1,9 @@
 {
-  "Id": "38dc63ed-0c93-4440-93aa-54d8cf6c29ff",
-  "Name": "Raygun - Register Deployment",
+  "Id": "bb7de751-edba-4c5f-9845-1bd1b26f6b62",
+  "Name": "Raygun API - Register Deployment",
   "Description": "Notifies [Raygun](https://raygun.com) of a deployment using their [Deployments API](https://raygun.com/documentation/product-guides/deployment-tracking/powershell/).\nSends the release number, deployer, release notes from the Octopus deployment.",
   "ActionType": "Octopus.Script",
-  "Version": 11,
+  "Version": 1,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "GitDependencies": [],
@@ -14,7 +14,7 @@
   },
   "Parameters": [
     {
-      "Id": "eb9ec822-343a-4dc5-be8e-85ef7a342258",
+      "Id": "0dd429d3-28f6-46b8-8fb7-e2ceb9124c15",
       "Name": "Raygun.ApiKey",
       "Label": "Api Key",
       "HelpText": "Raygun Application's ApiKey (the same one you use to set Raygun up within your app)",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "Id": "4f7794d2-8eac-4602-8203-812364398cd5",
+      "Id": "22d41dfb-f8f3-479d-8e72-08f456529f04",
       "Name": "Raygun.PersonalAccessToken",
       "Label": "Personal Access Token",
       "HelpText": "Personal Access Token to use from your [Raygun User Settings page](https://app.raygun.io/user).",

--- a/step-templates/raygun-register-deployment.json
+++ b/step-templates/raygun-register-deployment.json
@@ -1,19 +1,20 @@
 {
   "Id": "38dc63ed-0c93-4440-93aa-54d8cf6c29ff",
   "Name": "Raygun - Register Deployment",
-  "Description": "Notifies [Raygun](https://raygun.com) of a deployment using [Deployments API](https://raygun.com/docs/deployments/octopus-deploy).\nSends the release number, deployer, release notes from the Octopus deployment.",
+  "Description": "Notifies [Raygun](https://raygun.com) of a deployment using their [Deployments API](https://raygun.com/documentation/product-guides/deployment-tracking/powershell/).\nSends the release number, deployer, release notes from the Octopus deployment.",
   "ActionType": "Octopus.Script",
-  "Version": 10,
+  "Version": 11,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "Function Get-Parameter($Name, [switch]$Required, $Default, [switch]$FailOnValidate) {\n    $result = $null\n    $errMessage = [string]::Empty\n\n    If ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n        Write-Host \"Octopus paramter value for $Name : $result\"\n    }\n\n    If ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue\n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    If ($result -eq $null) {\n        If ($Required) {\n            $errMessage = \"Missing parameter value $Name\"\n        } Else {\n            $result = $Default\n        }\n    } \n\n    If (-Not [string]::IsNullOrEmpty($errMessage)) {\n        If ($FailOnValidate) {\n            Throw $errMessage\n        } Else {\n            Write-Warning $errMessage\n        }\n    }\n\n    return $result\n}\n\n& {\n    Write-Host \"Start AddInRaygun\"\n\n    $deploymentId = [string] (Get-Parameter \"Octopus.Release.Number\" $true [string]::Empty $true)\n    $ownerName = [string] (Get-Parameter \"Octopus.Deployment.CreatedBy.DisplayName\" $true [string]::Empty $true)\n    $emailAddress = [string] (Get-Parameter \"Octopus.Deployment.CreatedBy.EmailAddress\" $false [string]::Empty $true)\n    $comment = [string] (Get-Parameter \"Octopus.Release.Notes\" $false [string]::Empty $true)\n    $apiKey = [string] (Get-Parameter \"Raygun.ApiKey\" $true [string]::Empty $true)\n    $authToken = [string] (Get-Parameter \"Raygun.AuthToken\" $true [string]::Empty $true)\n\n    $command = ConvertTo-Json @{\n        apiKey = $apiKey\n        version = $deploymentId\n        ownerName = $ownerName\n        emailAddress = $emailAddress\n        comment = $comment\n    }\n\n    $url = \"https://app.raygun.io/deployments?authToken=\" + $authToken\n    try {\n        Invoke-RestMethod -Uri $url -Body $command -Method Post -ContentType \"application/json\"\n        Write-Host \"Added deployment in Raygun\"\n    } catch {\n        Write-Host \"Error occured when adding deployment in Raygun: \" $_\n    }\n\n    Write-Host \"End AddInRaygun\"\n}",
-    "Octopus.Action.Script.ScriptFileName": null,
-    "Octopus.Action.Package.NuGetFeedId": null,
-    "Octopus.Action.Package.NuGetPackageId": null
+    "Octopus.Action.Script.ScriptBody": "Function Get-Parameter($Name, [switch]$Required, $Default, [switch]$FailOnValidate) {\n    $result = $null\n    $errMessage = [string]::Empty\n\n    If ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n        Write-Host \"Octopus paramter value for $Name : $result\"\n    }\n\n    If ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue\n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    If ($result -eq $null) {\n        If ($Required) {\n            $errMessage = \"Missing parameter value $Name\"\n        } Else {\n            $result = $Default\n        }\n    } \n\n    If (-Not [string]::IsNullOrEmpty($errMessage)) {\n        If ($FailOnValidate) {\n            Throw $errMessage\n        } Else {\n            Write-Warning $errMessage\n        }\n    }\n\n    return $result\n}\n\n& {\n    Write-Host \"Start AddInRaygun\"\n\n    $deploymentId = [string] (Get-Parameter \"Octopus.Release.Number\" $true [string]::Empty $true)\n    $ownerName = [string] (Get-Parameter \"Octopus.Deployment.CreatedBy.DisplayName\" $true [string]::Empty $true)\n    $emailAddress = [string] (Get-Parameter \"Octopus.Deployment.CreatedBy.EmailAddress\" $false [string]::Empty $true)\n    $releaseNotes = [string] (Get-Parameter \"Octopus.Release.Notes\" $false [string]::Empty $true)\n    $personAccessToken = [string] (Get-Parameter \"Raygun.PersonalAccessToken\" $true [string]::Empty $true)\n    $apiKey = [string] (Get-Parameter \"Raygun.ApiKey\" $true [string]::Empty $true)\n    $deployedAt = Get-Date -Format \"o\"\n\n    Write-Host \"Registering deployment with Raygun\"\n\n    # Some older API keys may contain URL reserved characters (eg '/', '=', '+') and will need to be encoded.\n    # If your API key does not contain any reserved characters you can exclude the following line.\n    $urlEncodedApiKey = [System.Uri]::EscapeDataString($apiKey);\n\n    $url = \"https://api.raygun.com/v3/applications/api-key/\" + $urlEncodedApiKey + \"/deployments\"\n\n    $headers = @{\n        Authorization=\"Bearer \" + $personAccessToken\n    }\n\n    $payload = @{\n        version = $deploymentId\n        ownerName = $ownerName\n        emailAddress = $emailAddress\n        comment = $releaseNotes\n        deployedAt = $deployedAt\n    }\n\n    $payloadJson = $payload | ConvertTo-Json \n\n\n    try {\n        Invoke-RestMethod -Uri $url -Body $payloadJson -Method Post -Headers $headers -ContentType \"application/json\" -AllowInsecureRedirect\n        Write-Host \"Deployment registered with Raygun\"\n    } catch {\n        Write-Host \"Tried to send a deployment to \" $url \" with payload \" $payloadJson\n        Write-Error \"Error received when registering deployment with Raygun: $_\"\n    }\n\n    Write-Host \"End AddInRaygun\"\n}"
   },
   "Parameters": [
     {
+      "Id": "eb9ec822-343a-4dc5-be8e-85ef7a342258",
       "Name": "Raygun.ApiKey",
       "Label": "Api Key",
       "HelpText": "Raygun Application's ApiKey (the same one you use to set Raygun up within your app)",
@@ -23,20 +24,22 @@
       }
     },
     {
-      "Name": "Raygun.AuthToken",
-      "Label": "Auth Token",
-      "HelpText": "External Auth Token for your build server to use from your [Raygun User Settings page](https://app.raygun.io/user).",
+      "Id": "4f7794d2-8eac-4602-8203-812364398cd5",
+      "Name": "Raygun.PersonalAccessToken",
+      "Label": "Personal Access Token",
+      "HelpText": "Personal Access Token to use from your [Raygun User Settings page](https://app.raygun.io/user).",
       "DefaultValue": "",
       "DisplaySettings": {
-        "Octopus.ControlType": "SingleLineText"
+        "Octopus.ControlType": "Sensitive"
       }
     }
   ],
-  "LastModifiedBy": "sarbis",
+  "StepPackageId": "Octopus.Script",
   "$Meta": {
-    "ExportedAt": "2016-08-27T20:49:23.367+00:00",
-    "OctopusVersion": "3.3.16",
+    "ExportedAt": "2024-04-09T08:20:04.075Z",
+    "OctopusVersion": "2024.2.4248",
     "Type": "ActionTemplate"
   },
+  "LastModifiedBy": "benjimac93",
   "Category": "raygun"
 }


### PR DESCRIPTION
# Background

BREAKING CHANGE

The existing Raygun step has not been updated since 2016 and is using a legacy API that appears to no longer be supported. 

Prior to this update, I was unable to get the action to work.

This has meant moving to using Personal Access Tokens & changing the Parameters passed to the step template.

I can update the PR to have this as a NEW step, however, given the existing isn't working updating the existing template felt acceptable.

Raygun API docs & Powershell example I've followed can be found here: https://raygun.com/documentation/product-guides/deployment-tracking/powershell/

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [X] If a new `Category` has been created:
   - [X] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [X] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
