### PR TITLE
Add step template for creating an annotation in Azure Application Insights based on Azure CLI and RBAC instead of an API Key

### DIFF
--- a/step-templates/application-insights-annotate-release-with-rbac.json
+++ b/step-templates/application-insights-annotate-release-with-rbac.json
@@ -9,13 +9,13 @@
   "GitDependencies": [],
   "Properties": {
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "# Function to decrypt data\nfunction Convert-PasswordToPlainText {\n\t$base64password = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($OctopusParameters[\"ApplicationInsightsAccount.Password\"]))\n    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64password))\n}\n\n# Function to ensure all Unicode characters in a JSON string are properly escaped\nfunction Convert-UnicodeToEscapeHex {\n  param (\n    [parameter(Mandatory = $true)][string]$JsonString\n  )\n  $JsonObject = ConvertFrom-Json -InputObject $JsonString\n  foreach ($property in $JsonObject.PSObject.Properties) {\n    $name = $property.Name\n    $value = $property.Value\n    if ($value -is [string]) {\n      $value = [regex]::Unescape($value)\n      $OutputString = \"\"\n      foreach ($char in $value.ToCharArray()) {\n        $dec = [int]$char\n        if ($dec -gt 127) {\n          $hex = [convert]::ToString($dec, 16)\n          $hex = $hex.PadLeft(4, '0')\n          $OutputString += \"\\u$hex\"\n        }\n        else {\n          $OutputString += $char\n        }\n      }\n      $JsonObject.$name = $OutputString\n    }\n  }\n  return ConvertTo-Json -InputObject $JsonObject -Compress\n}\n\n$applicationName = $OctopusParameters[\"ApplicationName\"]\n$resourceGroup = $OctopusParameters[\"ResourceGroup\"]\n$releaseName = $OctopusParameters[\"ReleaseName\"]\n$properties = $OctopusParameters[\"ReleaseProperties\"]\n\n# Authenticate via Service Principal\n$securePassword = Convert-PasswordToPlainText\n$azEnv = if($OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"]) { $OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"] } else { \"AzureCloud\" }\n\n$azEnv = Get-AzEnvironment -Name $azEnv\nif (!$azEnv) {\n\tWrite-Error \"No Azure environment could be matched given the name $($OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"])\"\n\texit -2\n}\n\nWrite-Verbose \"Authenticating with Service Principal\"\n\n# Force any output generated to be verbose in Octopus logs.\naz login --service-principal -u $OctopusParameters[\"ApplicationInsightsAccount.Client\"] -p $securePassword --tenant $OctopusParameters[\"ApplicationInsightsAccount.TenantId\"]\n\nWrite-Verbose \"Initiating the body of the annotation\"\n\n$releaseProperties = $null\n\nif ($properties -ne $null)\n{\n    $releaseProperties = ConvertFrom-StringData -StringData $properties\n}\n\n$annotation = @{\n    Id = [GUID]::NewGuid();\n    AnnotationName = $releaseName;\n    EventTime = (Get-Date).ToUniversalTime().GetDateTimeFormats(\"s\")[0];\n    Category = \"Deployment\"; #Application Insights only displays annotations from the \"Deployment\" Category\n    Properties = ConvertTo-Json $releaseProperties -Compress\n}\n\n$annotation = ConvertTo-Json $annotation -Compress\n$annotation = Convert-UnicodeToEscapeHex -JsonString $annotation  \n\n$body = $annotation -replace '(\\\\+)\"', '$1$1\"' -replace \"`\"\", \"`\"`\"\"\n\nWrite-Verbose \"Send the annotation to Application Insights\"\n\naz rest --method put --uri \"/subscriptions/$($OctopusParameters[\"ApplicationInsightsAccount.SubscriptionNumber\"])/resourceGroups/$($resourceGroup)/providers/microsoft.insights/components/$($applicationName)/Annotations?api-version=2015-05-01\" --body \"$($body) \"",
+    "Octopus.Action.Script.ScriptBody": "# Function to decrypt data\nfunction Convert-PasswordToPlainText {\n\t$base64password = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($OctopusParameters[\"AppInsights.ApplicationInsightsAccount.Password\"]))\n    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64password))\n}\n\n# Function to ensure all Unicode characters in a JSON string are properly escaped\nfunction Convert-UnicodeToEscapeHex {\n  param (\n    [parameter(Mandatory = $true)][string]$JsonString\n  )\n  $JsonObject = ConvertFrom-Json -InputObject $JsonString\n  foreach ($property in $JsonObject.PSObject.Properties) {\n    $name = $property.Name\n    $value = $property.Value\n    if ($value -is [string]) {\n      $value = [regex]::Unescape($value)\n      $OutputString = \"\"\n      foreach ($char in $value.ToCharArray()) {\n        $dec = [int]$char\n        if ($dec -gt 127) {\n          $hex = [convert]::ToString($dec, 16)\n          $hex = $hex.PadLeft(4, '0')\n          $OutputString += \"\\u$hex\"\n        }\n        else {\n          $OutputString += $char\n        }\n      }\n      $JsonObject.$name = $OutputString\n    }\n  }\n  return ConvertTo-Json -InputObject $JsonObject -Compress\n}\n\n$applicationName = $OctopusParameters[\"AppInsights.ApplicationName\"]\n$resourceGroup = $OctopusParameters[\"AppInsights.ResourceGroup\"]\n$releaseName = $OctopusParameters[\"AppInsights.ReleaseName\"]\n$properties = $OctopusParameters[\"AppInsights.ReleaseProperties\"]\n\n# Authenticate via Service Principal\n$securePassword = Convert-PasswordToPlainText\n$azEnv = if($OctopusParameters[\"AppInsights.ApplicationInsightsAccount.AzureEnvironment\"]) { $OctopusParameters[\"AppInsights.ApplicationInsightsAccount.AzureEnvironment\"] } else { \"AzureCloud\" }\n\n$azEnv = Get-AzEnvironment -Name $azEnv\nif (!$azEnv) {\n\tWrite-Error \"No Azure environment could be matched given the name $($OctopusParameters[\"AppInsights.ApplicationInsightsAccount.AzureEnvironment\"])\"\n\texit -2\n}\n\nWrite-Verbose \"Authenticating with Service Principal\"\n\n# Force any output generated to be verbose in Octopus logs.\naz login --service-principal -u $OctopusParameters[\"AppInsights.ApplicationInsightsAccount.Client\"] -p $securePassword --tenant $OctopusParameters[\"AppInsights.ApplicationInsightsAccount.TenantId\"]\n\nWrite-Verbose \"Initiating the body of the annotation\"\n\n$releaseProperties = $null\n\nif ($properties -ne $null)\n{\n    $releaseProperties = ConvertFrom-StringData -StringData $properties\n}\n\n$annotation = @{\n    Id = [GUID]::NewGuid();\n    AnnotationName = $releaseName;\n    EventTime = (Get-Date).ToUniversalTime().GetDateTimeFormats(\"s\")[0];\n    Category = \"Deployment\"; #Application Insights only displays annotations from the \"Deployment\" Category\n    Properties = ConvertTo-Json $releaseProperties -Compress\n}\n\n$annotation = ConvertTo-Json $annotation -Compress\n$annotation = Convert-UnicodeToEscapeHex -JsonString $annotation  \n\n$body = $annotation -replace '(\\\\+)\"', '$1$1\"' -replace \"`\"\", \"`\"`\"\"\n\nWrite-Verbose \"Send the annotation to Application Insights\"\n\naz rest --method put --uri \"/subscriptions/$($OctopusParameters[\"AppInsights.ApplicationInsightsAccount.SubscriptionNumber\"])/resourceGroups/$($resourceGroup)/providers/microsoft.insights/components/$($applicationName)/Annotations?api-version=2015-05-01\" --body \"$($body) \"",
     "Octopus.Action.Script.ScriptSource": "Inline"
   },
   "Parameters": [
     {
       "Id": "ef9d044d-3765-4cb0-af55-22c15ce4013c",
-      "Name": "ApplicationInsightsAccount",
+      "Name": "AppInsights.ApplicationInsightsAccount",
       "Label": "Application Insights Account",
       "HelpText": "Azure account for the Application Insights instance",
       "DefaultValue": "",
@@ -25,7 +25,7 @@
     },
     {
       "Id": "98174616-d9dd-4e8e-9b01-2961a061360f",
-      "Name": "ApplicationName",
+      "Name": "AppInsights.ApplicationName",
       "Label": "Application Name",
       "HelpText": "The Application Insights Application name.",
       "DefaultValue": "",
@@ -35,7 +35,7 @@
     },
     {
       "Id": "41835ca3-76d3-47f8-b863-d26c782c4ba4",
-      "Name": "ResourceGroup",
+      "Name": "AppInsights.ResourceGroup",
       "Label": "Resource Group",
       "HelpText": "The Resource Group of the Application Insights instance",
       "DefaultValue": "",
@@ -45,7 +45,7 @@
     },
     {
       "Id": "e008808c-622d-4efe-91a0-ac666d264996",
-      "Name": "ReleaseName",
+      "Name": "AppInsights.ReleaseName",
       "Label": "Release Name",
       "HelpText": "The release name. Typically bound to #{Octopus.Release.Number}",
       "DefaultValue": "#{Octopus.Release.Number}",
@@ -55,7 +55,7 @@
     },
     {
       "Id": "551f06ad-9470-415b-aed9-dd80f3a4123d",
-      "Name": "ReleaseProperties",
+      "Name": "AppInsights.ReleaseProperties",
       "Label": "Release Properties",
       "HelpText": "List of key/value pairs separated by a new-line. For example:\n\n```\nReleaseDescription = Release with annotation\nTriggerBy = John Doe\n```",
       "DefaultValue": "",

--- a/step-templates/application-insights-annotate-release-with-rbac.json
+++ b/step-templates/application-insights-annotate-release-with-rbac.json
@@ -1,0 +1,76 @@
+{
+  "Id": "bc4eae30-786a-4974-a003-948b7a4ed023",
+  "Name": "Application Insights - Annotate Release with Azure CLI and RBAC",
+  "Description": "Marks a release point in Application Insights. This step template uses Azure CLI and Role-Based Access Control instead of an API Key. Used application-insights-annotate-release.json as inspiration.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "# Function to decrypt data\nfunction Convert-PasswordToPlainText {\n\t$base64password = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($OctopusParameters[\"ApplicationInsightsAccount.Password\"]))\n    return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($base64password))\n}\n\n# Function to ensure all Unicode characters in a JSON string are properly escaped\nfunction Convert-UnicodeToEscapeHex {\n  param (\n    [parameter(Mandatory = $true)][string]$JsonString\n  )\n  $JsonObject = ConvertFrom-Json -InputObject $JsonString\n  foreach ($property in $JsonObject.PSObject.Properties) {\n    $name = $property.Name\n    $value = $property.Value\n    if ($value -is [string]) {\n      $value = [regex]::Unescape($value)\n      $OutputString = \"\"\n      foreach ($char in $value.ToCharArray()) {\n        $dec = [int]$char\n        if ($dec -gt 127) {\n          $hex = [convert]::ToString($dec, 16)\n          $hex = $hex.PadLeft(4, '0')\n          $OutputString += \"\\u$hex\"\n        }\n        else {\n          $OutputString += $char\n        }\n      }\n      $JsonObject.$name = $OutputString\n    }\n  }\n  return ConvertTo-Json -InputObject $JsonObject -Compress\n}\n\n$applicationName = $OctopusParameters[\"ApplicationName\"]\n$resourceGroup = $OctopusParameters[\"ResourceGroup\"]\n$releaseName = $OctopusParameters[\"ReleaseName\"]\n$properties = $OctopusParameters[\"ReleaseProperties\"]\n\n# Authenticate via Service Principal\n$securePassword = Convert-PasswordToPlainText\n$azEnv = if($OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"]) { $OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"] } else { \"AzureCloud\" }\n\n$azEnv = Get-AzEnvironment -Name $azEnv\nif (!$azEnv) {\n\tWrite-Error \"No Azure environment could be matched given the name $($OctopusParameters[\"ApplicationInsightsAccount.AzureEnvironment\"])\"\n\texit -2\n}\n\nWrite-Verbose \"Authenticating with Service Principal\"\n\n# Force any output generated to be verbose in Octopus logs.\naz login --service-principal -u $OctopusParameters[\"ApplicationInsightsAccount.Client\"] -p $securePassword --tenant $OctopusParameters[\"ApplicationInsightsAccount.TenantId\"]\n\nWrite-Verbose \"Initiating the body of the annotation\"\n\n$releaseProperties = $null\n\nif ($properties -ne $null)\n{\n    $releaseProperties = ConvertFrom-StringData -StringData $properties\n}\n\n$annotation = @{\n    Id = [GUID]::NewGuid();\n    AnnotationName = $releaseName;\n    EventTime = (Get-Date).ToUniversalTime().GetDateTimeFormats(\"s\")[0];\n    Category = \"Deployment\"; #Application Insights only displays annotations from the \"Deployment\" Category\n    Properties = ConvertTo-Json $releaseProperties -Compress\n}\n\n$annotation = ConvertTo-Json $annotation -Compress\n$annotation = Convert-UnicodeToEscapeHex -JsonString $annotation  \n\n$body = $annotation -replace '(\\\\+)\"', '$1$1\"' -replace \"`\"\", \"`\"`\"\"\n\nWrite-Verbose \"Send the annotation to Application Insights\"\n\naz rest --method put --uri \"/subscriptions/$($OctopusParameters[\"ApplicationInsightsAccount.SubscriptionNumber\"])/resourceGroups/$($resourceGroup)/providers/microsoft.insights/components/$($applicationName)/Annotations?api-version=2015-05-01\" --body \"$($body) \"",
+    "Octopus.Action.Script.ScriptSource": "Inline"
+  },
+  "Parameters": [
+    {
+      "Id": "ef9d044d-3765-4cb0-af55-22c15ce4013c",
+      "Name": "ApplicationInsightsAccount",
+      "Label": "Application Insights Account",
+      "HelpText": "Azure account for the Application Insights instance",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AzureAccount"
+      }
+    },
+    {
+      "Id": "98174616-d9dd-4e8e-9b01-2961a061360f",
+      "Name": "ApplicationName",
+      "Label": "Application Name",
+      "HelpText": "The Application Insights Application name.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "41835ca3-76d3-47f8-b863-d26c782c4ba4",
+      "Name": "ResourceGroup",
+      "Label": "Resource Group",
+      "HelpText": "The Resource Group of the Application Insights instance",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e008808c-622d-4efe-91a0-ac666d264996",
+      "Name": "ReleaseName",
+      "Label": "Release Name",
+      "HelpText": "The release name. Typically bound to #{Octopus.Release.Number}",
+      "DefaultValue": "#{Octopus.Release.Number}",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "551f06ad-9470-415b-aed9-dd80f3a4123d",
+      "Name": "ReleaseProperties",
+      "Label": "Release Properties",
+      "HelpText": "List of key/value pairs separated by a new-line. For example:\n\n```\nReleaseDescription = Release with annotation\nTriggerBy = John Doe\n```",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2024-05-17T06:54:43.852Z",
+    "OctopusVersion": "2024.1.12600",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedOn": "2024-05-17T07:30:00.000Z",
+  "LastModifiedBy": "NielsDM",
+  "Category": "azure"
+}


### PR DESCRIPTION
# Background

As Azure will stop supporting the function to annotate releases based on API keys and only supports RBAC to create annotations. There for I created this step template so an annotation can be created with a service principle.

# Results

Create an annotation with Azure CLI and Role-Based Access Control.

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [X] If a new `Category` has been created:
   - [X] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [X] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
