### PR TITLE
Update ArgoCD CLI steps ActionType to be Octopus.Script

### DIFF
--- a/step-templates/argo-argocd-app-get.json
+++ b/step-templates/argo-argocd-app-get.json
@@ -1,7 +1,7 @@
 {
   "Id": "f67404e4-3394-4f8d-9739-74a04c99a6f1",
   "Name": "Argo - argocd app get",
-  "Description": "Get an Argo Application details using the [argocd app get](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_get/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "Description": "Get an Argo Application details using the [argocd app get](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_get/) CLI command\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n\n---\n\n_Note:_ This step **used to only** run against an Octopus kubernetes deployment target. It is now based on the *Run a script step* type. You may need to delete and re-add the step in your consuming process for the change to take effect.",
   "ActionType": "Octopus.Script",
   "Version": 2,
   "CommunityActionTemplateId": null,

--- a/step-templates/argo-argocd-app-set-with-package.json
+++ b/step-templates/argo-argocd-app-set-with-package.json
@@ -1,7 +1,7 @@
 {
   "Id": "8bcfe67d-cade-4fe3-a792-ce799dfb9ec1",
   "Name": "Argo - argocd app set (with package)",
-  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command.\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n- Selection of a package (for use with setting image parameters)",
+  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n- Selection of a package (for use with setting image parameters)\n\n---\n\n_Note:_ This step **used to only** run against an Octopus kubernetes deployment target. It is now based on the *Run a script step* type. You may need to delete and re-add the step in your consuming process for the change to take effect.",
   "ActionType": "Octopus.Script",
   "Version": 2,
   "CommunityActionTemplateId": null,

--- a/step-templates/argo-argocd-app-set.json
+++ b/step-templates/argo-argocd-app-set.json
@@ -1,7 +1,7 @@
 {
   "Id": "e27c8535-9375-4cd2-97e7-ac73a43e9ef1",
   "Name": "Argo - argocd app set",
-  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command. \n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "Description": "Set application parameters using the [argocd app set](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_set/) CLI command. \n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n\n---\n\n_Note:_ This step **used to only** run against an Octopus kubernetes deployment target. It is now based on the *Run a script step* type. You may need to delete and re-add the step in your consuming process for the change to take effect.",
   "ActionType": "Octopus.Script",
   "Version": 2,
   "CommunityActionTemplateId": null,

--- a/step-templates/argo-argocd-app-sync.json
+++ b/step-templates/argo-argocd-app-sync.json
@@ -1,7 +1,7 @@
 {
   "Id": "655058aa-2e76-4aac-a8eb-728337b5c664",
   "Name": "Argo - argocd app sync",
-  "Description": "Sync an application to its target state using the [argocd app sync](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_sync/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "Description": "Sync an application to its target state using the [argocd app sync](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_sync/) CLI command\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n\n---\n\n_Note:_ This step **used to only** run against an Octopus kubernetes deployment target. It is now based on the *Run a script step* type. You may need to delete and re-add the step in your consuming process for the change to take effect.",
   "ActionType": "Octopus.Script",
   "Version": 2,
   "CommunityActionTemplateId": null,

--- a/step-templates/argo-argocd-app-wait.json
+++ b/step-templates/argo-argocd-app-wait.json
@@ -1,7 +1,7 @@
 {
   "Id": "050e7819-ecf7-46de-bcd2-545f0956c1c5",
   "Name": "Argo - argocd app wait",
-  "Description": "Wait for an application to reach a synced and healthy state using the [argocd app wait](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_wait/) CLI command\n\n_Note:_ This step will only run against an Octopus [kubernetes](https://octopus.com/docs/infrastructure/deployment-targets/kubernetes) deployment target.\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.",
+  "Description": "Wait for an application to reach a synced and healthy state using the [argocd app wait](https://argo-cd.readthedocs.io/en/stable/user-guide/commands/argocd_app_wait/) CLI command\n\n**Pre-requisites:**\n- Access to the `argocd` CLI on the target or worker.\n\n---\n\n_Note:_ This step **used to only** run against an Octopus kubernetes deployment target. It is now based on the *Run a script step* type. You may need to delete and re-add the step in your consuming process for the change to take effect.",
   "ActionType": "Octopus.Script",
   "Version": 2,
   "CommunityActionTemplateId": null,


### PR DESCRIPTION
# Background

The `ActionType` property of the community step templates that leverage ArgoCD CLI to perform app functions such as sync, set etc were incorrectly based on the "Run a Kubectl script" (`Octopus.KubernetesRunScript` action type).

This meant that the only execution location these steps could run against were Kubernetes targets, despite not needing the Kubernetes context that Octopus provides with these step/target types.

The parameters and the steps themselve authenticate with the argocd CLI directly, and dont need the additional context.
A customer later informed us that having the need for a Kubernetes target was undesirable, when a woorker could do the same job.

# Results

No longer need to run the steps on a K8s target.

## Before

You had to run the scripts on a K8s target

## After

You can run the steps on any location supported by the run a script step.

Note: Changing the ActionType does not change it for installed steps in a consuming process. Having reviewed telemetry with R&D, the impact (usage) is very low - only 1 usage on a customer instance. 

The description has been updated to include a warning to reflect this and provide remediation advice (remove step and re-add to process).
