### PR TITLE
Updating description of package id.

### DIFF
--- a/step-templates/azure-deploy-containerapp.json
+++ b/step-templates/azure-deploy-containerapp.json
@@ -3,7 +3,7 @@
   "Name": "Azure - Deploy Container App",
   "Description": "Deploys a container to an Azure Container App Environment",
   "ActionType": "Octopus.Script",
-  "Version": 8,
+  "Version": 9,
   "CommunityActionTemplateId": null,
   "Packages": [
     {
@@ -110,7 +110,7 @@
       "Id": "d74123b0-4104-45b9-ae12-b1f808b8b948",
       "Name": "Template.Azure.Container.Name",
       "Label": "Container Name",
-      "HelpText": "The name of the container to create/update.  If you want to use the image name, specify `#{Octopus.Action.Package[Template.Azure.Container.Image].PackageId}`",
+      "HelpText": "The name of the container to create/update.  If you want to use the image name, specify `#{Octopus.Action.Package[Template.Azure.Container.Image].PackageId | Replace \"/\" \"-\"}`",
       "DefaultValue": "",
       "DisplaySettings": {
         "Octopus.ControlType": "SingleLineText"


### PR DESCRIPTION


_Before submitting your PR, please delete everything above the line below._

---

# Background

The instructions in the Parameter gave the example of `#{Octopus.Action.Package[Template.Azure.Container.Image].PackageId}`.  In situations where there was an organization preceding the package name, ie. octopussamples/ocopub-frontend, the container name was being set to `octopussamples/octopub-frontend`.  The `/` would cause issues and make the registration think it needed to be in a subfolder.

# Results

The change updates the example from `#{Octopus.Action.Package[Template.Azure.Container.Image].PackageId}` to `#{Octopus.Action.Package[Template.Azure.Container.Image].PackageId | Replace "/" "-"}

## Before

Setting the name to the example would result in step failure.

## After

The character replacement results in a valid container name; `octopussamples-octopub-frontend`

# Pre-requisites

- [X] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*. 
- [X] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [X] Parameter names should not start with `$`
- [X] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [X] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [X] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [ ] If a new `Category` has been created:
   - [ ] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [ ] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes # . _If there is an open issue that this PR fixes add it here, otherwise just remove this line_
