### PR TITLE
Account variables must be octostache templates

### DIFF
--- a/step-templates/octopus-apply-octoterra-module-azure.json
+++ b/step-templates/octopus-apply-octoterra-module-azure.json
@@ -3,7 +3,7 @@
   "Name": "Octopus - Populate Octoterra Space (Azure Backend)",
   "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform Azure backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
-  "Version": 1,
+  "Version": 2,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -38,7 +38,7 @@
     "Octopus.Action.Aws.AssumeRole": "False",
     "Octopus.Action.Terraform.TemplateDirectory": "space_population",
     "Octopus.Action.Terraform.FileSubstitution": "**/project_variable_sensitive*.tf",
-    "Octopus.Action.AzureAccount.Variable": "OctoterraApply.Azure.Account"
+    "Octopus.Action.AzureAccount.Variable": "#{OctoterraApply.Azure.Account}"
   },
   "Parameters": [
     {

--- a/step-templates/octopus-apply-octoterra-module-s3.json
+++ b/step-templates/octopus-apply-octoterra-module-s3.json
@@ -3,7 +3,7 @@
   "Name": "Octopus - Populate Octoterra Space (S3 Backend)",
   "Description": "This step exposes the fields required to deploy a project or space serialized with [octoterra](https://github.com/OctopusSolutionsEngineering/OctopusTerraformExport) using Terraform.\n\nThis step configures a Terraform S3 backend.\n\nIt is recommended that this step be run with the `octopuslabs/terraform-workertools` worker image.",
   "ActionType": "Octopus.TerraformApply",
-  "Version": 3,
+  "Version": 4,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -34,7 +34,7 @@
     "Octopus.Action.Package.DownloadOnTentacle": "False",
     "Octopus.Action.RunOnServer": "true",
     "Octopus.Action.AwsAccount.UseInstanceRole": "False",
-    "Octopus.Action.AwsAccount.Variable": "OctoterraApply.AWS.Account",
+    "Octopus.Action.AwsAccount.Variable": "#{OctoterraApply.AWS.Account}",
     "Octopus.Action.Aws.AssumeRole": "False",
     "Octopus.Action.Aws.Region": "#{OctoterraApply.AWS.S3.BucketRegion}",
     "Octopus.Action.Terraform.TemplateDirectory": "space_population",


### PR DESCRIPTION
# Background

Account parameters passed to Terraform steps must be resolved as Octostache templates rather than literal strings.

# Results

This PR fixes the AWS and Azure accounts passed to Terraform apply steps so they are correctly resolved.

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
