### PR TITLE
Update microsoft-teams-post-a-message.json

### DIFF
--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -1,7 +1,7 @@
 {
   "Id": "110a8b1e-4da4-498a-9209-ef8929c31168",
-  "Name": "Microsoft Teams - Post a message",
-  "Description": "Posts a message to Microsoft Teams using a general webhook.",
+  "Name": "Microsoft Teams - Post a message (Deprecated)",
+  "Description": "No longer functional due to Microsoft's webhook deprecation with Office 365 / MS Teams in Jan 2025. Please use the Microsoft Power Automate - Post AdaptiveCard step instead.",
   "ActionType": "Octopus.Script",
   "Version": 24,
   "CommunityActionTemplateId": null,

--- a/step-templates/microsoft-teams-post-a-message.json
+++ b/step-templates/microsoft-teams-post-a-message.json
@@ -3,7 +3,7 @@
   "Name": "Microsoft Teams - Post a message (Deprecated)",
   "Description": "No longer functional due to Microsoft's webhook deprecation with Office 365 / MS Teams in Jan 2025. Please use the Microsoft Power Automate - Post AdaptiveCard step instead.",
   "ActionType": "Octopus.Script",
-  "Version": 24,
+  "Version": 25,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {


### PR DESCRIPTION
# Background

Updated the name and description due to the [MS deprecation here](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/).

# Results

  Preview:
  ![image](https://github.com/user-attachments/assets/c1bd7d9b-105c-4902-8a83-989bd16673ff)


## Before

  "Name": "Microsoft Teams - Post a message",
  "Description": "Posts a message to Microsoft Teams using a general webhook.",

## After

  "Name": "Microsoft Teams - Post a message (Deprecated)",
  "Description": "No longer functional due to Microsoft's webhook deprecation with Office 365 / MS Teams in Jan 2025. Please use the Microsoft Power Automate - Post AdaptiveCard step instead.",

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
