### PR TITLE
Create Manual-Intervention-User-Restrictions-Enforcement.json

### DIFF
--- a/step-templates/Manual-Intervention-User-Restrictions-Enforcement.json
+++ b/step-templates/Manual-Intervention-User-Restrictions-Enforcement.json
@@ -1,0 +1,55 @@
+{
+  "Id": "06080873-f7f1-47e9-aaac-7ec1927f8146",
+  "Name": "Manual Intervention User Restrictions Enforcement",
+  "Description": "Use directly after a Manual Intervention step to enforce additional restrictions.\n\nUse cases include: \n- Preventing users from approving their own deployments\n- Restricting certain users (up to 2) from approving deployments",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptBody": "$manIntStepName = $OctopusParameters[\"URE.ManualInterventionStepName\"]\n\nWrite-Host \"Created by: \"$OctopusParameters[\"Octopus.Deployment.CreatedBy.Username\"]\nWrite-Host \"Approved by: \"$OctopusParameters[\"Octopus.Action[$manIntStepName].Output.Manual.ResponsibleUser.Username\"]\n\nIf ($OctopusParameters[\"URE.PreventDeployerFromApproving\"] -eq $true) {\n  $deploymentCreatedByUsername = $OctopusParameters[\"Octopus.Deployment.CreatedBy.Username\"]\n}\n$approvedByUsername = $OctopusParameters[\"Octopus.Action[$manIntStepName].Output.Manual.ResponsibleUser.Username\"]\n\nIf ($approvedByUsername -eq $deploymentCreatedByUsername) {\n  Write-Warning \"The same user may not be used to both start the deployment and approve the deployment.\"\n  Write-Warning \"Please retry the deployment with a different approver for the $manIntStepName step.\"\n  throw \"Terminating deployment...\"\n}\nElse {\n  $excludedUserList = $OctopusParameters[\"URE.ExcludedUsers\"].Split([System.Environment]::NewLine)\n  If ($excludedUserList -contains $approvedByUsername) {\n  Write-Warning \"The user $approvedByUsername may not approve this deployment.\"\n  Write-Warning \"Please retry the deployment with a different approver for the $manIntStepName step.\"\n  throw \"Terminating deployment...\"\n  }\n}\n\nIf (($OctopusParameters[\"URE.PreventDeployerFromApproving\"] -ne $true) -and (!$excludedUserList)) {\n  Write-Host \">>>PreventDeployerFromApproving set to FALSE\" \n  Write-Host \">>>ExcludedUsers contain no value(s)\"\n}\nWrite-Host \"Check complete\"\nWrite-Host \"Continuing...\"\n  "
+  },
+  "Parameters": [
+    {
+      "Id": "d3e12917-2af0-4cff-988a-083e30a36314",
+      "Name": "URE.PreventDeployerFromApproving",
+      "Label": "Prevent Deployer from approving?",
+      "HelpText": "When enabled, this terminates a deployment when the user who initiated the deployment also approves the manual intervention step",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "4ec5ca6e-b033-44f9-8746-e926d853b4ec",
+      "Name": "URE.ManualInterventionStepName",
+      "Label": "Manual Intervention step name",
+      "HelpText": "Select the step name from drop down",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "StepName"
+      }
+    },
+    {
+      "Id": "fed4cffe-d286-4793-ac6b-0d0b3ac35b27",
+      "Name": "URE.ExcludedUsers",
+      "Label": "Excluded Users",
+      "HelpText": "Usernames of users to be excluded from manual intervention approvals (one per line)",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2025-04-16T21:40:42.587Z",
+    "OctopusVersion": "2025.2.6682",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "donnybell",
+  "Category": "Octopus"
+}


### PR DESCRIPTION
# Background

To enhance the Manual Intervention step by adding a QOL Step Template which:

- Allows users to be excluded from a specified team used for Manual Intervention
- Can prevent the user responsible for a given Deployment from approving the Manual Intervention themselves

# Results
Stops a deployment with a warning and an error if parameters detect an issue

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
