### PR TITLE
LetsEncrypt: Support for DNS alias in Azure

### DIFF
--- a/step-templates/letsencrypt-azure-dns.json
+++ b/step-templates/letsencrypt-azure-dns.json
@@ -91,6 +91,16 @@
       "DisplaySettings": {
         "Octopus.ControlType": "Checkbox"
       }
+    },
+    {
+      "Id": "36451c6b-f61d-4e00-b1f6-956341c9691d",
+      "Name": "LE_AzureDNS_DnsAlias",
+      "Label": "DNS Alias",
+      "HelpText": "Use a CNAME alias for the TXT challenge.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      }
     }
   ],
   "$Meta": {


### PR DESCRIPTION
# Background

Reference https://poshac.me/docs/v4/Guides/Using-DNS-Challenge-Aliases/

The setup:

- `mydomain.com` is highly locked down. Only account type that can be created here is of the admin types (not something I want a service account to use).
- `myotherdomain.com` DNS is hosted in Azure, and allows more granular permission control for service accounts.
- `_acme-challenge.mydomain.com` is an existing CNAME alias for `thealias.myotherdomain.com` 

# Results

Providing the DNS alias parameter as `thealias.myotherdomain.com` to POSH-Acme's `New-PACertificate` results in the acme challenge nonce getting written to the TXT record of `thealias.myotherdomain.com` and the verification of `_acme-challenge.mydomain.com` succeeds.

## Before

--

## After

<img width="921" height="108" alt="image" src="https://github.com/user-attachments/assets/d0eb1335-688b-4942-be56-986374b2e1e2" />

Notice the alias for the `.net` domain is used but the challenge is for the `.com` one.


# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

