### PR TITLE
Add ArgoCD cli step templates

### DIFF
--- a/step-templates/argo-argocd-app-get.json
+++ b/step-templates/argo-argocd-app-get.json
@@ -1,0 +1,65 @@
+{
+  "Id": "f67404e4-3394-4f8d-9739-74a04c99a6f1",
+  "Name": "Argo - argocd app get",
+  "Description": "Get an Argo Application details using the [argocd app get](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_get/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "ActionType": "Octopus.KubernetesRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "# argocd is required\nif ! [ -x \"$(command -v argocd)\" ]; then\n\tfail_step 'argocd command not found'\nfi\n\n# Helper functions\nisSet() { [ ! -z \"${1}\" ]; }\nisNotSet() { [ -z \"${1}\" ]; }\n\n# Get variables\nargocd_server=$(get_octopusvariable \"ArgoCD.AppGet.ArgoCD_Server\")\nargocd_authToken=$(get_octopusvariable \"ArgoCD.AppGet.ArgoCD_Auth_Token\")\napplicationName=$(get_octopusvariable \"ArgoCD.AppGet.ApplicationName\")\nadditionalParameters=$(get_octopusvariable \"ArgoCD.AppGet.AdditionalParameters\")\n\n# Check required variables\nif isNotSet \"${argocd_server}\"; then\n  fail_step \"argocd_server is not set\"\nfi\n\nif isNotSet \"${argocd_authToken}\"; then\n  fail_step \"argocd_authToken is not set\"\nfi\n\nif isNotSet \"${applicationName}\"; then\n  fail_step \"applicationName is not set\"\nfi\n\nif isSet \"${additionalParameters}\"; then\n  IFS=$'\\n' read -rd '' -a additionalArgs <<< \"$additionalParameters\"\nelse\n  additionalArgs=()\nfi\n\nflattenedArgs=\"${additionalArgs[@]}\"\n\nwrite_verbose \"ARGOCD_SERVER: '${argocd_server}'\"\nwrite_verbose \"ARGOCD_AUTH_TOKEN: '********'\"\n\nauthArgs=\"--server ${argocd_server} --auth-token ${argocd_authToken}\"\nmaskedAuthArgs=\"--server ${argocd_server} --auth-token '********'\"\n\necho \"Executing: argocd app get ${applicationName} ${maskedAuthArgs} ${flattenedArgs}\"\nargocd app get ${applicationName} ${authArgs} ${flattenedArgs}"
+  },
+  "Parameters": [
+    {
+      "Id": "0a5f6eea-c876-4db2-a4ab-ea5b5d35fddb",
+      "Name": "ArgoCD.AppGet.ArgoCD_Server",
+      "Label": "ArgoCD Server",
+      "HelpText": "Enter the name of the ArgoCD Server to connect to. This sets the `--server` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4c034426-cf1d-4e9a-a69c-4de4aa6cde31",
+      "Name": "ArgoCD.AppGet.ArgoCD_Auth_Token",
+      "Label": "ArgoCD Auth Token",
+      "HelpText": "Enter the name of the ArgoCD Auth Token used to authenticate with. This sets the `--auth-token` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e738d659-aca8-4fc4-a021-36d57ec71325",
+      "Name": "ArgoCD.AppGet.ApplicationName",
+      "Label": "ArgoCD Application Name",
+      "HelpText": "Enter the name of the application you want to retrieve details for.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "566e77a0-fb80-4c3f-b2ef-cffaa2a2d797",
+      "Name": "ArgoCD.AppGet.AdditionalParameters",
+      "Label": "Additional Parameters (optional)",
+      "HelpText": "Enter additional parameter values(s) to be used when calling the `argocd` CLI. \n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.KubernetesRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-07-22T09:53:25.057Z",
+    "OctopusVersion": "2024.3.7046",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harrisonmeister",
+  "Category": "argo"
+}

--- a/step-templates/argo-argocd-app-set-with-package.json
+++ b/step-templates/argo-argocd-app-set-with-package.json
@@ -1,0 +1,99 @@
+{
+  "Id": "8bcfe67d-cade-4fe3-a792-ce799dfb9ec1",
+  "Name": "Argo - argocd app set (with package)",
+  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command.\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n- Selection of a package (for use with setting image parameters)",
+  "ActionType": "Octopus.KubernetesRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "9f2ad876-ad42-428d-bda9-676c6aaa0b60",
+      "Name": "ArgoCD.AppSet.ContainerImage",
+      "PackageId": null,
+      "FeedId": "Feeds-3807",
+      "AcquisitionLocation": "NotAcquired",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "ArgoCD.AppSet.ContainerImage",
+        "Purpose": ""
+      }
+    }
+  ],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "# argocd is required\nif ! [ -x \"$(command -v argocd)\" ]; then\n\tfail_step 'argocd command not found'\nfi\n\n# Helper functions\nisSet() { [ ! -z \"${1}\" ]; }\nisNotSet() { [ -z \"${1}\" ]; }\n\n# Get variables\nargocd_server=$(get_octopusvariable \"ArgoCD.AppSet.ArgoCD_Server\")\nargocd_authToken=$(get_octopusvariable \"ArgoCD.AppSet.ArgoCD_Auth_Token\")\napplicationName=$(get_octopusvariable \"ArgoCD.AppSet.ApplicationName\")\napplicationParameters=$(get_octopusvariable \"ArgoCD.AppSet.AppParameters\")\nadditionalParameters=$(get_octopusvariable \"ArgoCD.AppSet.AdditionalParameters\")\n\n# Check required variables\nif isNotSet \"${argocd_server}\"; then\n  fail_step \"argocd_server is not set\"\nfi\n\nif isNotSet \"${argocd_authToken}\"; then\n  fail_step \"argocd_authToken is not set\"\nfi\n\nif isNotSet \"${applicationName}\"; then\n  fail_step \"applicationName is not set\"\nfi\n\nif isSet \"${applicationParameters}\"; then\n  parameters=\"${applicationParameters//$'\\n'/ \\\\$'\\n'}\"\n  flattenedParams=\"${applicationParameters//$'\\n'/ }\"\n  IFS=$'\\n' read -rd '' -a appParameters <<< \"$applicationParameters\"\nelse\n  appParameters=()\nfi\nflattenedParams=\"${appParameters[@]}\"\n\n\nif isSet \"${additionalParameters}\"; then\n  IFS=$'\\n' read -rd '' -a additionalArgs <<< \"$additionalParameters\"\nelse\n  additionalArgs=()\nfi\n\nflattenedArgs=\"${additionalArgs[@]}\"\n\nwrite_verbose \"ARGOCD_SERVER: '${argocd_server}'\"\nwrite_verbose \"ARGOCD_AUTH_TOKEN: '********'\"\n\nauthArgs=\"--server ${argocd_server} --auth-token ${argocd_authToken}\"\nmaskedAuthArgs=\"--server ${argocd_server} --auth-token '********'\"\n\necho \"Executing: argocd app set ${applicationName} ${maskedAuthArgs} ${flattenedArgs} \\\\ \n${parameters}\"\nargocd app set ${applicationName} ${authArgs} ${flattenedArgs} ${flattenedParams}"
+  },
+  "Parameters": [
+    {
+      "Id": "0a5f6eea-c876-4db2-a4ab-ea5b5d35fddb",
+      "Name": "ArgoCD.AppSet.ArgoCD_Server",
+      "Label": "ArgoCD Server",
+      "HelpText": "Enter the name of the ArgoCD Server to connect to. This sets the `--server` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4c034426-cf1d-4e9a-a69c-4de4aa6cde31",
+      "Name": "ArgoCD.AppSet.ArgoCD_Auth_Token",
+      "Label": "ArgoCD Auth Token",
+      "HelpText": "Enter the name of the ArgoCD Auth Token used to authenticate with. This sets the `--auth-token` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e738d659-aca8-4fc4-a021-36d57ec71325",
+      "Name": "ArgoCD.AppSet.ApplicationName",
+      "Label": "ArgoCD Application Name",
+      "HelpText": "Enter the ArgoCD application name",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "b2054ad2-3c41-47bb-ac96-d5d8a6564ea6",
+      "Name": "ArgoCD.AppSet.ContainerImage",
+      "Label": "Container image",
+      "HelpText": "Provide the container image details",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "2adb0917-6b2d-4528-90a4-beff6a01109d",
+      "Name": "ArgoCD.AppSet.AppParameters",
+      "Label": "Application Parameters",
+      "HelpText": "Enter the parameters to set for the application, including the `--parameter` or `-p`. e.g.:\n- `-p key1=value1`\n- `--parameter key2=value2`\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "b13a3a5e-ac79-477d-bd51-cf6efd009bd4",
+      "Name": "ArgoCD.AppSet.AdditionalParameters",
+      "Label": "Additional Parameters (optional)",
+      "HelpText": "Enter additional parameter values(s) to be used when calling the `argocd` CLI.\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.KubernetesRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-07-22T09:55:12.863Z",
+    "OctopusVersion": "2024.3.7046",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harrisonmeister",
+  "Category": "argo"
+}

--- a/step-templates/argo-argocd-app-set-with-package.json
+++ b/step-templates/argo-argocd-app-set-with-package.json
@@ -10,7 +10,7 @@
       "Id": "9f2ad876-ad42-428d-bda9-676c6aaa0b60",
       "Name": "ArgoCD.AppSet.ContainerImage",
       "PackageId": null,
-      "FeedId": "Feeds-3807",
+      "FeedId": null,
       "AcquisitionLocation": "NotAcquired",
       "Properties": {
         "Extract": "True",

--- a/step-templates/argo-argocd-app-set.json
+++ b/step-templates/argo-argocd-app-set.json
@@ -1,0 +1,75 @@
+{
+  "Id": "e27c8535-9375-4cd2-97e7-ac73a43e9ef1",
+  "Name": "Argo - argocd app set",
+  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command. \n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "ActionType": "Octopus.KubernetesRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "# argocd is required\nif ! [ -x \"$(command -v argocd)\" ]; then\n\tfail_step 'argocd command not found'\nfi\n\n# Helper functions\nisSet() { [ ! -z \"${1}\" ]; }\nisNotSet() { [ -z \"${1}\" ]; }\n\n# Get variables\nargocd_server=$(get_octopusvariable \"ArgoCD.AppSet.ArgoCD_Server\")\nargocd_authToken=$(get_octopusvariable \"ArgoCD.AppSet.ArgoCD_Auth_Token\")\napplicationName=$(get_octopusvariable \"ArgoCD.AppSet.ApplicationName\")\napplicationParameters=$(get_octopusvariable \"ArgoCD.AppSet.AppParameters\")\nadditionalParameters=$(get_octopusvariable \"ArgoCD.AppSet.AdditionalParameters\")\n\n# Check required variables\nif isNotSet \"${argocd_server}\"; then\n  fail_step \"argocd_server is not set\"\nfi\n\nif isNotSet \"${argocd_authToken}\"; then\n  fail_step \"argocd_authToken is not set\"\nfi\n\nif isNotSet \"${applicationName}\"; then\n  fail_step \"applicationName is not set\"\nfi\n\nif isSet \"${applicationParameters}\"; then\n  parameters=\"${applicationParameters//$'\\n'/ \\\\$'\\n'}\"\n  flattenedParams=\"${applicationParameters//$'\\n'/ }\"\n  IFS=$'\\n' read -rd '' -a appParameters <<< \"$applicationParameters\"\nelse\n  appParameters=()\nfi\nflattenedParams=\"${appParameters[@]}\"\n\n\nif isSet \"${additionalParameters}\"; then\n  IFS=$'\\n' read -rd '' -a additionalArgs <<< \"$additionalParameters\"\nelse\n  additionalArgs=()\nfi\n\nflattenedArgs=\"${additionalArgs[@]}\"\n\nwrite_verbose \"ARGOCD_SERVER: '${argocd_server}'\"\nwrite_verbose \"ARGOCD_AUTH_TOKEN: '********'\"\n\nauthArgs=\"--server ${argocd_server} --auth-token ${argocd_authToken}\"\nmaskedAuthArgs=\"--server ${argocd_server} --auth-token '********'\"\n\necho \"Executing: argocd app set ${applicationName} ${maskedAuthArgs} ${flattenedArgs} \\\\ \n${parameters}\"\nargocd app set ${applicationName} ${authArgs} ${flattenedArgs} ${flattenedParams}"
+  },
+  "Parameters": [
+    {
+      "Id": "0a5f6eea-c876-4db2-a4ab-ea5b5d35fddb",
+      "Name": "ArgoCD.AppSet.ArgoCD_Server",
+      "Label": "ArgoCD Server",
+      "HelpText": "Enter the name of the ArgoCD Server to connect to. This sets the `--server` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4c034426-cf1d-4e9a-a69c-4de4aa6cde31",
+      "Name": "ArgoCD.AppSet.ArgoCD_Auth_Token",
+      "Label": "ArgoCD Auth Token",
+      "HelpText": "Enter the name of the ArgoCD Auth Token used to authenticate with. This sets the `--auth-token` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e738d659-aca8-4fc4-a021-36d57ec71325",
+      "Name": "ArgoCD.AppSet.ApplicationName",
+      "Label": "ArgoCD Application Name",
+      "HelpText": "Enter the ArgoCD application name",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "2adb0917-6b2d-4528-90a4-beff6a01109d",
+      "Name": "ArgoCD.AppSet.AppParameters",
+      "Label": "Application Parameters",
+      "HelpText": "Enter the parameters to set for the application, including the `--parameter` or `-p`. e.g.:\n- `-p key1=value1`\n- `--parameter key2=value2`\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "b13a3a5e-ac79-477d-bd51-cf6efd009bd4",
+      "Name": "ArgoCD.AppSet.AdditionalParameters",
+      "Label": "Additional Parameters (optional)",
+      "HelpText": "Enter additional parameter values(s) to be used when calling the `argocd` CLI.\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.KubernetesRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-07-22T09:57:16.491Z",
+    "OctopusVersion": "2024.3.7046",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harrisonmeister",
+  "Category": "argo"
+}

--- a/step-templates/argo-argocd-app-sync.json
+++ b/step-templates/argo-argocd-app-sync.json
@@ -1,0 +1,65 @@
+{
+  "Id": "655058aa-2e76-4aac-a8eb-728337b5c664",
+  "Name": "Argo - argocd app sync",
+  "Description": "Sync an application to its target state using the [argocd app sync](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_sync/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "ActionType": "Octopus.KubernetesRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "# argocd is required\nif ! [ -x \"$(command -v argocd)\" ]; then\n\tfail_step 'argocd command not found'\nfi\n\n# Helper functions\nisSet() { [ ! -z \"${1}\" ]; }\nisNotSet() { [ -z \"${1}\" ]; }\n\n# Get variables\nargocd_server=$(get_octopusvariable \"ArgoCD.AppSync.ArgoCD_Server\")\nargocd_authToken=$(get_octopusvariable \"ArgoCD.AppSync.ArgoCD_Auth_Token\")\napplicationSelector=$(get_octopusvariable \"ArgoCD.AppSync.ApplicationSelector\")\nadditionalParameters=$(get_octopusvariable \"ArgoCD.AppSync.AdditionalParameters\")\n\n# Check required variables\nif isNotSet \"${argocd_server}\"; then\n  fail_step \"argocd_server is not set\"\nfi\n\nif isNotSet \"${argocd_authToken}\"; then\n  fail_step \"argocd_authToken is not set\"\nfi\n\nif isNotSet \"${applicationSelector}\"; then\n  fail_step \"applicationSelector is not set\"\nfi\n\nif isSet \"${additionalParameters}\"; then\n  IFS=$'\\n' read -rd '' -a additionalArgs <<< \"$additionalParameters\"\nelse\n  additionalArgs=()\nfi\n\nflattenedArgs=\"${additionalArgs[@]}\"\n\nwrite_verbose \"ARGOCD_SERVER: '${argocd_server}'\"\nwrite_verbose \"ARGOCD_AUTH_TOKEN: '********'\"\n\nauthArgs=\"--server ${argocd_server} --auth-token ${argocd_authToken}\"\nmaskedAuthArgs=\"--server ${argocd_server} --auth-token '********'\"\n\necho \"Executing: argocd app sync ${applicationSelector} ${maskedAuthArgs} ${flattenedArgs}\"\nargocd app sync ${applicationSelector} ${authArgs} ${flattenedArgs}"
+  },
+  "Parameters": [
+    {
+      "Id": "0a5f6eea-c876-4db2-a4ab-ea5b5d35fddb",
+      "Name": "ArgoCD.AppSync.ArgoCD_Server",
+      "Label": "ArgoCD Server",
+      "HelpText": "Enter the name of the ArgoCD Server to connect to. This sets the `--server` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4c034426-cf1d-4e9a-a69c-4de4aa6cde31",
+      "Name": "ArgoCD.AppSync.ArgoCD_Auth_Token",
+      "Label": "ArgoCD Auth Token",
+      "HelpText": "Enter the name of the ArgoCD Auth Token used to authenticate with. This sets the `--auth-token` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e738d659-aca8-4fc4-a021-36d57ec71325",
+      "Name": "ArgoCD.AppSync.ApplicationSelector",
+      "Label": "ArgoCD Application Selector",
+      "HelpText": "Enter the ArgoCD application details you want to sync. Valid examples are:\n- Application Name(s) e.g.`appname`\n- Labels e.g. `-l app.kubernetes.io/instance=my-app`\n- Specific resource e.g. `--resource :Service:my-service`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "566e77a0-fb80-4c3f-b2ef-cffaa2a2d797",
+      "Name": "ArgoCD.AppSync.AdditionalParameters",
+      "Label": "Additional Parameters (optional)",
+      "HelpText": "Enter additional parameter values(s) to be used when calling the `argocd` CLI. e.g.:\n- `--revisions 0.0.1` \n- `--source-positions 1`\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.KubernetesRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-07-22T09:54:04.913Z",
+    "OctopusVersion": "2024.3.7046",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harrisonmeister",
+  "Category": "argo"
+}

--- a/step-templates/argo-argocd-app-wait.json
+++ b/step-templates/argo-argocd-app-wait.json
@@ -1,0 +1,65 @@
+{
+  "Id": "050e7819-ecf7-46de-bcd2-545f0956c1c5",
+  "Name": "Argo - argocd app wait",
+  "Description": "Wait for an application to reach a synced and healthy state using the [argocd app wait](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_wait/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "ActionType": "Octopus.KubernetesRunScript",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptBody": "# argocd is required\nif ! [ -x \"$(command -v argocd)\" ]; then\n\tfail_step 'argocd command not found'\nfi\n\n# Helper functions\nisSet() { [ ! -z \"${1}\" ]; }\nisNotSet() { [ -z \"${1}\" ]; }\n\n# Get variables\nargocd_server=$(get_octopusvariable \"ArgoCD.AppWait.ArgoCD_Server\")\nargocd_authToken=$(get_octopusvariable \"ArgoCD.AppWait.ArgoCD_Auth_Token\")\napplicationSelector=$(get_octopusvariable \"ArgoCD.AppWait.ApplicationSelector\")\nadditionalParameters=$(get_octopusvariable \"ArgoCD.AppWait.AdditionalParameters\")\n\n# Check required variables\nif isNotSet \"${argocd_server}\"; then\n  fail_step \"argocd_server is not set\"\nfi\n\nif isNotSet \"${argocd_authToken}\"; then\n  fail_step \"argocd_authToken is not set\"\nfi\n\nif isNotSet \"${applicationSelector}\"; then\n  fail_step \"applicationSelector is not set\"\nfi\n\nif isSet \"${additionalParameters}\"; then\n  IFS=$'\\n' read -rd '' -a additionalArgs <<< \"$additionalParameters\"\nelse\n  additionalArgs=()\nfi\n\nflattenedArgs=\"${additionalArgs[@]}\"\n\nwrite_verbose \"ARGOCD_SERVER: '${argocd_server}'\"\nwrite_verbose \"ARGOCD_AUTH_TOKEN: '********'\"\n\nauthArgs=\"--server ${argocd_server} --auth-token ${argocd_authToken}\"\nmaskedAuthArgs=\"--server ${argocd_server} --auth-token '********'\"\n\necho \"Executing: argocd app wait ${applicationSelector} ${maskedAuthArgs} ${flattenedArgs}\"\nargocd app wait ${applicationSelector} ${authArgs} ${flattenedArgs}"
+  },
+  "Parameters": [
+    {
+      "Id": "0a5f6eea-c876-4db2-a4ab-ea5b5d35fddb",
+      "Name": "ArgoCD.AppWait.ArgoCD_Server",
+      "Label": "ArgoCD Server",
+      "HelpText": "Enter the name of the ArgoCD Server to connect to. This sets the `--server` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "4c034426-cf1d-4e9a-a69c-4de4aa6cde31",
+      "Name": "ArgoCD.AppWait.ArgoCD_Auth_Token",
+      "Label": "ArgoCD Auth Token",
+      "HelpText": "Enter the name of the ArgoCD Auth Token used to authenticate with. This sets the `--auth-token` parameter used with the CLI.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      }
+    },
+    {
+      "Id": "e738d659-aca8-4fc4-a021-36d57ec71325",
+      "Name": "ArgoCD.AppWait.ApplicationSelector",
+      "Label": "ArgoCD Application Selector",
+      "HelpText": "Enter the ArgoCD application details you want to wait. Valid examples are:\n- Application Name(s) e.g.`appname`\n- Labels e.g. `-l app.kubernetes.io/instance=my-app`\n- Specific resource e.g. `--resource :Service:my-service`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "566e77a0-fb80-4c3f-b2ef-cffaa2a2d797",
+      "Name": "ArgoCD.AppWait.AdditionalParameters",
+      "Label": "Additional Parameters (optional)",
+      "HelpText": "Enter additional parameter values(s) to be used when calling the `argocd` CLI. e.g.:\n- `--app-namespace` \n- `--degraded`\n- `--sync`\n\n**Note:** Multiple parameters can be supplied by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.KubernetesRunScript",
+  "$Meta": {
+    "ExportedAt": "2024-07-22T09:54:34.458Z",
+    "OctopusVersion": "2024.3.7046",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "harrisonmeister",
+  "Category": "argo"
+}


### PR DESCRIPTION
This PR introduces 5 new step templates:

1. Argo - argocd app get
2. Argo - argocd app set
3. Argo - argocd app set (with package)
4. Argo - argocd app sync
5. Argo - argocd app wait

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
