### PR TITLE
Stupid mistake liquibase

### DIFF
--- a/step-templates/liquibase-run-command.json
+++ b/step-templates/liquibase-run-command.json
@@ -3,7 +3,7 @@
   "Name": "Liquibase - Run command",
   "Description": "Run Liqbuibase commands against a database.  You can include Liquibase in the package itself or choose Download to download it during runtime.\n\nNote:\n- AWS EC2 IAM Authentication requires the AWS CLI to be installed.\n- Windows Authentication has been tested with \n  - Microsoft SQL Server \n  - PostgreSQL\n- SQL Anywhere only works with Username/Password authentication\n\nOnce the Liquibase commands have executed, the output is stored in an Octopus [output variable](https://octopus.com/docs/projects/variables/output-variables) called `LiquibaseCommandOutput` for use in subsequent Octopus deployment or runbook steps.\n\n**Downloading the database driver(s) is now a separate option called: Download database driver?**",
   "ActionType": "Octopus.Script",
-  "Version": 28,
+  "Version": 29,
   "Author": "twerthi",
   "Packages": [
     {


### PR DESCRIPTION


---

# Background

I accidentally left a debug statement in the script.  It doesn't expose anything and will function fine, just provide some extra output.

# Results

Contents of .bat file no longer displayed

## Before

Contents of .bat file were written to log.

## After

Statement removed, no longer displayed.

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Doh!
