### PR TITLE
Add diff tool for reviewing step template script changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ scriptcs_packages.config
 step-templates/*.ps1
 step-templates/*.sh
 step-templates/*.py
+diff-output/
 /.vs
 !.vscode

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ Read our [contributing guidelines](https://github.com/OctopusDeploy/Library/blob
 Reviewing PRs
 -------------
 
+### Reviewing script changes
+
+Step template JSON files embed scripts as single-line escaped strings, making diffs hard to read. Use the `_diff.ps1` tool to extract old and new scripts into separate files you can compare in your diff tool:
+
+```powershell
+# Compare ScriptBody against previous commit
+.\tools\_diff.ps1 -SearchPattern "template-name"
+
+# Compare against a specific commit or branch
+.\tools\_diff.ps1 -SearchPattern "template-name" -CompareWith "master"
+```
+
+This outputs readable files to `diff-output/`:
+- `template-name.ScriptBody.old.ps1`
+- `template-name.ScriptBody.new.ps1`
+
+Also handles `PreDeploy`, `Deploy`, and `PostDeploy` custom scripts if present.
+
+### Checklist
+
 When reviewing a PR, keep the following things in mind:
 * `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
 * `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly

--- a/tools/_diff.ps1
+++ b/tools/_diff.ps1
@@ -1,0 +1,91 @@
+param
+(
+    [Parameter(Mandatory=$true)]
+    [string] $SearchPattern,
+
+    [Parameter(Mandatory=$false)]
+    [string] $CompareWith = "HEAD~1",
+
+    [Parameter(Mandatory=$false)]
+    [string] $OutputFolder = "diff-output"
+)
+
+$ErrorActionPreference = "Stop";
+Set-StrictMode -Version "Latest";
+
+$thisScript  = $MyInvocation.MyCommand.Path;
+$thisFolder  = [System.IO.Path]::GetDirectoryName($thisScript);
+$repoRoot    = [System.IO.Path]::GetDirectoryName($thisFolder);
+
+$stepTemplateFolder = [System.IO.Path]::Combine($repoRoot, "step-templates");
+$stepTemplates = [System.IO.Directory]::GetFiles($stepTemplateFolder, "$SearchPattern.json");
+
+if ($stepTemplates.Length -eq 0)
+{
+    Write-Error "No step templates found matching '$SearchPattern'";
+    return;
+}
+
+Import-Module -Name ([System.IO.Path]::Combine($thisFolder, "StepTemplatePacker")) -ErrorAction "Stop";
+
+$outputPath = [System.IO.Path]::Combine($repoRoot, $OutputFolder);
+if (-not (Test-Path $outputPath))
+{
+    New-Item -ItemType Directory -Path $outputPath | Out-Null;
+}
+
+$scriptProperties = @(
+    @{ Name = "ScriptBody"; Property = "Octopus.Action.Script.ScriptBody" },
+    @{ Name = "PreDeploy";  Property = "Octopus.Action.CustomScripts.PreDeploy.ps1" },
+    @{ Name = "Deploy";     Property = "Octopus.Action.CustomScripts.Deploy.ps1" },
+    @{ Name = "PostDeploy"; Property = "Octopus.Action.CustomScripts.PostDeploy.ps1" }
+)
+
+foreach ($stepTemplate in $stepTemplates)
+{
+    $relativePath = "step-templates/$([System.IO.Path]::GetFileName($stepTemplate))";
+    $templateName = [System.IO.Path]::GetFileNameWithoutExtension($stepTemplate);
+
+    $oldJson = $null;
+    try
+    {
+        $oldText = git show "${CompareWith}:${relativePath}" 2>$null;
+        if ($LASTEXITCODE -eq 0 -and $oldText)
+        {
+            $oldJson = ConvertFrom-Json -InputObject ($oldText -join "`n");
+        }
+    }
+    catch
+    {
+        Write-Host "No previous version found for '$templateName' at $CompareWith" -ForegroundColor Yellow;
+        continue;
+    }
+
+    $newText = Get-Content -Path $stepTemplate -Raw;
+    $newJson = ConvertFrom-Json -InputObject $newText;
+
+    # Get file extension from syntax
+    $syntax = Get-OctopusStepTemplateProperty -StepJson $newJson -PropertyName "Octopus.Action.Script.Syntax" -DefaultValue "PowerShell";
+    $fileType = Get-OctopusStepTemplateFileType -Syntax $syntax;
+
+    foreach ($prop in $scriptProperties)
+    {
+        $oldValue = Get-OctopusStepTemplateProperty -StepJson $oldJson -PropertyName $prop.Property;
+        $newValue = Get-OctopusStepTemplateProperty -StepJson $newJson -PropertyName $prop.Property;
+
+        if ([string]::IsNullOrEmpty($oldValue) -and [string]::IsNullOrEmpty($newValue)) { continue; }
+
+        $oldFile = [System.IO.Path]::Combine($outputPath, "$templateName.$($prop.Name).old$fileType");
+        $newFile = [System.IO.Path]::Combine($outputPath, "$templateName.$($prop.Name).new$fileType");
+
+        Set-Content -Path $oldFile -Value $oldValue -NoNewline;
+        Set-Content -Path $newFile -Value $newValue -NoNewline;
+
+        Write-Host "Created: $($prop.Name)" -ForegroundColor Cyan;
+        Write-Host "  Old: $oldFile";
+        Write-Host "  New: $newFile";
+    }
+}
+
+Write-Host "";
+Write-Host "Files written to: $outputPath" -ForegroundColor Green;


### PR DESCRIPTION
# Background
Step template JSON files embed scripts as single-line escaped strings. When reviewing PRs that modify these scripts, the JSON diff is unreadable. The existing `_unpack.ps1` tool extracts scripts but only outputs the current version, with no way to compare old vs new.

# Results

Adds `_diff.ps1` which extracts the old and new versions of embedded scripts into separate files for side-by-side comparison in any diff tool.

## Before
Reviewing script changes in step template PRs required manually extracting the ScriptBody from both versions of the JSON, or reading the escaped single-line diff.

## After
Run `.\tools\_diff.ps1 -SearchPattern "template-name"` and get readable `.old.ps1` / `.new.ps1` files in `diff-output/` ready for comparison.
<img width="1921" height="491" alt="image" src="https://github.com/user-attachments/assets/3b72f61c-389d-445c-b33f-f874753b0f47" />

# How to review this PR

Files changed:
- `tools/_diff.ps1` — new script that extracts old/new ScriptBody (and PreDeploy/Deploy/PostDeploy) using the existing StepTemplatePacker module
- `.gitignore` — added `diff-output/` since the output files are local-only
- `README.md` — usage instructions added under "Reviewing PRs"

# Reducing risk

## Automated Tests
- Low risk tooling change, no production impact