### PR TITLE
Speed up library page

### DIFF
--- a/app/components/TemplateItem.jsx
+++ b/app/components/TemplateItem.jsx
@@ -69,7 +69,7 @@ export default class TemplateItem extends React.Component {
         <div className="step-template">
           <div className="row clearfix">
             <div className="column two-thirds">
-              <img className="logo" src={this.state.template.Logo} loading="lazy" />
+              <img className="logo" loading="lazy" src={this.state.template.Logo} />
               <h2 className="name">{this.state.template.Name}</h2>
               <p className="who-when faint no-top-margin">
                 <i>{this.state.template.ActionType}</i> exported {moment(this.state.template.ExportedAt).calendar()} by

--- a/app/components/TemplateItem.jsx
+++ b/app/components/TemplateItem.jsx
@@ -69,7 +69,7 @@ export default class TemplateItem extends React.Component {
         <div className="step-template">
           <div className="row clearfix">
             <div className="column two-thirds">
-              <img className="logo" src={"data:image/gif;base64," + this.state.template.Logo} />
+              <img className="logo" src={this.state.template.Logo} loading="lazy" />
               <h2 className="name">{this.state.template.Name}</h2>
               <p className="who-when faint no-top-margin">
                 <i>{this.state.template.ActionType}</i> exported {moment(this.state.template.ExportedAt).calendar()} by

--- a/app/components/TemplateList.jsx
+++ b/app/components/TemplateList.jsx
@@ -26,8 +26,8 @@ export default class TemplateList extends React.Component {
       }
       let friendlySlug = SlugMaker.make(item.Name);
       return (
-        <li className={"item-summary " + item.ScriptClass} key={index + "." + item.Name}>
-          <img src={"data:image/gif;base64," + item.Logo} />
+        <li className={"item-summary " + (item.ScriptClass || "")} key={index + "." + item.Name}>
+          <img src={item.Logo} loading="lazy" />
           <h4 key={index + "." + item.Name + ".0"}>
             <Link to={`/step-templates/${item.Id}/${friendlySlug}`}>{item.Name}</Link>
           </h4>

--- a/app/components/TemplateList.jsx
+++ b/app/components/TemplateList.jsx
@@ -27,7 +27,7 @@ export default class TemplateList extends React.Component {
       let friendlySlug = SlugMaker.make(item.Name);
       return (
         <li className={"item-summary " + (item.ScriptClass || "")} key={index + "." + item.Name}>
-          <img src={item.Logo} loading="lazy" />
+          <img loading="lazy" src={item.Logo} />
           <h4 key={index + "." + item.Name + ".0"}>
             <Link to={`/step-templates/${item.Id}/${friendlySlug}`}>{item.Name}</Link>
           </h4>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -300,10 +300,8 @@ function provideMissingData() {
 
     template.Category = humanize(categoryId);
 
-    if (!template.Logo) {
-      var logo = fs.readFileSync("./step-templates/logos/" + categoryId + ".png");
-      template.Logo = Buffer.from(logo).toString("base64");
-    }
+    // Note: this deprecates base64 encoded images in the template files - they will be ignored
+    template.Logo = 'https://i.octopus.com/library/step-templates/' + categoryId + '.png';
 
     file.contents = Buffer.from(JSON.stringify(template));
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -301,7 +301,7 @@ function provideMissingData() {
     template.Category = humanize(categoryId);
 
     // Note: this deprecates base64 encoded images in the template files - they will be ignored
-    template.Logo = 'https://i.octopus.com/library/step-templates/' + categoryId + '.png';
+    template.Logo = "https://i.octopus.com/library/step-templates/" + categoryId + ".png";
 
     file.contents = Buffer.from(JSON.stringify(template));
 


### PR DESCRIPTION
We're looking at the loading time issue on library.octopus.com and think we can change the strategy for images to improve things.

This removes the inlining of images and instead refers to images on i.octopus.com.

The only templates affected are the Azure Load Balancer steps, which have specific logos rather than depending on categories.

The screenshot shows these specific images. We could create a category for these if necessary.

**Before** (production)

Server: 3,700 ms
Download: 2,370 ms

**After** (running in a GitHub code space)

Server: 483 ms
Download: 101 ms

## Before

![image](https://github.com/OctopusDeploy/Library/assets/99181436/69c61c10-c438-4729-9716-0eab69ddd653)

![image](https://github.com/OctopusDeploy/Library/assets/99181436/0c72d1e5-4b9a-461e-ba42-df918f1750b5)

## After

![image](https://github.com/OctopusDeploy/Library/assets/99181436/3929c692-d777-4e7d-9f17-fbace196b543)

![image](https://github.com/OctopusDeploy/Library/assets/99181436/7f93d595-0d6a-4bfc-930b-17ac3874a47e)



