### PR TITLE
Adding template to deploy image based Lamdbda functions

### DIFF
--- a/step-templates/aws-deploy-lambda-image.json
+++ b/step-templates/aws-deploy-lambda-image.json
@@ -1,0 +1,236 @@
+{
+  "Id": "480a3d93-7bad-42d4-b439-cced56ae792a",
+  "Name": "AWS - Deploy Image Lambda Function",
+  "Description": "Deploys an image to an AWS Lambda function.  \n\nThis step uses the following AWS CLI commands to deploy the AWS Lambda.  You will be required to install the AWS CLI on your server/worker for this to work.  The AWS CLI is pre-installed on the [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools) in Octopus Cloud as well as the provided docker containers for [Execution Containers](https://octopus.com/docs/deployment-process/execution-containers-for-workers).\n\n- [create-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html)\n- [get-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/get-function.html)\n- [publish-version](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/publish-version.html)\n- [tag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/tag-resource.html)\n- [untag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/untag-resource.html)\n- [update-function-code](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-code.html)\n- [update-function-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-configuration.html)\n\nThis step template is worker-friendly, you can pass in a package reference rather than having to reference a previous step that downloaded the package. This step requires **Octopus Deploy 2019.10.0** or higher.\n\n## Output Variables\n\nThis step template sets the following output variables:\n\n- `LambdaArn`: The ARN of the Lambda Function\n- `PublishedVersion`: The most recent version published (only set when Publish is set to `Yes`).",
+  "ActionType": "Octopus.AwsRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "8dbae499-5aa8-438e-a2fe-ae29fb8f0a39",
+      "Name": "AWS.Lambda.Package",
+      "PackageId": null,
+      "FeedId": null,
+      "AcquisitionLocation": "NotAcquired",
+      "Properties": {
+        "Extract": "False",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "AWS.Lambda.Package",
+        "Purpose": ""
+      }
+    }
+  ],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Aws.AssumeRole": "False",
+    "Octopus.Action.AwsAccount.UseInstanceRole": "False",
+    "Octopus.Action.AwsAccount.Variable": "#{AWS.Lambda.Account}",
+    "Octopus.Action.Aws.Region": "#{AWS.Lambda.Region}",
+    "Octopus.Action.Script.ScriptBody": "$ErrorActionPreference = \"Stop\";\n\n$functionName = $OctopusParameters[\"AWS.Lambda.FunctionName\"] \n$functionRole = $OctopusParameters[\"AWS.Lambda.FunctionRole\"]\n$functionRunTime = $OctopusParameters[\"AWS.Lambda.Runtime\"]\n$functionMemorySize = $OctopusParameters[\"AWS.Lambda.MemorySize\"]\n$functionDescription = $OctopusParameters[\"AWS.Lambda.Description\"]\n$functionVPCSubnetId = $OctopusParameters[\"AWS.Lambda.VPCSubnetIds\"]\n$functionVPCSecurityGroupId = $OctopusParameters[\"AWS.Lambda.VPCSecurityGroupIds\"]\n$functionEnvironmentVariables = $OctopusParameters[\"AWS.Lambda.EnvironmentVariables\"]\n$functionEnvironmentVariablesKey = $OctopusParameters[\"AWS.Lambda.EnvironmentVariablesKey\"]\n$functionTimeout = $OctopusParameters[\"AWS.Lambda.FunctionTimeout\"]\n$functionTags = $OctopusParameters[\"AWS.Lambda.Tags\"]\n$functionFileSystemConfig = $OctopusParameters[\"AWS.Lambda.FileSystemConfig\"]\n$functionDeadLetterConfig = $OctopusParameters[\"AWS.Lambda.DeadLetterConfig\"]\n$functionTracingConfig = $OctopusParameters[\"AWS.Lambda.TracingConfig\"]\n$functionVersionNumber = $OctopusParameters[\"Octopus.Action.Package[AWS.Lambda.Package].PackageVersion\"]\n$functionPublishOption = $OctopusParameters[\"AWS.Lambda.Publish\"]\n\n$functionReleaseNumber = $OctopusParameters[\"Octopus.Release.Number\"]\n$functionRunbookRun = $OctopusParameters[\"Octopus.RunbookRun.Id\"]\n$stepName = $OctopusParameters[\"Octopus.Step.Name\"]\n\n$regionName = $OctopusParameters[\"AWS.Lambda.Region\"]\n\nif ($null -ne $OctopusParameters[\"Octopus.Action.Package[AWS.Lambda.Package].Image\"]) {\n    $imageUri = $OctopusParameters[\"Octopus.Action.Package[AWS.Lambda.Package].Image\"]\n}\n\nif ([string]::IsNullOrWhiteSpace($functionName)) {\n    Write-Error \"The parameter Function Name is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionRole)) {\n    Write-Error \"The parameter Role is required.\"\n    Exit 1\n}\n\nif ([string]::IsNullOrWhiteSpace($functionReleaseNumber) -eq $false) {\n    $deployVersionTag = \"Octopus-Release=$functionReleaseNumber\"\n}\nelse {\n    $deployVersionTag = \"Octopus-Runbook-Run=$functionRunbookRun\"\n}\n\nWrite-Host \"Function Name: $functionName\"\nWrite-Host \"Function Role: $functionRole\"\nWrite-Host \"Function Memory Size: $functionMemorySize\"\nWrite-Host \"Function Description: $functionDescription\"\nWrite-Host \"Function Subnet Ids: $functionVPCSubnetId\"\nWrite-Host \"Function Security Group Ids: $functionVPCSecurityGroupId\"\nWrite-Host \"Function Timeout: $functionTimeout\"\nWrite-Host \"Function Tags: $functionTags\"\nWrite-Host \"Function File System Config: $functionFileSystemConfig\"\nWrite-Host \"Function Dead Letter Config: $functionDeadLetterConfig\"\nWrite-Host \"Function Tracing Config: $functionTracingConfig\"\nWrite-Host \"Function Publish: $functionPublishOption\"\nWrite-Host \"Function Image URI: $imageUri\"\nWrite-Host \"Function Environment Variables: $functionEnvironmentVariables\"\nWrite-Host \"Function Environment Variables Key: $functionEnvironmentVariablesKey\"\n\nif (![string]::IsNullOrWhitespace($OctopusParameters[\"AWS.Lambda.Image.Entrypoint\"]))\n{\n  Write-Host \"Image Entrypoint override: $($OctopusParameters[\"AWS.Lambda.Image.Entrypoint\"])\"\n}\n\nif (![string]::IsNullOrWhitespace($OctopusParameters[\"AWS.Lambda.Image.Command\"]))\n{\n  Write-Host \"Image Command override: $($OctopusParameters[\"AWS.Lambda.Image.Command\"])\"\n}\n\n\nWrite-Host \"Attempting to find the function $functionName in the region $regionName\"\n$hasExistingFunction = $true\n\ntry {\n    $existingFunction = aws lambda get-function --function-name \"$functionName\" 2> $null\n    \n    Write-Host \"The exit code from the lookup was $LASTEXITCODE\"\n    if ($LASTEXITCODE -eq 255 -or $LASTEXITCODE -eq 254) {\n        $hasExistingFunction = $false\n    }   \n    \n    $existingFunction = $existingFunction | ConvertFrom-Json\n}\ncatch {\n    Write-Host \"The function was not found\"\n    $hasExistingFunction = $false\n}\n\nWrite-Host \"Existing functions: $hasExistingFunction\"\nWrite-Host $existingFunction\n\n# Init argument variable\n$lambdaArguments = @(\"lambda\")\n$waitArguments = @(\"lambda\", \"wait\")\n\nif ($hasExistingFunction -eq $false) {\n    Write-Highlight \"Creating $functionName in $regionName\"\n\n    $waitArguments += @(\"function-active-v2\")\n\n    $lambdaArguments += @(\"create-function\", \"--role\", $functionRole, \"--memory-size\", $functionMemorySize)\n\n    if ($null -ne $imageUri) {\n        Write-Host \"Deploying Lambda container ...\"\n        $lambdaArguments += @(\"--code\", \"ImageUri=$imageUri\", \"--package-type\", \"Image\")\n      \n        if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Entrypoint']) -or ![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Command'])) {\n            $lambdaArguments += \"--image-config\"\n        \n            if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Entrypoint'])) {\n                $lambdaArguments += \"EntryPoint=$($OctopusParameters['AWS.Lambda.Image.Entrypoint'])\"\n            }\n\n            if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Command'])) {\n                $lambdaArguments += \"Command=$($OctopusParameters['AWS.Lambda.Image.Command'])\"\n            }\n        }\n    }\n}\nelse {\n    Write-Highlight \"Updating the $functionName code\"\n\n    $waitArguments += @(\"function-updated\")\n    $lambdaArguments += \"update-function-code\"\n\n    if ($null -ne $imageUri) {\n        Write-Host \"Deploying Lambda container ...\"\n        $lambdaArguments += @(\"--image-uri\", $imageUri)\n    }\n}\n\n$waitArguments += @(\"--function-name\", \"$functionName\")\n\n$lambdaArguments += @(\"--function-name\", \"$functionName\")\n\n# Wait for function to be done creating\nWrite-Host \"Running aws $lambdaArguments ...\"\n$functionInformation = (aws $lambdaArguments)\n(aws $waitArguments)\n\n\nif ($hasExistingFunction -eq $true) {\n    # update configuration\n    $lambdaArguments = @(\"lambda\", \"update-function-configuration\", \"--function-name\", \"$functionName\", \"--role\", $functionRole, \"--memory-size\", $functionMemorySize)\n       \n    if ($null -ne $imageUri) {\n        Write-Highlight \"Updating the $functionName image configuration\"\n        if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Entrypoint']) -or ![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Command'])) {\n            $lambdaArguments += \"--image-config\"\n        \n            if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Entrypoint'])) {\n                $lambdaArguments += \"EntryPoint=$($OctopusParameters['AWS.Lambda.Image.Entrypoint'])\"\n            }\n\n            if (![string]::IsNullOrWhitespace($OctopusParameters['AWS.Lambda.Image.Command'])) {\n                $lambdaArguments += \"Command=$($OctopusParameters['AWS.Lambda.Image.Command'])\"\n            }\n        }\n    }\n    \n    $functionInformation = (aws $lambdaArguments)\n    Write-Highlight \"Waiting for configuration update to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\n$functionInformation = $functionInformation | ConvertFrom-JSON\n$functionArn = $functionInformation.FunctionArn\n\nWrite-Host \"Function ARN: $functionArn\"\n\nif ([string]::IsNullOrWhiteSpace($functionEnvironmentVariables) -eq $false) {\n    Write-Highlight \"Environment variables specified, updating environment variables configuration for $functionName\"\n    $environmentVariables = \"Variables={$functionEnvironmentVariables}\"\n    \n    if ([string]::IsNullOrWhiteSpace($functionEnvironmentVariablesKey) -eq $true) {\n        $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --environment \"$environmentVariables\"\n    }\n    else {\n        $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --environment \"$environmentVariables\" --kms-key-arn \"$functionEnvironmentVariablesKey\"\n    }\n    \n    Write-Highlight \"Waiting for environment variable update to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTimeout) -eq $false) {\n    Write-Highlight \"Timeout specified, updating timeout configuration for $functionName\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --timeout \"$functionTimeout\"\n    \n    Write-Highlight \"Waiting for timeout upate to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTags) -eq $false) {\n    Write-Highlight \"Tags specified, updating tags configuration for $functionName\"\n    $updatedConfig = aws lambda tag-resource --resource \"$functionArn\" --tags \"$functionTags\"\n}\n\nif ([string]::IsNullOrWhiteSpace($deployVersionTag) -eq $false) {\n    Write-Highlight \"Deploy version tag found with value of $deployVersionTag, updating tags configuration for $functionName\"\n    aws lambda untag-resource --resource \"$functionArn\" --tag-keys \"Octopus-Release\" \"Octopus-Runbook-Run\"\n    $updatedConfig = aws lambda tag-resource --resource \"$functionArn\" --tags \"$deployVersionTag\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionVPCSubnetId) -eq $false -and [string]::IsNullOrWhiteSpace($functionVPCSecurityGroupId) -eq $false) {\n    Write-Highlight \"VPC subnets and security group specified, updating vpc configuration for $functionName\"\n    $vpcConfig = \"SubnetIds=$functionVPCSubnetId,SecurityGroupIds=$functionVPCSecurityGroupId\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --vpc-config \"$vpcConfig\"\n    \n    Write-Highlight \"Waiting for vpc configuration to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionDescription) -eq $false) {\n    Write-Highlight \"Description specified, updating description configuration for $functionName\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --description \"$functionDescription\"\n    \n    Write-Highlight \"Waiting for description configuration ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionFileSystemConfig) -eq $false) {\n    Write-Highlight \"File System Config specified, updating file system configuration for $functionName\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --file-system-configs \"$functionFileSystemConfig\"\t\n    \n    Write-Highlight \"Wating for file system configuration update to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionDeadLetterConfig) -eq $false) {\n    Write-Highlight \"Dead Letter specified, updating dead letter configuration for $functionName\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --dead-letter-config \"$functionDeadLetterConfig\"\t\n    \n    Write-Highlight \"Waitng for Dead Letter configuration update to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nif ([string]::IsNullOrWhiteSpace($functionTracingConfig) -eq $false) {\n    Write-Highlight \"Tracing config specified, updating tracing configuration for $functionName\"\n    $updatedConfig = aws lambda update-function-configuration --function-name \"$functionArn\" --tracing-config \"$functionTracingConfig\"\t\n    \n    Write-Highlight \"Waiting for tracing configuration to complete ...\"\n    aws lambda wait function-updated --function-name \"$functionName\"\n}\n\nWrite-Host $updatedConfig | ConvertFrom-JSON\n\nif ($functionPublishOption -eq \"Yes\") {\n    Write-Highlight \"Publishing the function with the description $functionVersionNumber to create a snapshot of the current code and configuration of this function in AWS.\"\n    $publishedVersion = aws lambda publish-version --function-name \"$functionArn\" --description \"$functionVersionNumber\"\n    \n    $publishedVersion = $publishedVersion | ConvertFrom-JSON\n    \n    Write-Highlight \"Setting the output variable 'Octopus.Action[$($stepName)].Output.PublishedVersion' to $($publishedVersion.Version)\"\n    Set-OctopusVariable -name \"PublishedVersion\" -value \"$($publishedVersion.Version)\"    \n}\n\nWrite-Highlight \"Setting the output variable 'Octopus.Action[$($stepName)].Output.LambdaArn' to $functionArn\"\nSet-OctopusVariable -name \"LambdaArn\" -value \"$functionArn\"\n\nWrite-Highlight \"AWS Lambda $functionName successfully deployed.\"",
+    "OctopusUseBundledTooling": "False"
+  },
+  "Parameters": [
+    {
+      "Id": "8c0297c2-5a7c-4776-9ce7-8bd3dbe93e45",
+      "Name": "AWS.Lambda.FunctionName",
+      "Label": "Function Name",
+      "HelpText": "Required.\n\nThe name of the function to create or update.  See [documentation](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html#options)\n\nExamples:\n- Function name - my-function .\n- Function ARN - arn:aws:lambda:us-west-2:123456789012:function:my-function .\n- Partial ARN - 123456789012:function:my-function .\n\nThe length constraint applies only to the full ARN. If you specify only the function name, it is limited to 64 characters in length.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "711a1557-03c2-4c78-87aa-730389673884",
+      "Name": "AWS.Lambda.Account",
+      "Label": "AWS Account",
+      "HelpText": "Required.\n\nThe AWS Account with permissions to create / update AWS Lambdas.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "AmazonWebServicesAccount"
+      }
+    },
+    {
+      "Id": "304f276c-ed3e-4766-93e1-3fb25a727ccd",
+      "Name": "AWS.Lambda.Region",
+      "Label": "Region",
+      "HelpText": "Required.\n\nThe region where the function will live.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "us-east-2|US East (Ohio)\nus-east-1|US East (N. Virginia)\nus-west-1|US West (N. California)\nus-west-2|US West (Oregon)\naf-south-1|Africa (Cape Town)\nap-east-1|Asia Pacific (Hong Kong)\nap-south-1|Asia Pacific (Mumbai)\nap-northeast-3|Asia Pacific (Osaka-Local)\nap-northeast-2|Asia Pacific (Seoul)\nap-southeast-1|Asia Pacific (Singapore)\nap-southeast-2|Asia Pacific (Sydney)\nap-northeast-1|Asia Pacific (Tokyo)\nca-central-1|Canada (Central)\neu-central-1|Europe (Frankfurt)\neu-west-1|Europe (Ireland)\neu-west-2|Europe (London)\neu-south-1|Europe (Milan)\neu-west-3|Europe (Paris)\neu-north-1|Europe (Stockholm)\nme-south-1|Middle East (Bahrain)\nsa-east-1|South America (São Paulo)"
+      }
+    },
+    {
+      "Id": "d9d48dc2-d671-41b9-8a5e-59efbf4e29e3",
+      "Name": "AWS.Lambda.Package",
+      "Label": "Image",
+      "HelpText": "Required.\n\nThe registry containing the image you wish to deploy to the AWS Lambda function.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "a44a4664-f3b7-41f7-bc9c-cd7e06be7dbe",
+      "Name": "AWS.Lambda.FunctionRole",
+      "Label": "Function Role",
+      "HelpText": "Required.\n\nThe Amazon Resource Name (ARN) of the function’s execution role.  This role must exist prior to this step is run.  See [documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) for more detail on creating an execution role.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "12b11c8c-b31d-42b1-a4a4-c7fa0cf6219d",
+      "Name": "AWS.Lambda.MemorySize",
+      "Label": "Memory Size",
+      "HelpText": "Required.\n\nThe amount of memory that your function has access to. Increasing the function’s memory also increases its CPU allocation. The default value is 128 MB. The value must be a multiple of 64 MB.",
+      "DefaultValue": "128",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "c16ab198-835b-4c1d-b289-b87ad5fe3df2",
+      "Name": "AWS.Lambda.Description",
+      "Label": "Description",
+      "HelpText": "Optional.\n\nA description of the function.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "903476ad-6eca-4ddf-a656-f121c12e8785",
+      "Name": "AWS.Lambda.VPCSubnetIds",
+      "Label": "VPC Subnet Ids",
+      "HelpText": "Optional.\n\nFormat: `SubnetId1,SubnetId2`\n\nFor network connectivity to AWS resources in a VPC, specify a list of security groups and subnets in the VPC. When you connect a function to a VPC, it can only access resources and the internet through that VPC. For more information, see [VPC Settings](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "457ac64f-5538-49b4-b7a2-f6ab97b5affe",
+      "Name": "AWS.Lambda.VPCSecurityGroupIds",
+      "Label": "VPC Security Group Ids",
+      "HelpText": "Optional.\n\nFormat: `SecurityGroupId1,SecurityGroupId2`\n\nFor network connectivity to AWS resources in a VPC, specify a list of security groups and subnets in the VPC. When you connect a function to a VPC, it can only access resources and the internet through that VPC. For more information, see [VPC Settings](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html).",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "6ba57e09-dfea-4dcb-9372-6e9fc5d43051",
+      "Name": "AWS.Lambda.Image.Entrypoint",
+      "Label": "Entrypoint override",
+      "HelpText": "Optional for Image Package type.\n\nComma-delimited list of commands to override the Image Entrypoint.\n\nFormat: `entrypoint1, entrypoint2`\n\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "f85d4334-e896-488f-aeef-bf6d66efc8a5",
+      "Name": "AWS.Lambda.Image.Command",
+      "Label": "Command override",
+      "HelpText": "Optional for Image Package type.\n\nComma-delimited list of commands to override the Image Entrypoint.\n\nFormat: `command1, command2`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "383e3565-d091-447e-828e-f6ab50d79150",
+      "Name": "AWS.Lambda.EnvironmentVariables",
+      "Label": "Environment Variables",
+      "HelpText": "Optional.\n\nFormat: `KeyName1=string,KeyName2=string`\n\nEnvironment variables that are accessible from function code during execution.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "53366a6a-783e-4db9-b8af-eb5665ea805f",
+      "Name": "AWS.Lambda.EnvironmentVariablesKey",
+      "Label": "Environment Variables Encryption Key",
+      "HelpText": "Optional.\n\nThe ARN of the AWS Key Management Service (AWS KMS) key that’s used to encrypt your function’s environment variables. If it’s not provided, AWS Lambda uses a default service key.\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b2c16584-9f90-4dc1-85de-539cddd6482b",
+      "Name": "AWS.Lambda.FunctionTimeout",
+      "Label": "Timeout",
+      "HelpText": "Optional.\n\nThe amount of time that Lambda allows a function to run before stopping it. The default is 3 seconds. The maximum allowed value is 900 seconds.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "e67b885a-5972-458d-9d67-2b5b8860fe61",
+      "Name": "AWS.Lambda.Tags",
+      "Label": "Tags",
+      "HelpText": "Optional.\n\nFormat: `KeyName1=string,KeyName2=string`\n\nA list of tags to apply to the function.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "bb8af54e-5f79-45c4-b150-bdf4ee377b7b",
+      "Name": "AWS.Lambda.FileSystemConfig",
+      "Label": "File System Config",
+      "HelpText": "Optional.\n\nFormat: `Arn=string,LocalMountPath=string`\n\nConnection settings for an Amazon EFS file system.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "59047de4-a921-4437-a2a2-c9e684bcf21e",
+      "Name": "AWS.Lambda.TracingConfig",
+      "Label": "Tracing Config",
+      "HelpText": "Optional.\n\nFormat: `Mode=string`\n\nSet Mode to Active to sample and trace a subset of incoming requests with AWS X-Ray.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "37a91d63-9c42-4d49-832b-dbe64d81f6da",
+      "Name": "AWS.Lambda.DeadLetterConfig",
+      "Label": "Dead Letter Config",
+      "HelpText": "Optional.\n\nFormat: `TargetArn=string`\n\nA dead letter queue configuration that specifies the queue or topic where Lambda sends asynchronous events when they fail processing. For more information, see [Dead Letter Queues](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#dlq).\n",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "1db6270a-9138-48d8-8d34-05c39ade10a8",
+      "Name": "AWS.Lambda.Publish",
+      "Label": "Publish",
+      "HelpText": "Required.\n\nCreates a [version](https://docs.aws.amazon.com/lambda/latest/dg/versioning-aliases.html) from the current code and configuration of a function. Use versions to create a snapshot of your function code and configuration that doesn’t change.\n\n**Important**: Lambda doesn’t publish a version if the function’s configuration and code haven’t changed since the last version. Use UpdateFunctionCode or UpdateFunctionConfiguration to update the function before publishing a version.",
+      "DefaultValue": "Yes",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "Yes|Yes\nNo|No"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.AwsRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-06-03T15:07:31.689Z",
+    "OctopusVersion": "2024.3.1025",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "twerthi",
+  "Category": "aws"
+}


### PR DESCRIPTION

---

# Background

This template implements the ability to deploy a lambda function using a docker image.  This is similar to [AWS - Configure Lambda Function](https://library.octopus.com/step-templates/db4f7564-1b04-41c6-a3a6-aca911236aee/actiontemplate-aws-configure-lambda-function), however, the new template allows you to use the package selector instead of the string based image uri.  In addition. it also implements the ENTRYPOINT and CMD override functionality AWS provides.

# Results

The deployment of a Lambda using a docker image.

## Before

The [AWS - Configure Lambda Function](https://library.octopus.com/step-templates/db4f7564-1b04-41c6-a3a6-aca911236aee/actiontemplate-aws-configure-lambda-function) template does not have the ability to use the package selector.  Modifying the [AWS - Configure Lambda Function](https://library.octopus.com/step-templates/db4f7564-1b04-41c6-a3a6-aca911236aee/actiontemplate-aws-configure-lambda-function) template would most likely lead to a breaking change.

## After

A new template to deploy image based Lambda functions

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it


