### PR TITLE
Improve community site local dev workflow (fixes watch & hot-reloading)

### DIFF
--- a/app/services/LibraryDb.js
+++ b/app/services/LibraryDb.js
@@ -1,12 +1,15 @@
 "use strict";
 
+import fs from "fs";
+import path from "path";
 import _ from "underscore";
 
-import StepTemplates from "./step-templates.json";
-
 class LibraryDb {
-  constructor() {
-    this._items = _.chain(StepTemplates.items)
+  loadTemplates() {
+    const templatePath = path.join(__dirname, "step-templates.json");
+    const stepTemplates = JSON.parse(fs.readFileSync(templatePath, "utf8"));
+
+    return _.chain(stepTemplates.items)
       .map(function (t) {
         if (t.Properties) {
           var script = t.Properties["Octopus.Action.Script.ScriptBody"];
@@ -41,16 +44,14 @@ class LibraryDb {
         return t.Name.toLowerCase();
       })
       .value();
-
-    this._all = _.indexBy(this._items, "Id");
   }
 
   list(cb) {
-    cb(null, this._items);
+    cb(null, this.loadTemplates());
   }
 
   get(id, cb) {
-    var item = this._all[id];
+    var item = _.indexBy(this.loadTemplates(), "Id")[id];
     cb(null, item);
   }
 }

--- a/app/services/LibraryDb.js
+++ b/app/services/LibraryDb.js
@@ -5,11 +5,22 @@ import path from "path";
 import _ from "underscore";
 
 class LibraryDb {
-  loadTemplates() {
-    const templatePath = path.join(__dirname, "step-templates.json");
-    const stepTemplates = JSON.parse(fs.readFileSync(templatePath, "utf8"));
+  constructor() {
+    this._items = null;
+    this._all = null;
+  }
 
-    return _.chain(stepTemplates.items)
+  isDevelopment() {
+    return process.env.NODE_ENV === "development";
+  }
+
+  readTemplatesFromDisk() {
+    const templatePath = path.join(__dirname, "step-templates.json");
+    return JSON.parse(fs.readFileSync(templatePath, "utf8"));
+  }
+
+  hydrateTemplates(stepTemplates) {
+    const items = _.chain(stepTemplates.items)
       .map(function (t) {
         if (t.Properties) {
           var script = t.Properties["Octopus.Action.Script.ScriptBody"];
@@ -44,14 +55,40 @@ class LibraryDb {
         return t.Name.toLowerCase();
       })
       .value();
+
+    return {
+      items,
+      all: _.indexBy(items, "Id"),
+    };
+  }
+
+  loadTemplates() {
+    return this.hydrateTemplates(this.readTemplatesFromDisk());
+  }
+
+  getTemplates() {
+    if (this.isDevelopment()) {
+      return this.loadTemplates();
+    }
+
+    if (!this._items || !this._all) {
+      const templates = this.loadTemplates();
+      this._items = templates.items;
+      this._all = templates.all;
+    }
+
+    return {
+      items: this._items,
+      all: this._all,
+    };
   }
 
   list(cb) {
-    cb(null, this.loadTemplates());
+    cb(null, this.getTemplates().items);
   }
 
   get(id, cb) {
-    var item = _.indexBy(this.loadTemplates(), "Id")[id];
+    var item = this.getTemplates().all[id];
     cb(null, item);
   }
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -115,7 +115,6 @@ function lint(files, options = {}) {
   return () => {
     return gulp
       .src(files)
-      .pipe(reload({ stream: true, once: true }))
       .pipe($.eslint(options))
       .pipe($.eslint.format("compact"))
       .pipe($.if(!browserSync.active, $.eslint.failOnError()));
@@ -490,7 +489,9 @@ gulp.task(
     );
 
     function reloadServer(done) {
-      server.start.bind(server)();
+      process.chdir(`${buildDir}`);
+      server.start();
+      process.chdir(`../`);
       done();
     }
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -30,8 +30,11 @@ import jasmineReporters from "jasmine-reporters";
 import jasmineTerminalReporter from "jasmine-terminal-reporter";
 import eventStream from "event-stream";
 import fs from "fs";
+import http from "http";
+import https from "https";
 import jsonlint from "gulp-jsonlint";
 import path from "path";
+import { spawn } from "child_process";
 
 const sass = gulpSass(dartSass);
 const clientDir = "app";
@@ -48,6 +51,54 @@ const $ = gulpLoadPlugins({
 
 const reload = browserSync.reload;
 const argv = yargs.argv;
+
+function openBrowser(url) {
+  if (process.env.CI) {
+    return;
+  }
+
+  if (process.platform === "darwin") {
+    spawn("open", [url], { detached: true, stdio: "ignore" }).unref();
+    return;
+  }
+
+  if (process.platform === "win32") {
+    spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" }).unref();
+    return;
+  }
+
+  spawn("xdg-open", [url], { detached: true, stdio: "ignore" }).unref();
+}
+
+function waitForServer(url, { timeoutMs = 10000, pollIntervalMs = 200 } = {}) {
+  const parsedUrl = new URL(url);
+  const client = parsedUrl.protocol === "https:" ? https : http;
+  const startedAt = Date.now();
+
+  return new Promise((resolve) => {
+    function tryConnect() {
+      const request = client.get(url, (response) => {
+        response.resume();
+        resolve();
+      });
+
+      request.on("error", () => {
+        if (Date.now() - startedAt >= timeoutMs) {
+          resolve();
+          return;
+        }
+
+        setTimeout(tryConnect, pollIntervalMs);
+      });
+
+      request.setTimeout(pollIntervalMs, () => {
+        request.destroy();
+      });
+    }
+
+    tryConnect();
+  });
+}
 
 const vendorStyles = [
   "node_modules/font-awesome/css/font-awesome.min.css",
@@ -323,17 +374,16 @@ function provideMissingData() {
   });
 }
 
-gulp.task(
-  "step-templates",
-  gulp.series("tests", () => {
-    return gulp
-      .src("./step-templates/*.json")
-      .pipe(provideMissingData())
-      .pipe(concat("step-templates.json", { newLine: "," }))
-      .pipe(insert.wrap('{"items": [', "]}"))
-      .pipe(argv.production ? gulp.dest(`${publishDir}/app/services`) : gulp.dest(`${buildDir}/app/services`));
-  })
-);
+gulp.task("step-templates:data", () => {
+  return gulp
+    .src("./step-templates/*.json")
+    .pipe(provideMissingData())
+    .pipe(concat("step-templates.json", { newLine: "," }))
+    .pipe(insert.wrap('{"items": [', "]}"))
+    .pipe(argv.production ? gulp.dest(`${publishDir}/app/services`) : gulp.dest(`${buildDir}/app/services`));
+});
+
+gulp.task("step-templates", gulp.series("tests", "step-templates:data"));
 
 gulp.task("styles:vendor", () => {
   return gulp.src(vendorStyles, { base: "node_modules/" }).pipe(argv.production ? gulp.dest(`${publishDir}/public/styles/vendor`) : gulp.dest(`${buildDir}/public/styles/vendor`));
@@ -426,14 +476,28 @@ gulp.task(
     server.start();
     process.chdir(`../`);
 
-    browserSync.init(null, {
-      proxy: "http://localhost:9000",
-    });
+    browserSync.init(
+      null,
+      {
+        proxy: "http://localhost:9000",
+        open: false,
+      },
+      () => {
+        waitForServer("http://localhost:9000").then(() => {
+          openBrowser("http://localhost:9000");
+        });
+      }
+    );
+
+    function reloadServer(done) {
+      server.start.bind(server)();
+      done();
+    }
 
     gulp.watch(`${clientDir}/**/*.jade`, gulp.series("build:client"));
-    gulp.watch(`${clientDir}/**/*.jsx`, gulp.series("scripts", "copy:app"));
+    gulp.watch(`${clientDir}/**/*.jsx`, gulp.series("scripts", "copy:app", reloadServer));
     gulp.watch(`${clientDir}/content/styles/**/*.scss`, gulp.series("styles:client"));
-    gulp.watch("step-templates/*.json", gulp.series("step-templates"));
+    gulp.watch("step-templates/*.json", gulp.series("step-templates:data"));
 
     gulp.watch(`${buildDir}/**/*.*`).on("change", reload);
   })

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -92,7 +92,7 @@ function waitForServer(url, { timeoutMs = 10000, pollIntervalMs = 200 } = {}) {
       });
 
       request.setTimeout(pollIntervalMs, () => {
-        request.destroy();
+        request.destroy(new Error("timeout"));
       });
     }
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -79,12 +79,12 @@ function waitForServer(url, { timeoutMs = 10000, pollIntervalMs = 200 } = {}) {
     function tryConnect() {
       const request = client.get(url, (response) => {
         response.resume();
-        resolve();
+        resolve(true);
       });
 
       request.on("error", () => {
         if (Date.now() - startedAt >= timeoutMs) {
-          resolve();
+          resolve(false);
           return;
         }
 
@@ -482,8 +482,13 @@ gulp.task(
         open: false,
       },
       () => {
-        waitForServer("http://localhost:9000").then(() => {
-          openBrowser("http://localhost:9000");
+        waitForServer("http://localhost:9000").then((isReady) => {
+          if (isReady) {
+            openBrowser("http://localhost:9000");
+            return;
+          }
+
+          log.warn("Timed out waiting for http://localhost:9000, skipping automatic browser launch.");
         });
       }
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,17 +2992,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "1.2.3",
       "dev": true,
@@ -3338,21 +3327,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/browser-sync/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/browser-sync/node_modules/get-caller-file": {
@@ -6480,14 +6454,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fill-range": {
       "version": "4.0.0",
       "dev": true,
@@ -6770,26 +6736,6 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -10168,14 +10114,6 @@
       "version": "0.0.7",
       "license": "ISC"
     },
-    "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "dev": true,
@@ -10577,8 +10515,38 @@
       }
     },
     "node_modules/octopus-library": {
-      "resolved": "",
-      "link": true
+      "version": "2.0.0",
+      "resolved": "file:",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/node": "^7.23.9",
+        "@babel/preset-env": "^7.24.3",
+        "@babel/preset-react": "^7.24.1",
+        "@babel/register": "^7.23.7",
+        "compression": "^1.6.1",
+        "eslint-config-prettier": "^4.3.0",
+        "events": "^1.1.0",
+        "express": "^4.13.4",
+        "font-awesome": "^4.6.1",
+        "frameguard": "^3.0.0",
+        "history": "^2.1.0",
+        "isomorphic-dompurify": "^0.17.0",
+        "marked": "^4.0.10",
+        "moment": "^2.13.0",
+        "node-uuid": "^1.4.7",
+        "normalize.css": "^4.1.1",
+        "octopus-library": "file:",
+        "prettier": "^2.6.2",
+        "prop-types": "^15.6.0",
+        "pug": "^3.0.2",
+        "react": "^15.0.1",
+        "react-copy-to-clipboard": "^5.0.2",
+        "react-dom": "^15.0.1",
+        "react-router": "^2.3.0",
+        "react-syntax-highlighter": "^15.4.5",
+        "underscore": "^1.12.1"
+      }
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -12510,21 +12478,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sass/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/sass/node_modules/glob-parent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,6 +2992,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "1.2.3",
       "dev": true,
@@ -3327,6 +3338,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/browser-sync/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/browser-sync/node_modules/get-caller-file": {
@@ -6454,6 +6480,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "4.0.0",
       "dev": true,
@@ -6736,6 +6770,26 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -10114,6 +10168,14 @@
       "version": "0.0.7",
       "license": "ISC"
     },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.4",
       "dev": true,
@@ -10515,38 +10577,8 @@
       }
     },
     "node_modules/octopus-library": {
-      "version": "2.0.0",
-      "resolved": "file:",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/node": "^7.23.9",
-        "@babel/preset-env": "^7.24.3",
-        "@babel/preset-react": "^7.24.1",
-        "@babel/register": "^7.23.7",
-        "compression": "^1.6.1",
-        "eslint-config-prettier": "^4.3.0",
-        "events": "^1.1.0",
-        "express": "^4.13.4",
-        "font-awesome": "^4.6.1",
-        "frameguard": "^3.0.0",
-        "history": "^2.1.0",
-        "isomorphic-dompurify": "^0.17.0",
-        "marked": "^4.0.10",
-        "moment": "^2.13.0",
-        "node-uuid": "^1.4.7",
-        "normalize.css": "^4.1.1",
-        "octopus-library": "file:",
-        "prettier": "^2.6.2",
-        "prop-types": "^15.6.0",
-        "pug": "^3.0.2",
-        "react": "^15.0.1",
-        "react-copy-to-clipboard": "^5.0.2",
-        "react-dom": "^15.0.1",
-        "react-router": "^2.3.0",
-        "react-syntax-highlighter": "^15.4.5",
-        "underscore": "^1.12.1"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -12478,6 +12510,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sass/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/sass/node_modules/glob-parent": {

--- a/server/server.js
+++ b/server/server.js
@@ -74,11 +74,13 @@ app.get("*", (req, res) => {
 
         LibraryActions.sendTemplates(data, () => {
           var libraryAppHtml = ReactDOMServer.renderToStaticMarkup(<RouterContext {...renderProps} />);
+          const browserSyncClientUrl = process.env.NODE_ENV === "development" ? `${req.protocol}://${req.hostname}:3000/browser-sync/browser-sync-client.js` : null;
           res.render("index", {
             siteKeywords: config.keywords.join(),
             siteDescription: config.description,
             reactOutput: libraryAppHtml,
             stepTemplates: JSON.stringify(data),
+            browserSyncClientUrl,
           });
         });
       });

--- a/server/server.js
+++ b/server/server.js
@@ -18,9 +18,22 @@ import LibraryStorageService from "./app/services/LibraryDb.js";
 import LibraryActions from "./app/actions/LibraryActions";
 
 let app = express();
+const isDevelopment = process.env.NODE_ENV === "development";
+const staticAssetOptions = isDevelopment
+  ? {
+      maxAge: 0,
+      etag: false,
+      lastModified: false,
+      setHeaders: (res) => {
+        res.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, proxy-revalidate");
+        res.setHeader("Pragma", "no-cache");
+        res.setHeader("Expires", "0");
+      },
+    }
+  : { maxage: "1d" };
 
-app.use(express.static(path.join(__dirname, "public"), { maxage: "1d" }));
-app.use(express.static(path.join(__dirname, "views"), { maxage: "1d" }));
+app.use(express.static(path.join(__dirname, "public"), staticAssetOptions));
+app.use(express.static(path.join(__dirname, "views"), staticAssetOptions));
 app.use("/.well-known", express.static(".well-known"));
 
 app.set("views", path.join(__dirname, "views"));

--- a/server/server.js
+++ b/server/server.js
@@ -30,7 +30,7 @@ const staticAssetOptions = isDevelopment
         res.setHeader("Expires", "0");
       },
     }
-  : { maxage: "1d" };
+  : { maxAge: "1d" };
 
 app.use(express.static(path.join(__dirname, "public"), staticAssetOptions));
 app.use(express.static(path.join(__dirname, "views"), staticAssetOptions));

--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -46,5 +46,8 @@ html
 
       ga('create', 'UA-24461753-5', 'octopusdeploy.com');
 
+    if browserSyncClientUrl
+      script(type='text/javascript', async=true, src=browserSyncClientUrl)
+
     //- inject:js
     //- endinject


### PR DESCRIPTION
# Background

This PR improves the local development workflow for the Octopus Community Library (library.octopus.com) site.

The current local dev loop has several issues:

- `npm run watch` opens the BrowserSync proxy URL instead of the primary app URL on port `9000`
- Once that is resolved, the browser can still open before the app is ready
- edits to step template JSON files do not flow through the fastest possible rebuild path
- regenerated step template data is not reliably served without restarting in development
- client-side React edits do not always show up cleanly through the normal reload flow

# Results

The local watch and hot-reload loop is now more reliable and closer to what a developer expects during day-to-day work.

## Before

- local watch opened the proxy URL instead of the main app URL
- the browser could open before the app was reachable
- step template edits used a heavier rebuild path
- generated template data could stay stale until restart
- React edits did not hot-reload reliably and could require a hard refresh to appear

## After

- local watch opens `http://localhost:9000`
- the browser waits until the app is reachable before opening
- step template edits use a narrower `step-templates:data` path
- development reads refreshed generated template data without requiring a restart
- React edits now hot-reload more reliably during local development
- production behavior is kept tighter by caching template data outside development

# Pre-requisites

- [x] `Id` should be a **GUID** that is not `00000000-0000-0000-0000-000000000000`
  - **NOTE** If you are modifying an existing step template, please make sure that you **do not** modify the `Id` property *(updating the `Id` will break the Library sync functionality in Octopus)*.
- [x] `Version` should be incremented, otherwise the integration with Octopus won't update the step template correctly
- [x] Parameter names should not start with `$`
- [x] **Step template parameter names (the ones declared in the JSON, not the script body) should be prefixed with a namespace so that they are less likely to clash with other user-defined variables in Octopus** (see [this issue](https://github.com/OctopusDeploy/Issues/issues/2126)). For example, use an abbreviated name of the step template or the category of the step template).
- [x] `LastModifiedBy` field must be present, and (_optionally_) updated with the correct author
- [x] The best practices documented [here](https://github.com/OctopusDeploy/Library/wiki/Best-Practices) have been applied
- [x] If a new `Category` has been created:
   - [x] An image with the name `{categoryname}.png` must be present under the `step-templates/logos` folder
   - [x] The `switch` in the `humanize` function in [`gulpfile.babel.js`](https://github.com/OctopusDeploy/Library/blob/master/gulpfile.babel.js#L92) must have a `case` statement corresponding to it

Fixes #1673