### PR TITLE
Remove unsupported runtimes + add .Net 8 runtime to Deploy Lambda ste…

### DIFF
--- a/step-templates/aws-deploy-lambda.json
+++ b/step-templates/aws-deploy-lambda.json
@@ -3,7 +3,7 @@
     "Name": "AWS - Deploy Lambda Function",
     "Description": "Deploys a Zip file to an AWS Lambda function.  \n\nThis step does **not** perform variable substitution (it used to).  It takes the .zip file from the specified feed and uploads it to AWS as is.  The recommended approach to changing a lambda configuration per environment is to use [environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)  \n\nThis step uses the following AWS CLI commands to deploy the AWS Lambda.  You will be required to install the AWS CLI on your server/worker for this to work.  The AWS CLI is pre-installed on the [dynamic workers](https://octopus.com/docs/infrastructure/workers/dynamic-worker-pools) in Octopus Cloud as well as the provided docker containers for [Execution Containers](https://octopus.com/docs/deployment-process/execution-containers-for-workers).\n\n- [create-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/create-function.html)\n- [get-function](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/get-function.html)\n- [publish-version](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/publish-version.html)\n- [tag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/tag-resource.html)\n- [untag-resource](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/untag-resource.html)\n- [update-function-code](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-code.html)\n- [update-function-configuration](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/lambda/update-function-configuration.html)\n\nThis step template is worker-friendly, you can pass in a package reference rather than having to reference a previous step that downloaded the package. This step requires **Octopus Deploy 2019.10.0** or higher.\n\n## Output Variables\n\nThis step template sets the following output variables:\n\n- `LambdaArn`: The ARN of the Lambda Function\n- `PublishedVersion`: The most recent version published (only set when Publish is set to `Yes`).",
     "ActionType": "Octopus.AwsRunScript",
-    "Version": 8,
+    "Version": 9,
     "CommunityActionTemplateId": null,
     "Packages": [
       {
@@ -89,7 +89,7 @@
         "DefaultValue": "",
         "DisplaySettings": {
           "Octopus.ControlType": "Select",
-          "Octopus.SelectOptions": "nodejs|nodejs\nnodejs4.3|nodejs4.3\nnodejs4.3-edge|nodejs4.3-edge\nnodejs6.10|nodejs6.10\nnodejs8.10|nodejs8.10\nnodejs10.x|nodejs10.x\nnodejs12.x|nodejs12.x\nnodejs14.x|nodejs14.x\njava8|java8\njava8.al2|java8.al2\njava11|java11\npython2.7|python2.7\npython3.6|python3.6\npython3.7|python3.7\npython3.8|python3.8\npython3.9|python3.9\ndotnetcore1.0|dotnetcore1.0\ndotnetcore2.0|dotnetcore2.0\ndotnetcore2.1|dotnetcore2.1\ndotnetcore3.1|dotnetcore3.1\ndotnet6|dotnet6\nnodejs4.3-edge|nodejs4.3-edge\ngo1.x|go1.x\nruby2.5|ruby2.5\nruby2.7|ruby2.7\nprovided|provided\nprovided.al2|provided.al2"
+          "Octopus.SelectOptions": "nodejs|nodejs\nnodejs4.3|nodejs4.3\nnodejs4.3-edge|nodejs4.3-edge\nnodejs6.10|nodejs6.10\nnodejs8.10|nodejs8.10\nnodejs10.x|nodejs10.x\nnodejs12.x|nodejs12.x\nnodejs14.x|nodejs14.x\njava8|java8\njava8.al2|java8.al2\njava11|java11\npython2.7|python2.7\npython3.6|python3.6\npython3.7|python3.7\npython3.8|python3.8\npython3.9|python3.9\ndotnet6|dotnet6\ndotnet8|dotnet8\nnodejs4.3-edge|nodejs4.3-edge\ngo1.x|go1.x\nruby2.5|ruby2.5\nruby2.7|ruby2.7\nprovided|provided\nprovided.al2|provided.al2"
         }
       },
       {
@@ -225,10 +225,10 @@
       }
     ],
     "$Meta": {
-      "ExportedAt": "2022-09-16T00:50:35.270Z",
-      "OctopusVersion": "2022.3.10382",
+      "ExportedAt": "2025-09-07T22:51:56.457Z",
+      "OctopusVersion": "2025.3.13248",
       "Type": "ActionTemplate"
     },
-    "LastModifiedBy": "twerthi",
+    "LastModifiedBy": "benjimac93",
     "Category": "aws"
   }


### PR DESCRIPTION
# Background

To Remove unsupported .Net runtime + add the new Default Lambda .Net runtime (.Net 8)

# Results

<!-- Describe the result of the change -->

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [X] If a new `Category` has been created:
   - [X] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [X] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it