### PR TITLE
Unpack scripts under test automatically

### DIFF
--- a/step-templates/tests/Invoke-PesterTests.ps1
+++ b/step-templates/tests/Invoke-PesterTests.ps1
@@ -3,36 +3,60 @@ Set-StrictMode -Version "Latest";
 
 $thisScript = $MyInvocation.MyCommand.Path;
 $thisFolder = [System.IO.Path]::GetDirectoryName($thisScript);
-$rootFolder = [System.IO.Path]::GetDirectoryName($thisFolder);
-$parentFolder = [System.IO.Path]::GetDirectoryName($rootFolder);
-
-# Unpack any tests that are not present
-$testableScripts = Get-ChildItem -Path $thisFolder -Filter "*.ScriptBody.ps1"
-foreach ($script in $testableScripts) {
-    $filename = [System.IO.Path]::Combine($rootFolder, $script.Name)
-    if (-not [System.IO.File]::Exists($filename)) {
-        $searchpattern = $script.BaseName -replace "\.ScriptBody$"
-        $toolsFolder = [System.IO.Path]::Combine($parentFolder, "tools")
-        $converter = [System.IO.Path]::Combine($toolsFolder, "Converter.ps1")
-        & $converter -operation unpack -searchpattern $searchpattern
-    }
-    . $filename;
-}
-
-# Attempt to use local Pester module, fallback to global if not found
-try {
-    $packagesFolder = [System.IO.Path]::Combine($rootFolder, "packages")
-    $pester3Path = [System.IO.Path]::Combine($packagesFolder, "Pester\tools\Pester")
-    # Import the specific version of Pester 3.4.0
-    Import-Module -Name $pester3Path -RequiredVersion 3.4.0 -ErrorAction Stop
-} catch {
-    Write-Host "Using globally installed Pester module version 3.4.0."
-    # Specify the exact version of Pester 3.x you have installed
-    Import-Module -Name Pester -RequiredVersion 3.4.0 -ErrorAction Stop}
-
-# Find and run all Pester test files in the tests directory
+$rootFolder = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($thisFolder, "..", "..")); # Adjust to always point to the root
 $testFiles = Get-ChildItem -Path "$thisFolder" -Filter "*.tests.ps1" -Recurse
-foreach ($testFile in $testFiles) {
-    Write-Host "Running tests in: $($testFile.FullName)"
-    Invoke-Pester -Path $testFile.FullName
+
+function Unpack-Scripts-Under-Test {
+  foreach ($testFile in $testFiles) {
+      $baseName = $testFile.BaseName -replace "\.ScriptBody.Tests$"
+      $scriptFileName = "$baseName.ScriptBody.ps1"
+      $scriptFilePath = [System.IO.Path]::Combine($rootFolder, "step-templates", $scriptFileName)
+
+      # If the .ps1 file is missing, find the corresponding .json file and unpack it
+      if (-not [System.IO.File]::Exists($scriptFilePath)) {
+          Write-Host "Unpacking script for $($testFile.Name) since $scriptFileName is missing..."
+
+          $jsonFileName = "$baseName.json"
+          $jsonFilePath = [System.IO.Path]::Combine($rootFolder, "step-templates", $jsonFileName)
+
+          if (-not [System.IO.File]::Exists($jsonFilePath)) {
+              throw "JSON file $jsonFileName not found. Cannot unpack script."
+          }
+
+          $converter = [System.IO.Path]::Combine($rootFolder, "tools", "Converter.ps1")
+          & $converter -operation unpack -searchpattern $baseName
+
+          if (-not [System.IO.File]::Exists($scriptFilePath)) {
+              throw "Failed to unpack $scriptFileName. Make sure the JSON template exists and the unpack operation succeeded."
+          }
+      } else {
+          Write-Host "Script $scriptFileName already exists, no need to unpack."
+      }
+  }
 }
+
+function Import-Pester {
+  # Attempt to use local Pester module, fallback to global if not found
+  try {
+      $packagesFolder = [System.IO.Path]::Combine($rootFolder, "packages")
+      $pester3Path = [System.IO.Path]::Combine($packagesFolder, "Pester\tools\Pester")
+      # Import the specific version of Pester 3.4.0
+      Import-Module -Name $pester3Path -RequiredVersion 3.4.0 -ErrorAction Stop
+  } catch {
+      Write-Host "Using globally installed Pester module version 3.4.0."
+      # Specify the exact version of Pester 3.x you have installed
+      Import-Module -Name Pester -RequiredVersion 3.4.0 -ErrorAction Stop
+  }
+}
+
+function Run-Tests {
+  # Find and run all Pester test files in the tests directory
+  foreach ($testFile in $testFiles) {
+      Write-Host "Running tests in: $($testFile.FullName)"
+      Invoke-Pester -Path $testFile.FullName
+  }
+}
+
+Import-Pester
+Unpack-Scripts-Under-Test
+Run-Tests


### PR DESCRIPTION
**Background**
On a fresh clone of the repo, I was unable to run pester tests until I manually extracted them the scripts under test. There is some code in Invoke-PesterTests.ps1 that is _supposed_ to unpack any scripts under test, but it does not seem to work properly.

With this change, the code has been reorganized into 3 functions, `Import-Pester`, `Run-Tests` and `Unpack-Scripts-Under-Test`, with the code for `Unpack-Scripts-Under-Test` reworked the most to make it reliable.

**Pre-requisites**
[NA] Id should be a GUID that is not 00000000-0000-0000-0000-000000000000
NOTE If you are modifying an existing step template, please make sure that you do not modify the Id property (updating the Id will break the Library sync functionality in Octopus).
[NA] Version should be incremented, otherwise the integration with Octopus won't update the step template correctly
[NA] Parameter names should not start with $
[NA] Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus (see https://github.com/OctopusDeploy/Issues/issues/2126). For example, use an abbreviated name of the step template or the category of the step template).
[NA] LastModifiedBy field must be present, and (optionally) updated with the correct author
[✔] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
[NA] If a new Category has been created:
[NA] An image with the name {categoryname}.png must be present under the step-templates/logos folder
[NA] The switch in the humanize function in [gulpfile.babel.js](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a case statement corresponding to it