### PR TITLE
Use `pull_request_target` instead of `pull_request`

### DIFF
--- a/.github/workflows/Hyponome.yml
+++ b/.github/workflows/Hyponome.yml
@@ -1,6 +1,6 @@
 name: Link to hyponome
 on: 
-  pull_request:
+  pull_request_target:
     types: [opened]
     paths:
       - 'step-templates/**'


### PR DESCRIPTION
The GH Token generated will have permissions to comment on PRs from public forks as well as local PRs and should be safe as explained [here](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)