### PR TITLE
Update FeedId to null in sbom-scan.json to fix the error:

### DIFF
--- a/step-templates/sbom-scan.json
+++ b/step-templates/sbom-scan.json
@@ -10,7 +10,7 @@
       "Id": "9b495093-0020-4df8-bc44-2fd65ab13943",
       "Name": "application",
       "PackageId": "",
-      "FeedId": "feeds-builtin",
+      "FeedId": null,
       "AcquisitionLocation": "Server",
       "Properties": {
         "Extract": "True",


### PR DESCRIPTION
The [build](https://build.octopushq.com/buildConfiguration/Library_BuildAndPushToOctopus/19722719) is failing due to the error:

```
Package FeedId for sbom-scan.json should be null, but was: feeds-builtin
```

This sets the `FeedId` to `null`