### PR TITLE
Remove space from link.

### DIFF
--- a/step-templates/hockeyapp-upload-mobile-app.json
+++ b/step-templates/hockeyapp-upload-mobile-app.json
@@ -13,7 +13,7 @@
     {
       "Name": "HockeyAppApiToken",
       "Label": "HockeyApp Api Token",
-      "HelpText": "HockeyApp requires an access token for their API as show in the [HockeyApp API Authentication Documentation]( http://support.hockeyapp.net/kb/api/api-basics-and-authentication#authentication). Logged in users can generate tokens under [API Tokens](https://rink.hockeyapp.net/manage/auth_tokens) in the account menu.\n\nYou should generate an application specific token for this purpose.",
+      "HelpText": "HockeyApp requires an access token for their API as show in the [HockeyApp API Authentication Documentation](http://support.hockeyapp.net/kb/api/api-basics-and-authentication#authentication). Logged in users can generate tokens under [API Tokens](https://rink.hockeyapp.net/manage/auth_tokens) in the account menu.\n\nYou should generate an application specific token for this purpose.",
       "DefaultValue": null,
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"


### PR DESCRIPTION
# Background

The markdown link has a leading space. This should be removed.
