### PR TITLE
New Lets Encrypt CAs

### DIFF
--- a/step-templates/letsencrypt-azure-dns.json
+++ b/step-templates/letsencrypt-azure-dns.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - Azure DNS",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [Azure DNS](https://azure.microsoft.com/en-us/services/dns/) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
     "ActionType": "Octopus.Script",
-    "Version": 12,
+    "Version": 13,
     "Packages": [],
     "Properties": {
         "Octopus.Action.Script.ScriptSource": "Inline",
@@ -93,10 +93,10 @@
         }
     ],
     "$Meta": {
-        "ExportedAt": "2024-08-01T10:57:00.608Z",
-        "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
         "Type": "ActionTemplate"
       },
-      "LastModifiedBy": "harrisonmeister",
+      "LastModifiedBy": "benjimac93",
     "Category": "lets-encrypt"
 }

--- a/step-templates/letsencrypt-cloudflare.json
+++ b/step-templates/letsencrypt-cloudflare.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - Cloudflare",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [Cloudflare DNS](https://www.cloudflare.com/en-au/dns/) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
     "ActionType": "Octopus.Script",
-    "Version": 11,
+    "Version": 12,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
@@ -104,10 +104,10 @@
         }
     ],
     "$Meta": {
-        "ExportedAt": "2024-08-01T10:57:00.608Z",
-        "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
         "Type": "ActionTemplate"
       },
-      "LastModifiedBy": "harrisonmeister",
+      "LastModifiedBy": "benjimac93",
     "Category": "lets-encrypt"
 }

--- a/step-templates/letsencrypt-dnsimple.json
+++ b/step-templates/letsencrypt-dnsimple.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - DNSimple",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [DNSimple](https://dnsimple.com/) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
     "ActionType": "Octopus.Script",
-    "Version": 8,
+    "Version": 9,
     "CommunityActionTemplateId": null,
     "Packages": [
         
@@ -107,10 +107,10 @@
         }
     ],    
     "$Meta": {
-        "ExportedAt": "2024-08-01T10:57:00.608Z",
-        "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
         "Type": "ActionTemplate"
       },
-      "LastModifiedBy": "harrisonmeister",
+      "LastModifiedBy": "benjimac93",
     "Category": "lets-encrypt"
 }

--- a/step-templates/letsencrypt-google-cloud.json
+++ b/step-templates/letsencrypt-google-cloud.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - Google Cloud DNS",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [Google Cloud DNS](https://cloud.google.com/dns) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
     "ActionType": "Octopus.Script",
-    "Version": 12,
+    "Version": 13,
     "CommunityActionTemplateId": null,
     "Packages": [],
     "Properties": {
@@ -94,10 +94,10 @@
         }
     ],
     "$Meta": {
-        "ExportedAt": "2024-08-01T10:57:00.608Z",
-        "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
         "Type": "ActionTemplate"
       },
-      "LastModifiedBy": "harrisonmeister",
+      "LastModifiedBy": "benjimac93",
     "Category": "lets-encrypt"
 }

--- a/step-templates/letsencrypt-route-53.json
+++ b/step-templates/letsencrypt-route-53.json
@@ -3,7 +3,7 @@
     "Name": "Lets Encrypt - Route53",
     "Description": "Request (or renew) a X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/). \n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com)\n- [AWS Route53](https://aws.amazon.com/route53/) Challenge for TLD, CNAME and Wildcard domains. \n- Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates). \n- Verified to work on both Windows (PowerShell 5+) and Linux (PowerShell 6+) deployment Targets or Workers.",
     "ActionType": "Octopus.Script",
-    "Version": 13,
+    "Version": 14,
     "Packages": [],
     "Properties": {
         "Octopus.Action.Script.ScriptSource": "Inline",
@@ -93,10 +93,10 @@
         }
     ],
     "$Meta": {
-        "ExportedAt": "2024-08-01T10:57:00.608Z",
-        "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
         "Type": "ActionTemplate"
       },
-      "LastModifiedBy": "harrisonmeister",
+      "LastModifiedBy": "benjimac93",
     "Category": "lets-encrypt"
 }

--- a/step-templates/letsencrypt-selfhosted-http.json
+++ b/step-templates/letsencrypt-selfhosted-http.json
@@ -3,7 +3,7 @@
   "Name": "Lets Encrypt - Self-Hosted HTTP Challenge",
   "Description": "Request (or renew) an X.509 SSL Certificate from the [Let's Encrypt Certificate Authority](https://letsencrypt.org/) using the Self-hosted HTTP Challenge Listener provided by the [Posh-ACME](https://github.com/rmbolger/Posh-ACME/) PowerShell Module.\n\n---\n#### Please Note\n\nIt's generally a better idea to use one of the Posh-ACME [DNS providers](https://github.com/rmbolger/Posh-ACME/wiki/List-of-Supported-DNS-Providers) for Let's Encrypt.\n\nThere are a number of Octopus Step templates in the [Community Library](https://library.octopus.com/listing/letsencrypt) that support DNS providers.\n\n---\n\n#### Features\n\n- ACME v2 protocol support which allows generating wildcard certificates (*.example.com).\n- [Self-hosted HTTP Challenge](https://github.com/rmbolger/Posh-ACME/wiki/How-To-Self-Host-HTTP-Challenges) Challenge for TLD, CNAME, and Wildcard domains. \n- _Optionally_ Publishes/Updates SSL Certificates in the [Octopus Deploy Certificate Store](https://octopus.com/docs/deployment-examples/certificates).\n- _Optionally_ import SSL Certificate into the local machine store. \n- _Optionally_ Export PFX (PKCS#12) SSL Certificate to a supplied file path.\n- Verified to work on Windows and Linux deployment targets\n\n#### Pre-requisites\n\n- There are specific requirements when [running on Windows](https://github.com/rmbolger/Posh-ACME/wiki/How-To-Self-Host-HTTP-Challenges#windows-only-prerequisites).\n- HTTP Challenge Listener must be available on Port 80.\n- When updating the Octopus Certificate Store, access to the Octopus Server from where the script template runs e.g. deployment target or worker is required.",
   "ActionType": "Octopus.Script",
-  "Version": 11,
+  "Version": 12,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "Properties": {
@@ -114,10 +114,10 @@
     }
   ],
   "$Meta": {
-      "ExportedAt": "2024-08-01T10:57:00.608Z",
-      "OctopusVersion": "2024.3.8336",
+    "ExportedAt": "2025-09-11T14:51:42.815Z",
+    "OctopusVersion": "2025.3.14236",
       "Type": "ActionTemplate"
     },
-    "LastModifiedBy": "harrisonmeister",
+    "LastModifiedBy": "benjimac93",
   "Category": "lets-encrypt"
 }


### PR DESCRIPTION
# Background

Lets encrypt have updated their CAs, due to them not existing in the Octous scripts - I have duplicate certs being created every time our runbook runs

# Results

This adds the new CAs as per https://letsencrypt.org/certificates/

## Before

<!-- Consider adding a log excerpt or screen capture. -->

## After

<!-- Consider adding a log excerpt or screen capture. -->

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [X] If a new `Category` has been created:
   - [X] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [X] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it
