### PR TITLE
Update the message when checking for Argo CD instances

### DIFF
--- a/step-templates/octopus-check-for-argo-instance.json
+++ b/step-templates/octopus-check-for-argo-instance.json
@@ -3,14 +3,14 @@
   "Name": "Octopus - Check for Argo CD Instances",
   "Description": "Checks to see if there are any Argo CD instances registered to the space.",
   "ActionType": "Octopus.Script",
-  "Version": 2,
+  "Version": 3,
   "CommunityActionTemplateId": null,
   "Packages": [],
   "GitDependencies": [],
   "Properties": {
     "Octopus.Action.Script.ScriptSource": "Inline",
     "Octopus.Action.Script.Syntax": "PowerShell",
-    "Octopus.Action.Script.ScriptBody": "# Fix ANSI Color on PWSH Core issues when displaying objects\nif ($PSEdition -eq \"Core\") {\n    $PSStyle.OutputRendering = \"PlainText\"\n}\n\n# Define variables\n$isArgoPresent = $false\n\n# Check to see if the Octopus.Web.ServerUri variable has a value\nif (![string]::IsNullOrWhitespace($OctopusParameters[\"Octopus.Web.ServerUri\"]))\n{\n    $baseUrl = $OctopusParameters[\"Octopus.Web.ServerUri\"]\n}\nelse\n{\n    $baseUrl = $OctopusParameters[\"Octopus.Web.BaseUrl\"]\n}\n\n# Validate parameters\nif ([string]::IsNullOrWhitespace($OctopusParameters[\"Template.Octopus.API.Key\"]) -or -not $OctopusParameters[\"Template.Octopus.API.Key\"].StartsWith(\"API-\"))\n{\n    Write-Highlight \"An API Key was not provided, unable to check to see if there are any Argo CD instances registered in this space.\"\n}\nelse\n{\n    $header = @{ \"X-Octopus-ApiKey\" = $OctopusParameters[\"Template.Octopus.API.Key\"] }\n\n    # Get registered Argo CD instances\n    $argoInstances = Invoke-RestMethod -Method Get -Uri \"$($baseUrl)/api/#{Octopus.Space.Id}/argocdinstances/summaries\" -Headers $header\n\n    # Check the returned values\n    if ($argoInstances.Resources.Count -gt 0)\n    {\n        Write-Highlight \"Found $($argoInstances.Resources.Count) Argo instance(s) registered!\"\n        $isArgoPresent = $true\n    }\n    else\n    {\n        Write-Highlight \"No Argo CD instances registered to space $($OctopusParameters['Octopus.Space.Name']).  Please [register an Argo CD instance](https://octopus.com/docs/argo-cd/instances) with this space.\"\n    }\n}\n\n# Set output variable\nSet-OctopusVariable -Name ArgoPresent -Value $isArgoPresent"
+    "Octopus.Action.Script.ScriptBody": "# Fix ANSI Color on PWSH Core issues when displaying objects\nif ($PSEdition -eq \"Core\") {\n    $PSStyle.OutputRendering = \"PlainText\"\n}\n\n# Define variables\n$isArgoPresent = $false\n\n# Check to see if the Octopus.Web.ServerUri variable has a value\nif (![string]::IsNullOrWhitespace($OctopusParameters[\"Octopus.Web.ServerUri\"]))\n{\n    $baseUrl = $OctopusParameters[\"Octopus.Web.ServerUri\"]\n}\nelse\n{\n    $baseUrl = $OctopusParameters[\"Octopus.Web.BaseUrl\"]\n}\n\n# Validate parameters\nif ([string]::IsNullOrWhitespace($OctopusParameters[\"Template.Octopus.API.Key\"]) -or -not $OctopusParameters[\"Template.Octopus.API.Key\"].StartsWith(\"API-\"))\n{\n    Write-Highlight \"An API Key was not provided, unable to check to see if there are any Argo CD instances registered in this space.\"\n    Write-Highlight \"See the [Octopus documentation](https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key) for details on creating API keys.\"\n    Write-Highlight \"Once you have an API key, add it to the $($OctopusParameters['Octopus.Step.Name']) step to enable the ability to check for Argo CD instances in this space.\"\n}\nelse\n{\n    $header = @{ \"X-Octopus-ApiKey\" = $OctopusParameters[\"Template.Octopus.API.Key\"] }\n\n    # Get registered Argo CD instances\n    $argoInstances = Invoke-RestMethod -Method Get -Uri \"$($baseUrl)/api/#{Octopus.Space.Id}/argocdinstances/summaries\" -Headers $header\n\n    # Check the returned values\n    if ($argoInstances.Resources.Count -gt 0)\n    {\n        Write-Highlight \"Found $($argoInstances.Resources.Count) Argo instance(s) registered!\"\n        $isArgoPresent = $true\n    }\n    else\n    {\n        Write-Highlight \"No Argo CD instances registered to space $($OctopusParameters['Octopus.Space.Name']).  Please [register an Argo CD instance](https://octopus.com/docs/argo-cd/instances) with this space.\"\n    }\n}\n\n# Set output variable\nSet-OctopusVariable -Name ArgoPresent -Value $isArgoPresent"
   },
   "Parameters": [
     {
@@ -30,6 +30,6 @@
     "OctopusVersion": "2025.4.6474",
     "Type": "ActionTemplate"
   },
-  "LastModifiedBy": "twerthi",
+  "LastModifiedBy": "mcasperson",
   "Category": "octopus"
 }


### PR DESCRIPTION
# Background

This PR updates the message displayed when checking for Argo CD instances to include next steps if no API key is present.
