### PR TITLE
Update aspnetcore-set-environment-variable-iis to support '='

### DIFF
--- a/step-templates/aspnetcore-set-environment-variable-iis.json
+++ b/step-templates/aspnetcore-set-environment-variable-iis.json
@@ -4,10 +4,10 @@
   "Name": "ASP.NET Core Set Environment Variables Via IIS Config",
   "Description": "Set environment variables in IIS config (no web.config)",
   "ActionType": "Octopus.Script",
-  "Version": 1,
+  "Version": 2,
   "Packages": [],
   "Properties": {
-    "Octopus.Action.Script.ScriptBody": "function AddOrReplaceEnvironmentVariable {\n    param\n    (\n        [string] $variableName, \n        [string] $variableValue,\n        [string] $siteName,\n        [string] $appCmd\n    )\n\n    Try {\n        [xml] $xmlConfig = (&$appCmd list config $sev_siteName -section:system.webServer/aspNetCore)\n    }\n    Catch {\n        Write-Host $sev_siteName 'either does not exist or is not an AspNetCore site!'\n        exit -1\n    }\n\n    if($xmlConfig.selectNodes(\"//environmentVariable[@name='$variableName']\")) {\n        &$appCmd set config $sev_siteName -section:system.webServer/aspNetCore /-\"environmentVariables.[name='$variableName',value='$variableValue']\" /commit:apphost\n    }\n    \n    &$appCmd set config $sev_siteName -section:system.webServer/aspNetCore /+\"environmentVariables.[name='$variableName',value='$variableValue']\" /commit:apphost\n}\n\n[string] $sev_siteName=$OctopusParameters['sev_siteName']\n[string] $sev_envVariables=$OctopusParameters['sev_envVariables']\n[string] $sev_appCmdPath=$OctopusParameters['sev_appCmdPath']\n\nWrite-Host \"---------------------------\"\nWrite-Host $sev_envVariables\nWrite-Host $sev_appCmdPath\nWrite-Host \"---------------------------\"\n\n$appCmd = Join-Path $sev_appCmdPath 'appcmd.exe'\n\nforeach($line in $sev_envVariables -split '\\r?\\n') {\n    $keyValuePair = $line -split '='\n\n    AddOrReplaceEnvironmentVariable $keyValuePair[0] $keyValuePair[1] $sev_siteName $appCmd\n}\n",
+    "Octopus.Action.Script.ScriptBody": "function AddOrReplaceEnvironmentVariable {\n    param\n    (\n        [string] $variableName, \n        [string] $variableValue,\n        [string] $siteName,\n        [string] $appCmd\n    )\n\n    Try {\n        [xml] $xmlConfig = (&$appCmd list config $sev_siteName -section:system.webServer/aspNetCore)\n    }\n    Catch {\n        Write-Host $sev_siteName 'either does not exist or is not an AspNetCore site!'\n        exit -1\n    }\n\n    if($xmlConfig.selectNodes(\"//environmentVariable[@name='$variableName']\")) {\n        &$appCmd set config $sev_siteName -section:system.webServer/aspNetCore /-\"environmentVariables.[name='$variableName',value='$variableValue']\" /commit:apphost\n    }\n    \n    &$appCmd set config $sev_siteName -section:system.webServer/aspNetCore /+\"environmentVariables.[name='$variableName',value='$variableValue']\" /commit:apphost\n}\n\n[string] $sev_siteName=$OctopusParameters['sev_siteName']\n[string] $sev_envVariables=$OctopusParameters['sev_envVariables']\n[string] $sev_appCmdPath=$OctopusParameters['sev_appCmdPath']\n\nWrite-Host \"---------------------------\"\nWrite-Host $sev_envVariables\nWrite-Host $sev_appCmdPath\nWrite-Host \"---------------------------\"\n\n$appCmd = Join-Path $sev_appCmdPath 'appcmd.exe'\n\nforeach($line in $sev_envVariables -split '\\r?\\n') {\n    $indexOfEquals = $line.IndexOf('=')\n    if ($indexOfEquals -eq -1) {\n        Write-Host \"Invalid environment variable format: $line\"\n        continue\n    }\n    $key = $line.Substring(0, $indexOfEquals)\n    $value = $line.Substring($indexOfEquals + 1)\n\n    AddOrReplaceEnvironmentVariable $key $value $sev_siteName $appCmd\n}\n",
     "Octopus.Action.Script.Syntax": "PowerShell",
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.RunOnServer": "false"
@@ -44,10 +44,10 @@
       }
     }
   ],
-  "LastModifiedBy": "waxtell",    
+  "LastModifiedBy": "geeknz",
   "$Meta": {
-    "ExportedAt": "2020-08-11T17:06:34.462Z",
-    "OctopusVersion": "2020.1.4",
+    "ExportedAt": "2024-07-15T22:40:29.070Z",
+    "OctopusVersion": "2024.2.9220",
     "Type": "ActionTemplate"
   },
   "Category": "dotnetcore"


### PR DESCRIPTION
# Background

When using the `ASP.NET Core Set Environment Variables Via IIS Config` step template, it would incorrectly set the environment variable if it contained `=`

For example,

`ConnectionStrings__Default=Data Source=.;Initial Catalog=AppDB;`

Would set `ConnectionStrings__Default` to `Data Source` instead of `Data Source=.;Initial Catalog=AppDB;`

See the screenshot below,

![ASP.NET Core Set Environment Variables Via IIS Config Screenshot](https://github.com/user-attachments/assets/2f4ab5fb-4102-4545-ad73-133e689ce64e)

This pull request updates the step template to split the string on the first `=`.

See the diff below,

```diff
@@ -32,9 +32,15 @@
 Write-Host "---------------------------"

 $appCmd = Join-Path $sev_appCmdPath 'appcmd.exe'

 foreach($line in $sev_envVariables -split '\r?\n') {
-    $keyValuePair = $line -split '='
+    $indexOfEquals = $line.IndexOf('=')
+    if ($indexOfEquals -eq -1) {
+        Write-Host "Invalid environment variable format: $line"
+        continue
+    }
+    $key = $line.Substring(0, $indexOfEquals)
+    $value = $line.Substring($indexOfEquals + 1)

-    AddOrReplaceEnvironmentVariable $keyValuePair[0] $keyValuePair[1] $sev_siteName $appCmd
+    AddOrReplaceEnvironmentVariable $key $value $sev_siteName $appCmd
 }
```

# Results

- The step template will split the string on the first `=`.
- The part before the first `=` will be the name of the environment variable
- The part after the first `=` will be the value of the environment variable
- If the string doesn't contain `=`, it will be ignored and a warning message will be logged

## Before

`ConnectionStrings__Default=Data Source=.;Initial Catalog=AppDB;` will set `ConnectionStrings__Default` to `Data Source`

## After

`ConnectionStrings__Default=Data Source=.;Initial Catalog=AppDB;` will set `ConnectionStrings__Default` to `Data Source=.;Initial Catalog=AppDB;`

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] ~Parameter names should not start with `$`~
- [ ] ~**Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).~
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] ~The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied~
- [ ] ~If a new `Category` has been created:~
   - [ ] ~An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder~
   - [ ] ~The `switch` in the `humanize` function in [`gulpfile.babel.js`]~(https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

