### PR TITLE
Removing broken link

### DIFF
--- a/step-templates/yams-upload.json
+++ b/step-templates/yams-upload.json
@@ -1,7 +1,7 @@
 {
   "Id": "a1d95c5f-42fb-43b3-8bee-74a255f2ae71",
   "Name": "YAMS Uploader",
-  "Description": "Upload YAMS application.\n\n[YAMS](https://github.com/Microsoft/Yams) is a library that can be used to deploy and host microservices in the cloud or on premises. This step uses [YAMS Uploader](https://github.com/Applicita/YamsUploader) to publish applications to YAMS cluster.",
+  "Description": "Upload YAMS application.\n\n[YAMS](https://github.com/Microsoft/Yams) is a library that can be used to deploy and host microservices in the cloud or on premises. This step uses YAMS Uploader to publish applications to YAMS cluster.",
   "ActionType": "Octopus.Script",
   "Version": 1,
   "Properties": {


### PR DESCRIPTION
# Background

Fixing a broken link

# Pre-requisites

- [ ] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [ ] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [ ] Parameter names should not start with `$`
- [ ] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [ ] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [ ] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
