### PR TITLE
Add msi installer package variable

### DIFF
--- a/step-templates/run-windows-installer.json
+++ b/step-templates/run-windows-installer.json
@@ -1,9 +1,9 @@
 {
   "Id": "f56647ac-7762-4986-bc98-c3fb74bb844f",
-  "Name": "Run - Windows Installer",
+  "Name": "Windows - Install MSI From Filesystem",
   "Description": "Runs the Windows Installer to non-interactively install an MSI",
   "ActionType": "Octopus.Script",
-  "Version": 13,
+  "Version": 14,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
@@ -85,13 +85,12 @@
       }
     }
   ],
-  "LastModifiedOn": "2019-11-07T17:00:00.000+00:00",
-  "LastModifiedBy": "jzabroski",
-  "SpaceId": "Spaces-1",
+  "LastModifiedOn": "2025-08-21T16:07:30.818Z",
   "$Meta": {
-    "ExportedAt": "2019-11-07T16:37:00.415Z",
-    "OctopusVersion": "2019.3.3",
+    "ExportedAt": "2025-08-21T16:07:30.818Z",
+    "OctopusVersion": "2025.2.13043",
     "Type": "ActionTemplate"
   },
+  "LastModifiedBy": "twerthi",
   "Category": "windows"
 }

--- a/step-templates/windows-install-msi.json
+++ b/step-templates/windows-install-msi.json
@@ -1,0 +1,110 @@
+{
+  "Id": "73994d6a-4cff-4bde-81c4-c4da362adaba",
+  "Name": "Windows - Install MSI",
+  "Description": "Runs the Windows Installer to non-interactively install an MSI",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Packages": [
+    {
+      "Id": "910a6653-0534-492a-98d8-f02196931773",
+      "Name": "Template.Package",
+      "PackageId": null,
+      "FeedId": "feeds-builtin",
+      "AcquisitionLocation": "Server",
+      "Properties": {
+        "Extract": "True",
+        "SelectionMode": "deferred",
+        "PackageParameterName": "Template.Package",
+        "Purpose": ""
+      }
+    }
+  ],
+  "GitDependencies": [],
+  "Properties": {
+    "Octopus.Action.Script.ScriptBody": "# Running outside octopus\nparam(\n    [string]$MsiFilePath,\n\t[ValidateSet(\"Install\", \"Repair\", \"Remove\", IgnoreCase=$true)]\n\t[string]$Action,\n\t[string]$ActionModifier,\n    [string]$LoggingOptions = \"*\",\n    [ValidateSet(\"False\", \"True\")]\n    [string]$LogAsArtifact,\n\t[string]$Properties,\n\t[int[]]$IgnoredErrorCodes,\n    [switch]$WhatIf\n) \n\n$ErrorActionPreference = \"Stop\"\n\n$ErrorMessages = @{\n\t\"0\" = \"Action completed successfully.\";\n\t\"13\" = \"The data is invalid.\";\n\t\"87\" = \"One of the parameters was invalid.\";\n\t\"1601\" = \"The Windows Installer service could not be accessed. Contact your support personnel to verify that the Windows Installer service is properly registered.\";\n\t\"1602\" = \"User cancel installation.\";\n\t\"1603\" = \"Fatal error during installation.\";\n\t\"1604\" = \"Installation suspended, incomplete.\";\n\t\"1605\" = \"This action is only valid for products that are currently installed.\";\n\t\"1606\" = \"Feature ID not registered.\";\n\t\"1607\" = \"Component ID not registered.\";\n\t\"1608\" = \"Unknown property.\";\n\t\"1609\" = \"Handle is in an invalid state.\";\n\t\"1610\" = \"The configuration data for this product is corrupt. Contact your support personnel.\";\n\t\"1611\" = \"Component qualifier not present.\";\n\t\"1612\" = \"The installation source for this product is not available. Verify that the source exists and that you can access it.\";\n\t\"1613\" = \"This installation package cannot be installed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.\";\n\t\"1614\" = \"Product is uninstalled.\";\n\t\"1615\" = \"SQL query syntax invalid or unsupported.\";\n\t\"1616\" = \"Record field does not exist.\";\n\t\"1618\" = \"Another installation is already in progress. Complete that installation before proceeding with this install.\";\n\t\"1619\" = \"This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package.\";\n\t\"1620\" = \"This installation package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer package.\";\n\t\"1621\" = \"There was an error starting the Windows Installer service user interface. Contact your support personnel.\";\n\t\"1622\" = \"Error opening installation log file. Verify that the specified log file location exists and is writable.\";\n\t\"1623\" = \"This language of this installation package is not supported by your system.\";\n\t\"1624\" = \"Error applying transforms. Verify that the specified transform paths are valid.\";\n\t\"1625\" = \"This installation is forbidden by system policy. Contact your system administrator.\";\n\t\"1626\" = \"Function could not be executed.\";\n\t\"1627\" = \"Function failed during execution.\";\n\t\"1628\" = \"Invalid or unknown table specified.\";\n\t\"1629\" = \"Data supplied is of wrong type.\";\n\t\"1630\" = \"Data of this type is not supported.\";\n\t\"1631\" = \"The Windows Installer service failed to start. Contact your support personnel.\";\n\t\"1632\" = \"The temp folder is either full or inaccessible. Verify that the temp folder exists and that you can write to it.\";\n\t\"1633\" = \"This installation package is not supported on this platform. Contact your application vendor.\";\n\t\"1634\" = \"Component not used on this machine.\";\n\t\"1635\" = \"This patch package could not be opened. Verify that the patch package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer patch package.\";\n\t\"1636\" = \"This patch package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer patch package.\";\n\t\"1637\" = \"This patch package cannot be processed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.\";\n\t\"1638\" = \"Another version of this product is already installed. Installation of this version cannot continue. To configure or remove the existing version of this product, use Add/Remove Programs on the Control Panel.\";\n\t\"1639\" = \"Invalid command line argument. Consult the Windows Installer SDK for detailed command line help.\";\n\t\"1640\" = \"Installation from a Terminal Server client session not permitted for current user.\";\n\t\"1641\" = \"The installer has started a reboot.\";\n\t\"1642\" = \"The installer cannot install the upgrade patch because the program being upgraded may be missing, or the upgrade patch updates a different version of the program. Verify that the program to be upgraded exists on your computer and that you have the correct upgrade patch.\";\n\t\"3010\" = \"A restart is required to complete the install. This does not include installs where the ForceReboot action is run. Note that this error will not be available until future version of the installer.\"\n};\n\nfunction Get-Param($Name, [switch]$Required, $Default) {\n    $result = $null\n\n    if ($OctopusParameters -ne $null) {\n        $result = $OctopusParameters[$Name]\n    }\n\n    if ($result -eq $null) {\n        $variable = Get-Variable $Name -EA SilentlyContinue   \n        if ($variable -ne $null) {\n            $result = $variable.Value\n        }\n    }\n\n    if ($result -eq $null) {\n        if ($Required) {\n            throw \"Missing parameter value $Name\"\n        } else {\n            $result = $Default\n        }\n    }\n\n    return $result\n}\n\nfunction Resolve-PotentialPath($Path) {\n\t[Environment]::CurrentDirectory = $pwd\n\treturn [IO.Path]::GetFullPath($Path)\n}\n\nfunction Get-LogOptionFile($msiFile, $streamLog) {\n\t$logPath = Resolve-PotentialPath \"$msiFile.log\"\n\t\n\tif (Test-Path $logPath) {\n\t\tRemove-Item $logPath\n\t}\n\t\n\treturn $logPath\n}\n\nfunction Exec\n{\n    [CmdletBinding()]\n    param(\n        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,\n        [string]$errorMessage = ($msgs.error_bad_command -f $cmd),\n\t\t[switch]$ReturnCode\n    )\n\n\t$lastexitcode = 0\n    & $cmd\n\t\n\tif ($ReturnCode) {\n\t\treturn $lastexitcode\n\t} else  {\n\t\tif ($lastexitcode -ne 0) {\n\t\t\tthrow (\"Exec: \" + $errorMessage)\n\t\t}\t\t\n\t}\n}\n\nfunction Wrap-Arguments($Arguments)\n{\n\treturn $Arguments | % { \n\t\t\n\t\t[string]$val = $_\n\t\t\n\t\t#calling msiexec fails when arguments are quoted\n\t\tif (($val.StartsWith(\"/\") -and $val.IndexOf(\" \") -eq -1) -or ($val.IndexOf(\"=\") -ne -1) -or ($val.IndexOf('\"') -ne -1)) {\n\t\t\treturn $val\n\t\t}\n\t\n\t\treturn '\"{0}\"' -f $val\n\t}\n}\n\nfunction Start-Process2($FilePath, $ArgumentList, [switch]$showCall, [switch]$whatIf)\n{\n\t$ArgumentListString = (Wrap-Arguments $ArgumentList) -Join \" \"\n\n\t$pinfo = New-Object System.Diagnostics.ProcessStartInfo\n\t$pinfo.FileName = $FilePath\n\t$pinfo.UseShellExecute = $false\n\t$pinfo.CreateNoWindow = $true\n\t$pinfo.RedirectStandardOutput = $true\n\t$pinfo.RedirectStandardError = $true\n\t$pinfo.Arguments = $ArgumentListString;\n\t$pinfo.WorkingDirectory = $pwd\n\n\t$exitCode = 0\n\t\n\tif (!$whatIf) {\n\t\n\t\tif ($showCall) {\n\t\t\t$x = Write-Output \"$FilePath $ArgumentListString\"\n\t\t}\n\t\t\n\t\t$p = New-Object System.Diagnostics.Process\n\t\t$p.StartInfo = $pinfo\n\t\t$started = $p.Start()\n\t\t$p.WaitForExit()\n\n\t\t$stdout = $p.StandardOutput.ReadToEnd()\n\t\t$stderr = $p.StandardError.ReadToEnd()\n\t\t$x = Write-Output $stdout\n\t\t$x = Write-Output $stderr\n\t\t\n\t\t$exitCode = $p.ExitCode\n\t} else {\n\t\tWrite-Output \"skipping: $FilePath $ArgumentListString\"\n\t}\n\t\n\treturn $exitCode\n}\n\nfunction Get-EscapedFilePath($FilePath)\n{\n    return [Management.Automation.WildcardPattern]::Escape($FilePath)\n}\n\nfunction Get-MsiPathFromExtractedPath\n{\n  $fileReference = (Get-ChildItem -Path $OctopusParameters[\"Octopus.Action.Package[Template.Package].ExtractedPath\"] -Recurse | Where-Object { $_.Extension -eq \".msi\" })\n  return $fileReference.FullName\n}\n\n& {\n    param(\n        [string]$MsiFilePath,\n\t\t[string]$Action,\n\t\t[string]$ActionModifier,\n        [string]$LoggingOptions,\n        [bool]$LogAsArtifact,\n\t\t[string]$Properties,\n\t\t[int[]]$IgnoredErrorCodes\n    ) \n\n    $MsiFilePathLeaf = Split-Path -Path $MsiFilePath -Leaf\n    $EscapedMsiFilePath = Get-EscapedFilePath (Split-Path -Path $MsiFilePath)\n    \n\t$MsiFilePath = Get-EscapedFilePath (Resolve-Path \"$EscapedMsiFilePath\\$MsiFilePathLeaf\" | Select-Object -First 1).ProviderPath\n\n    Write-Output \"Installing MSI\"\n    Write-Host \" MsiFilePath: $MsiFilePath\" -f Gray\n\tWrite-Host \" Action: $Action\" -f Gray\n\tWrite-Host \" Properties: $Properties\" -f Gray\n\tWrite-Host\n\n\tif ((Get-Command msiexec) -Eq $Null) {\n\t\tthrow \"Command msiexec could not be found\"\n\t}\n\t\n\tif (!(Test-Path $MsiFilePath)) {\n\t\tthrow \"Could not find the file $MsiFilePath\"\n\t}\n\n\t$actions = @{\n\t\t\"Install\" = \"/i\";\n\t\t\"Repair\" = \"/f\";\n\t\t\"Remove\" = \"/x\";\n\t};\n\t\n\t$actionOption = $actions[$action]\n\t$actionOptionFile = $MsiFilePath\n\tif ($ActionModifier)\n\t{\n\t\t$actionOption += $ActionModifier\n\t}\n\t\n    if ($LoggingOptions) {\n\t    $logOption = \"/L$LoggingOptions\"\n\t    $logOptionFile = Get-LogOptionFile $MsiFilePath\n\t}\n\t$quiteOption = \"/qn\"\n\t$noRestartOption = \"/norestart\"\n\t\n\t$parameterOptions = $Properties -Split \"\\r\\n?|\\n\" | ? { !([string]::IsNullOrEmpty($_)) } | % { $_.Trim() }\n\t\n\t$options = @($actionOption, $actionOptionFile, $logOption, $logOptionFile, $quiteOption, $noRestartOption) + $parameterOptions\n\n\t$exePath = \"msiexec.exe\"\n\n\t$exitCode = Start-Process2 -FilePath $exePath -ArgumentList $options -whatIf:$whatIf -ShowCall\n\t\n\tWrite-Output \"Exit Code was! $exitCode\"\n\t\n\tif (Test-Path $logOptionFile) {\n\n\t\tWrite-Output \"Reading installer log\"\n\n        # always write out these (http://robmensching.com/blog/posts/2010/8/2/the-first-thing-i-do-with-an-msi-log/)\n        (Get-Content $logOptionFile) | Select-String -SimpleMatch \"value 3\" -Context 10,0 | ForEach-Object { Write-Warning $_ }\n\n        if ($LogAsArtifact) {\n            New-OctopusArtifact -Path $logOptionFile -Name \"$Action-$([IO.Path]::GetFileNameWithoutExtension($MsiFilePath)).log\"\n        } else {\n\t    \tGet-Content $logOptionFile | Write-Output\n        }\n\n\t} else {\n\t\tWrite-Output \"No logs were generated\"\n\t}\n\n\tif ($exitCode -Ne 0) {\n\t\t$errorCodeString = $exitCode.ToString()\n\t\t$errorMessage = $ErrorMessages[$errorCodeString]\n\t\t\n\t\tif ($IgnoredErrorCodes -notcontains $exitCode) {\n\n\t\t\tthrow \"Error code $exitCodeString was returned: $errorMessage\"\n\t\t}\n\t\telse {\n\t\t\tWrite-Output \"Error code [$exitCodeString] was ignored because it was in the IgnoredErrorCodes [$($IgnoredErrorCodes -join ',')] parameter. Error Message [$errorMessage]\"\n\t\t}\n\t}\n\t\n} `\n(Get-MsiPathFromExtractedPath) `\n(Get-Param 'Action' -Required) `\n(Get-Param 'ActionModifier') `\n(Get-Param 'LoggingOptions') `\n((Get-Param 'LogAsArtifact') -eq \"True\") `\n(Get-Param 'Properties') `\n(Get-Param 'IgnoredErrorCodes')\n",
+    "Octopus.Action.Script.Syntax": "PowerShell",
+    "Octopus.Action.Script.ScriptSource": "Inline"
+  },
+  "Parameters": [
+    {
+      "Id": "b2195039-8e80-4216-b4f2-10a205e6837f",
+      "Name": "Template.Package",
+      "Label": "MSI Package",
+      "HelpText": "The package that contains the .Msi file to execute.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Package"
+      }
+    },
+    {
+      "Id": "f644f7aa-9051-4404-8665-a9eaebafdbc0",
+      "Name": "Action",
+      "Label": "Action",
+      "HelpText": "The task to perform with the MSI, options include install, repair or remove.",
+      "DefaultValue": "Install",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Select",
+        "Octopus.SelectOptions": "Install\nRepair\nRemove"
+      }
+    },
+    {
+      "Id": "7a43723d-6242-4bb5-9acd-198933517d13",
+      "Name": "ActionModifier",
+      "Label": "Action Modifier",
+      "HelpText": "Use this to specify a different behavior for the Repair action",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "fc9f6977-f2fc-4fa3-9f38-171c9b2ace95",
+      "Name": "Properties",
+      "Label": "Properties",
+      "HelpText": "Properties that will be passed to the MSI separated by lines. Properties are in the format key=value, note that values with spaces in the must be quoted. \n\n    Key=Value\n    Key=\"Value\"",
+      "DefaultValue": "REBOOT=ReallySuppress",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      }
+    },
+    {
+      "Id": "5e38bac3-31fb-4c7d-bbb8-331be0eb6283",
+      "Name": "LoggingOptions",
+      "Label": "Logging Options",
+      "HelpText": "One or more of:\n\n    [i|w|e|a|r|u|c|m|o|p|v|x|+|!|*]\n\n-  i - Status messages\n-  w - Nonfatal warnings\n-  e - All error messages\n-  a - Start-up of actions\n-  r - Action-specific records\n-  u - User requests\n-  c - Initial UI parameters\n-  m - Out-of-memory or fatal exit information\n-  o - Out-of-disk-space messages\n-  p - Terminal properties\n-  v - Verbose output\n-  x - Extra debugging information\n-  \\+ - Append to existing log file\n-  ! - Flush each line to the log\n-  \\* - Log all information, except for v and x options",
+      "DefaultValue": "*",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    },
+    {
+      "Id": "a7fcf5b5-e416-4706-b9fd-c3d418f60007",
+      "Name": "LogAsArtifact",
+      "Label": "Log as artifact",
+      "HelpText": "If selected, then return log output as an artifact.\nIf unselected then return log output as inline content",
+      "DefaultValue": "false",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      }
+    },
+    {
+      "Id": "53e9621e-0967-4b10-9635-2070ae7f808c",
+      "Name": "IgnoredErrorCodes",
+      "Label": "Ignored Error Codes",
+      "HelpText": "Use commas to separate integer values.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
+    }
+  ],
+  "StepPackageId": "Octopus.Script",
+  "$Meta": {
+    "ExportedAt": "2025-08-21T16:07:30.818Z",
+    "OctopusVersion": "2025.2.13043",
+    "Type": "ActionTemplate"
+  },
+  "LastModifiedBy": "twerthi",
+  "Category": "windows"
+}

--- a/step-templates/windows-install-msi.json
+++ b/step-templates/windows-install-msi.json
@@ -1,6 +1,6 @@
 {
   "Id": "73994d6a-4cff-4bde-81c4-c4da362adaba",
-  "Name": "Windows - Install MSI",
+  "Name": "Windows - Install MSI From Package",
   "Description": "Runs the Windows Installer to non-interactively install an MSI",
   "ActionType": "Octopus.Script",
   "Version": 1,
@@ -10,7 +10,7 @@
       "Id": "910a6653-0534-492a-98d8-f02196931773",
       "Name": "Template.Package",
       "PackageId": null,
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",


### PR DESCRIPTION
---

# Background

Current MSI installer template required another step to get the .MSI file onto the target.  This step allows the user to choose a package instead.

# Results

Allows users to simplify the deployment by choosing an MSI package variable to install.

## Before

Users had to first get the MSI on the filesystem and hardcode the location in the template.

## After

Users can now choose a package and do the installation that way.

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
