### PR TITLE
Revert performance changes as it break API consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 build/
 app/services/*.json
+integrations/
 .idea/
 
 junitresults.xml

--- a/app/components/TemplateItem.jsx
+++ b/app/components/TemplateItem.jsx
@@ -69,7 +69,7 @@ export default class TemplateItem extends React.Component {
         <div className="step-template">
           <div className="row clearfix">
             <div className="column two-thirds">
-              <img className="logo" loading="lazy" src={this.state.template.Logo} />
+              <img className="logo" src={"data:image/gif;base64," + this.state.template.Logo} />
               <h2 className="name">{this.state.template.Name}</h2>
               <p className="who-when faint no-top-margin">
                 <i>{this.state.template.ActionType}</i> exported {moment(this.state.template.ExportedAt).calendar()} by

--- a/app/components/TemplateList.jsx
+++ b/app/components/TemplateList.jsx
@@ -27,7 +27,7 @@ export default class TemplateList extends React.Component {
       let friendlySlug = SlugMaker.make(item.Name);
       return (
         <li className={"item-summary " + (item.ScriptClass || "")} key={index + "." + item.Name}>
-          <img loading="lazy" src={item.Logo} />
+          <img src={"data:image/gif;base64," + item.Logo} />
           <h4 key={index + "." + item.Name + ".0"}>
             <Link to={`/step-templates/${item.Id}/${friendlySlug}`}>{item.Name}</Link>
           </h4>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -300,8 +300,10 @@ function provideMissingData() {
 
     template.Category = humanize(categoryId);
 
-    // Note: this deprecates base64 encoded images in the template files - they will be ignored
-    template.Logo = "https://i.octopus.com/library/step-templates/" + categoryId + ".png";
+    if (!template.Logo) {
+      var logo = fs.readFileSync("./step-templates/logos/" + categoryId + ".png");
+      template.Logo = Buffer.from(logo).toString("base64");
+    }
 
     file.contents = Buffer.from(JSON.stringify(template));
 


### PR DESCRIPTION
Octopus pulls data from the API in this project and it doesn't like the change to the Logo field.

Reverting changes to restore community step sync in Octopus.