### PR TITLE
Add Conjur step template with JWT authentication

### DIFF
--- a/step-templates/cyberark-secretsmanager-retrieve-secrets-jwt.json
+++ b/step-templates/cyberark-secretsmanager-retrieve-secrets-jwt.json
@@ -1,0 +1,95 @@
+{
+  "Id": "4b30f084-fb30-4c12-b0c4-0cd4eab05793",
+  "Name": "CyberArk Secrets Manager - Retrieve Secrets (JWT)",
+  "Description": "This step retrieves one or more secrets from CyberArk Secrets Manager and creates sensitive output variables for each value retrieved. It uses the JWT authenticator in Secrets Manager in combination with a Generic OIDC Account configured in Octopus to authenticate the workload.",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.Script.Syntax": "Python",
+    "Octopus.Action.Script.ScriptBody": "import subprocess\nimport sys\nimport tempfile\n\n# Install Conjur SDK\nsubprocess.check_call([sys.executable, '-m', 'pip', 'install', 'conjur-api', '--disable-pip-version-check'])\nsubprocess.check_call([sys.executable, '-m', 'pip', 'install', 'async-timeout', '--disable-pip-version-check'])\n\n# Conjur SDK imports\nfrom conjur_api.models import SslVerificationMode, ConjurConnectionInfo\nfrom conjur_api.providers import JWTAuthenticationStrategy\nfrom conjur_api import Client\nfrom conjur_api.errors.errors import HttpStatusError\n\n# Fetch configuration values\ndef retrieve_inputs():\n    inputs = {}\n    inputs[\"service_id\"] = get_octopusvariable('CyberArk.SecretsManager.ServiceId')\n    inputs[\"account\"] = get_octopusvariable('CyberArk.SecretsManager.Account')\n    inputs[\"url\"] = get_octopusvariable('CyberArk.SecretsManager.Url')\n    inputs[\"token\"] = get_octopusvariable('CyberArk.SecretsManager.Jwt.OpenIdConnect.Jwt')\n    inputs[\"variables\"] = get_octopusvariable('CyberArk.SecretsManager.Variables')\n    inputs[\"ca_bundle\"] = get_octopusvariable('CyberArk.SecretsManager.Certificate')\n    inputs[\"print_outputs\"] = get_octopusvariable('CyberArk.SecretsManager.PrintVariableNames')\n    return inputs\n\n# Validate the required inputs are not empty\ndef validate_inputs(inputs):\n    if not inputs[\"service_id\"]:\n        raise ValueError(\"Service ID is required.\")\n    if not inputs[\"account\"]:\n        raise ValueError(\"Account is required.\")\n    if not inputs[\"url\"]:\n        raise ValueError(\"Conjur URL is required.\")\n    if not inputs[\"token\"]:\n        raise ValueError(\"JWT token is required.\")\n    if not inputs[\"variables\"]:\n        raise ValueError(\"At least one variable must be specified.\")\n\n# Parse the requested input/output variables\n# If no output variable name is provided, the Conjur var ID will be used\ndef parse_variables(variables):\n    var_map = {}\n    for line_number, line in enumerate(variables.strip().splitlines(), start=1):\n        line = line.strip()\n        if not line:\n            continue\n\n        parts = [part.strip() for part in line.split('|')]\n        input_var = parts[0]\n        if len(parts) == 1:\n            output_var = input_var\n        elif len(parts) == 2:\n            output_var = parts[1]\n        else:\n            raise ValueError(f\"Variables line {line_number} has too many '|' characters: '{line}'\")\n\n        # Basic validations\n        if not input_var:\n            raise ValueError(f\"Variables line {line_number} is missing an input variable name: '{line}'\")\n        if ' ' in input_var or ' ' in output_var:\n            raise ValueError(f\"Variables line {line_number} has illegal spaces in a variable name: '{line}'\")\n\n        # Warn if any duplicate output vars exist\n        if output_var in var_map.values():\n            print(f\"WARN: Two or more secrets mapped to the same output variable: `{output_var}`. The earlier value will be overwritten.\")\n        var_map[input_var] = output_var\n    return var_map\n\n# Configure a Conjur client for JWT authentication\ndef create_conjur_client(inputs):\n    ssl_verification_mode = SslVerificationMode.TRUST_STORE\n    cert_file = None\n    # If a server certificate or CA was provided, use that instead of the default trust store\n    if inputs[\"ca_bundle\"]:\n        with tempfile.NamedTemporaryFile(mode='w', delete=False) as temp_cert_file:\n            temp_cert_file.write(inputs[\"ca_bundle\"])\n            cert_file = temp_cert_file.name\n        ssl_verification_mode = SslVerificationMode.CA_BUNDLE\n\n    connection_info = ConjurConnectionInfo(conjur_url=inputs[\"url\"],\n                                           account=inputs[\"account\"],\n                                           service_id=inputs[\"service_id\"],\n                                           cert_file=cert_file)\n    jwt_provider = JWTAuthenticationStrategy(inputs[\"token\"])\n    return Client(connection_info,\n                    authn_strategy=jwt_provider,\n                    ssl_verification_mode=ssl_verification_mode,\n                    async_mode=False)\n\n# Retrieve requested secrets from Conjur and set them as sensitive Octopus variables\ndef retrieve_secrets(var_map, client, inputs):\n    variable_ids = list(var_map.keys())\n    print(f\"INFO: Attempting to authenticate and retrieve {len(variable_ids)} secrets...\")\n    try:\n        retrieval_response = client.get_many(*variable_ids)\n    except HttpStatusError as e:\n        if e.response is not None:\n            if e.status == 401:\n                print(\"ERROR: Authentication failed. Please validate the JWT and authenticator configuration.\")\n            elif e.status == 403:\n                print(\"ERROR: Access denied. Please ensure the role has permissions to access the requested variables.\")\n            elif e.status == 404:\n                print(\"ERROR: One or more requested variables not found.\")\n        raise\n\n    print(\"INFO: Successfully retrieved secrets.\")\n\n    # Set the output variables\n    for input_var, output_var in var_map.items():\n        if input_var in retrieval_response:\n            set_octopusvariable(output_var, retrieval_response[input_var], True)\n\n    # Print a list output variable names if requested\n    if inputs[\"print_outputs\"]:\n        output_var_names = list(dict.fromkeys(var_map.values()))\n        print(f\"INFO: Populated sensitive output variables: {', '.join(output_var_names)}\")\n\n# Main execution starts here - this has to be inline to run in the Octopus environment\ninputs = retrieve_inputs()\nvalidate_inputs(inputs)\nvar_map = parse_variables(inputs[\"variables\"])\nclient = create_conjur_client(inputs)\nretrieve_secrets(var_map, client, inputs)\n"
+  },
+  "Parameters": [
+    {
+      "Id": "e750e1fc-3ffc-40cb-9d74-a2519d5451c1",
+      "Name": "CyberArk.SecretsManager.Url",
+      "Label": "Secrets Manager URL",
+      "HelpText": "The URL of the Secrets Manager instance.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "68b8272e-17e4-46ee-8042-09780a763530",
+      "Name": "CyberArk.SecretsManager.Account",
+      "Label": "Secrets Manager Account",
+      "HelpText": "The Secrets Manager account.",
+      "DefaultValue": "conjur",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "8ac15e8c-ba7f-4b20-8329-52df64f69729",
+      "Name": "CyberArk.SecretsManager.ServiceId",
+      "Label": "Authenticator Service ID",
+      "HelpText": "The service ID of the authn-jwt instance to be used for authentication to Secrets Manager.",
+      "DefaultValue": "octopus",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "42d42fe0-6d39-4970-be62-8ad34f611462",
+      "Name": "CyberArk.SecretsManager.Jwt",
+      "Label": "OIDC Account",
+      "HelpText": "The Generic OIDC Account configured in Octopus to generate JWT credentials for workload authentication to Secrets Manager.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "GenericOidcAccount"
+      }
+    },
+    {
+      "Id": "fe47f2ea-efa9-4468-b837-79a52ce3c22e",
+      "Name": "CyberArk.SecretsManager.Variables",
+      "Label": "Secrets Manager Variables",
+      "HelpText": "Specify the names of the secrets to be returned from Secrets Manager, in the format:\n\n`VariableID | OutputVariableName` where:\n\n* VariableID is the Variable ID of the secret to be retrieved from Secrets Manager.\n* OutputVariableName is the optional Octopus output variable name to store the secret's value in. If this value isn't specified, an output name will be generated dynamically based on the Variable ID.\n\n**Note:** Multiple Variable IDs can be retrieved by entering each one on a new line.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "8f8672c4-4e93-44b0-b7a7-ecf77e45f919",
+      "Name": "CyberArk.SecretsManager.Certificate",
+      "Label": "Trusted Server Certificate (Optional)",
+      "HelpText": "CA bundle or server certificate to establish a trusted TLS connection with Secrets Manager.\n\nYou can also use this to trust self-signed certificates.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "5ae5bb25-5f20-46d9-af93-90a493f75123",
+      "Name": "CyberArk.SecretsManager.PrintVariableNames",
+      "Label": "Print output variable names",
+      "HelpText": "Write out the Octopus output variable names to the task log.",
+      "DefaultValue": "False",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2025-05-21T14:32:50.303Z",
+    "OctopusVersion": "2025.2.10930",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "gl-johnson",
+  "Category": "cyberark"
+}


### PR DESCRIPTION
# Background

We have a customer ask to provide a CyberArk-certified step template using short-lived credentials (via Generic OIDC Accounts feature) to authenticate Octopus workloads and retrieve secrets from CyberArk Conjur.

# Results

This PR adds the aforementioned step template.

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
