### PR TITLE
Feed id not null

### DIFF
--- a/step-templates/argo-rollouts-set-image.json
+++ b/step-templates/argo-rollouts-set-image.json
@@ -10,7 +10,7 @@
       "Id": "67a06773-8f2b-49a7-95bb-1e087a38b3b9",
       "Name": "Argo.Rollout.Image",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "NotAcquired",
       "Properties": {
         "Extract": "True",


### PR DESCRIPTION


---

# Background

Build was broken due to feedid not bieng null.

# Results

Fixed the build

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
