### PR TITLE
Adding check capabilities

### DIFF
--- a/step-templates/flyway-state-based-migration.json
+++ b/step-templates/flyway-state-based-migration.json
@@ -56,7 +56,7 @@
       "DefaultValue": "prepare",
       "DisplaySettings": {
         "Octopus.ControlType": "Select",
-        "Octopus.SelectOptions": "check|Check\ndeploy|Deploy\ndeploy|Deploy\nprepare|Prepare"
+        "Octopus.SelectOptions": "check|Check\ndeploy|Deploy\nprepare|Prepare"
       }
     },
     {


### PR DESCRIPTION


---

# Background

Customer requested adding the `check` command option to the template.

# Results

Added `check` to available commands to select within the template.

## Before

This template did not have the option.

## After

Option has been added and generated report is added as an Octopus Artifact.

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes #1643
