### PR TITLE
fix: correct history link handling in the library UI

### DIFF
--- a/app/components/TemplateItem.jsx
+++ b/app/components/TemplateItem.jsx
@@ -114,7 +114,7 @@ export default class TemplateItem extends React.Component {
                 </SyntaxHighlighter>
               </div>
               <p className="align-right">
-                <a className="faint" href={this.state.template.HistoryUrl}>
+                <a className="faint" href={this.state.template.HistoryUrl} rel="noopener noreferrer" target="_blank">
                   History &raquo;
                 </a>
               </p>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -31,6 +31,7 @@ import jasmineTerminalReporter from "jasmine-terminal-reporter";
 import eventStream from "event-stream";
 import fs from "fs";
 import jsonlint from "gulp-jsonlint";
+import path from "path";
 
 const sass = gulpSass(dartSass);
 const clientDir = "app";
@@ -292,8 +293,7 @@ function provideMissingData() {
   return eventStream.map(function (file, cb) {
     var fileContent = file.contents.toString();
     var template = JSON.parse(fileContent);
-    var pathParts = file.path.split("\\");
-    var fileName = pathParts[pathParts.length - 1];
+    var fileName = path.basename(file.path);
 
     if (!template.HistoryUrl) {
       template.HistoryUrl = "https://github.com/OctopusDeploy/Library/commits/master/step-templates/" + fileName;


### PR DESCRIPTION
## Background

This PR fixes the `History` link on https://library.octopus.com/ template detail pages.

The current behavior has two problems:

- the fallback GitHub history link can be generated incorrectly because the filename is extracted using a Windows-only path split
- when the source path comes from a Linux build agent, that can cause the full absolute `/opt/buildagent/.../step-templates/<file>.json` path to be embedded into the final URL
- the History link opens in the current tab, which navigates the user away from the Library page

### Example
* visit any Step Template page, such as [.NET - Check .NET Framework Version](https://library.octopus.com/step-templates/b15c6b3d-20a1-4059-b0e4-75bef1ff41d5/actiontemplate-.net-check-.net-framework-version)
* note the url on the link "History »" is https://github.com/OctopusDeploy/Library/commits/master/step-templates//opt/buildagent/work/a381802920158308/step-templates/windows-check-net-framework-version.json

## Results

The History link now preserves the current-`master` GitHub URL shape under `step-templates/<template>.json`, uses cross-platform filename extraction, and opens in a new tab.

## Before

- the fallback `HistoryUrl` depended on `file.path.split("\\")`
- when the source path came from a Linux build agent, the generated link could include the full `/opt/buildagent/.../step-templates/<file>.json` path instead of just `<file>.json`
- the History link opened in the current tab

## After

- the fallback `HistoryUrl` uses `path.basename(file.path)` for cross-platform filename extraction
- build-agent absolute paths are reduced to just the template filename before the GitHub URL is built
- the History link opens in a new tab using `target="_blank"` and `rel="noopener noreferrer"`


# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*.
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes #1666
