### PR TITLE
Add source-first migration tooling for step templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,11 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
-* text=auto
-*.ps1 text eol=crlf
-*.sh text eol=lf
-*.py text eol=lf
-*.json text eol=lf
 
-# Denote all files that are truly binary and should not be modified.
+*.json text eol=lf
 *.png binary
+
+src/step-templates/*/scriptbody.ps1 -text
+src/step-templates/*/predeploy.ps1 -text
+src/step-templates/*/deploy.ps1 -text
+src/step-templates/*/postdeploy.ps1 -text
+src/step-templates/*/scriptbody.sh -text
+src/step-templates/*/scriptbody.py -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,10 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+* text=auto
+*.ps1 text eol=crlf
+*.sh text eol=lf
+*.py text eol=lf
+*.json text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,8 @@ junitresults.xml
 scriptcs_packages/
 scriptcs_packages.config
 
-step-templates/*.ps1
-step-templates/*.sh
-step-templates/*.py
+/step-templates/
+/step-templates-orig/
 diff-output/
 /.vs
 !.vscode

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -34,7 +34,7 @@ import http from "http";
 import https from "https";
 import jsonlint from "gulp-jsonlint";
 import path from "path";
-import { spawn } from "child_process";
+import { execFileSync, spawn } from "child_process";
 
 const sass = gulpSass(dartSass);
 const clientDir = "app";
@@ -42,6 +42,33 @@ const serverDir = "server";
 
 const buildDir = "build";
 const publishDir = "dist";
+const sourceStepTemplatesDir = "src/step-templates";
+const scriptDefinitions = [
+  {
+    sourceBaseName: "scriptbody",
+    sourceExtensions: [".ps1", ".sh", ".py"],
+    propertyName: "Octopus.Action.Script.ScriptBody",
+    legacyBaseName: "ScriptBody",
+  },
+  {
+    sourceBaseName: "predeploy",
+    sourceExtensions: [".ps1"],
+    propertyName: "Octopus.Action.CustomScripts.PreDeploy.ps1",
+    legacyBaseName: "PreDeploy",
+  },
+  {
+    sourceBaseName: "deploy",
+    sourceExtensions: [".ps1"],
+    propertyName: "Octopus.Action.CustomScripts.Deploy.ps1",
+    legacyBaseName: "Deploy",
+  },
+  {
+    sourceBaseName: "postdeploy",
+    sourceExtensions: [".ps1"],
+    propertyName: "Octopus.Action.CustomScripts.PostDeploy.ps1",
+    legacyBaseName: "PostDeploy",
+  },
+];
 
 const $ = gulpLoadPlugins({
   rename: {
@@ -51,6 +78,156 @@ const $ = gulpLoadPlugins({
 
 const reload = browserSync.reload;
 const argv = yargs.argv;
+
+function isDirectory(targetPath) {
+  return fs.existsSync(targetPath) && fs.statSync(targetPath).isDirectory();
+}
+
+function ensureDirectory(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function listMigratedTemplates() {
+  if (!isDirectory(sourceStepTemplatesDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(sourceStepTemplatesDir)
+    .filter((entry) => !["logos", "tests"].includes(entry))
+    .filter((entry) => isDirectory(path.join(sourceStepTemplatesDir, entry)))
+    .filter((entry) => fs.existsSync(path.join(sourceStepTemplatesDir, entry, "metadata.json")))
+    .sort();
+}
+
+function getLegacyJsonPath(templateName) {
+  return path.join("step-templates", `${templateName}.json`);
+}
+
+function getSourceTemplateDirectory(templateName) {
+  return path.join(sourceStepTemplatesDir, templateName);
+}
+
+function getLegacySidecarFileName(templateName, sourceFileName, definition) {
+  const extension = path.extname(sourceFileName);
+
+  return `${templateName}.${definition.legacyBaseName}${extension}`;
+}
+
+function runPack(templateName) {
+  execFileSync(process.env.PWSH_PATH || "pwsh", ["-NoProfile", "-File", path.join("tools", "_pack.ps1"), "-SearchPattern", templateName], {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  });
+}
+
+function runPackAll() {
+  execFileSync(process.env.PWSH_PATH || "pwsh", ["-NoProfile", "-File", path.join("tools", "_pack.ps1")], {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  });
+}
+
+function cleanGeneratedSidecars(templateName) {
+  for (const definition of scriptDefinitions) {
+    for (const extension of definition.sourceExtensions) {
+      const sidecarPath = path.join("step-templates", getLegacySidecarFileName(templateName, `${definition.sourceBaseName}${extension}`, definition));
+      if (fs.existsSync(sidecarPath)) {
+        fs.rmSync(sidecarPath, { force: true });
+      }
+    }
+  }
+}
+
+function cleanGeneratedSidecarsForTemplates(templateNames) {
+  for (const templateName of templateNames) {
+    cleanGeneratedSidecars(templateName);
+  }
+}
+
+function materializeLegacyTemplate(templateName) {
+  const sourceDirectory = getSourceTemplateDirectory(templateName);
+  const metadataPath = path.join(sourceDirectory, "metadata.json");
+
+  if (!fs.existsSync(metadataPath)) {
+    return false;
+  }
+
+  ensureDirectory("step-templates");
+  fs.copyFileSync(metadataPath, getLegacyJsonPath(templateName));
+
+  for (const definition of scriptDefinitions) {
+    for (const extension of definition.sourceExtensions) {
+      const sourceFileName = `${definition.sourceBaseName}${extension}`;
+      const sourceFilePath = path.join(sourceDirectory, sourceFileName);
+
+      if (!fs.existsSync(sourceFilePath)) {
+        continue;
+      }
+
+      const legacySidecarPath = path.join("step-templates", getLegacySidecarFileName(templateName, sourceFileName, definition));
+      fs.copyFileSync(sourceFilePath, legacySidecarPath);
+      break;
+    }
+  }
+
+  return true;
+}
+
+function generateMigratedTemplate(templateName) {
+  if (!materializeLegacyTemplate(templateName)) {
+    return false;
+  }
+
+  try {
+    runPack(templateName);
+  } finally {
+    cleanGeneratedSidecars(templateName);
+  }
+
+  return true;
+}
+
+function generateAllMigratedTemplates() {
+  const templateNames = listMigratedTemplates();
+  const materializedTemplateNames = templateNames.filter((templateName) => materializeLegacyTemplate(templateName));
+
+  if (materializedTemplateNames.length === 0) {
+    return false;
+  }
+
+  try {
+    runPackAll();
+  } finally {
+    cleanGeneratedSidecarsForTemplates(materializedTemplateNames);
+  }
+
+  return true;
+}
+
+function getChangedSourcePathType(changedPath) {
+  const absolutePath = path.resolve(changedPath);
+  const relativePath = path.relative(path.resolve(sourceStepTemplatesDir), absolutePath);
+
+  if (relativePath.startsWith("..")) {
+    return { type: "outside" };
+  }
+
+  const [firstSegment] = relativePath.split(path.sep).filter(Boolean);
+  if (!firstSegment) {
+    return { type: "all" };
+  }
+
+  if (firstSegment === "logos") {
+    return { type: "logos" };
+  }
+
+  if (firstSegment === "tests") {
+    return { type: "tests" };
+  }
+
+  return { type: "template", templateName: firstSegment };
+}
 
 function openBrowser(url) {
   if (process.env.CI) {
@@ -123,6 +300,11 @@ function lint(files, options = {}) {
 
 gulp.task("lint:client", lint(`${clientDir}/**/*.jsx`));
 gulp.task("lint:server", lint(`./${serverDir}/server.js`));
+gulp.task("prepare:step-templates", (done) => {
+  generateAllMigratedTemplates();
+  done();
+});
+
 gulp.task("lint:step-templates", () => {
   return gulp
     .src("./step-templates/*.json")
@@ -132,25 +314,24 @@ gulp.task("lint:step-templates", () => {
     .pipe(jsonlint.reporter());
 });
 
-gulp.task(
-  "tests",
-  gulp.series("lint:step-templates", () => {
-    return (
-      gulp
-        .src("./spec/*-tests.js")
-        // gulp-jasmine works on filepaths so you can't have any plugins before it
-        .pipe(
-          jasmine({
-            includeStackTrace: false,
-            reporter: [new jasmineReporters.JUnitXmlReporter(), process.env.TEAMCITY_VERSION ? new jasmineReporters.TeamCityReporter() : new jasmineTerminalReporter()],
-          })
-        )
-        .on("error", function () {
-          process.exit(1);
+gulp.task("test:step-templates", () => {
+  return (
+    gulp
+      .src("./spec/*-tests.js")
+      // gulp-jasmine works on filepaths so you can't have any plugins before it
+      .pipe(
+        jasmine({
+          includeStackTrace: false,
+          reporter: [new jasmineReporters.JUnitXmlReporter(), process.env.TEAMCITY_VERSION ? new jasmineReporters.TeamCityReporter() : new jasmineTerminalReporter()],
         })
-    );
-  })
-);
+      )
+      .on("error", function () {
+        process.exit(1);
+      })
+  );
+});
+
+gulp.task("tests", gulp.series("prepare:step-templates", "lint:step-templates", "test:step-templates"));
 
 function humanize(categoryId) {
   switch (categoryId) {
@@ -363,7 +544,9 @@ function provideMissingData() {
     template.Category = humanize(categoryId);
 
     if (!template.Logo) {
-      var logo = fs.readFileSync("./step-templates/logos/" + categoryId + ".png");
+      var sourceLogoPath = "./src/step-templates/logos/" + categoryId + ".png";
+      var legacyLogoPath = "./step-templates/logos/" + categoryId + ".png";
+      var logo = fs.readFileSync(fs.existsSync(sourceLogoPath) ? sourceLogoPath : legacyLogoPath);
       template.Logo = Buffer.from(logo).toString("base64");
     }
 
@@ -504,6 +687,26 @@ gulp.task(
     gulp.watch(`${clientDir}/**/*.jsx`, gulp.series("scripts", "copy:app", reloadServer));
     gulp.watch(`${clientDir}/content/styles/**/*.scss`, gulp.series("styles:client"));
     gulp.watch("step-templates/*.json", gulp.series("step-templates:data"));
+    gulp.watch(`${sourceStepTemplatesDir}/**/*`).on("all", (eventName, changedPath) => {
+      const change = changedPath ? getChangedSourcePathType(changedPath) : { type: "all" };
+
+      if (change.type === "template") {
+        generateMigratedTemplate(change.templateName);
+      } else if (change.type === "logos" || change.type === "all") {
+        generateAllMigratedTemplates();
+      } else if (change.type === "outside" || change.type === "tests") {
+        return;
+      }
+
+      gulp.series("step-templates:data")((error) => {
+        if (error) {
+          log.error(error);
+          return;
+        }
+
+        reload();
+      });
+    });
 
     gulp.watch(`${buildDir}/**/*.*`).on("change", reload);
   })

--- a/spec/logos-validation-tests.js
+++ b/spec/logos-validation-tests.js
@@ -2,9 +2,9 @@ var fs = require("fs");
 
 describe("logos", function () {
   it("logos have valid details", function (done) {
-    var filenameCounter = 0;
-    var stepTemplateCount = 0;
-    var dirname = "./step-templates/logos";
+    var sourceDirname = "./src/step-templates/logos";
+    var legacyDirname = "./step-templates/logos";
+    var dirname = fs.existsSync(sourceDirname) ? sourceDirname : legacyDirname;
 
     fs.readdir(dirname, function (err, filenames) {
       if (err) {

--- a/spec/step-template-validation-tests.js
+++ b/spec/step-template-validation-tests.js
@@ -109,9 +109,8 @@ describe("step-templates", function () {
       }
 
       var otherThings = results.filter(function (file) {
-        var pesterFile = file.endsWith(".ScriptBody.ps1");
         var jsonFile = file.endsWith(".json");
-        return !pesterFile && !jsonFile && file !== "logos" && file !== "tests";
+        return !jsonFile && file !== "logos" && file !== "tests";
       });
       expect(otherThings).toEqual([]);
       done();

--- a/tools/migrate-source-first-reset.js
+++ b/tools/migrate-source-first-reset.js
@@ -1,0 +1,106 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline/promises");
+const { stdin, stdout } = require("process");
+const { execFileSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const legacyRoot = path.join(repoRoot, "step-templates");
+const sourceRoot = path.join(repoRoot, "src", "step-templates");
+const backupRoot = path.join(repoRoot, "step-templates-orig");
+
+function pathExists(targetPath) {
+  return fs.existsSync(targetPath);
+}
+
+function removePath(targetPath) {
+  if (pathExists(targetPath)) {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+  }
+}
+
+function runGit(args) {
+  execFileSync("git", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+}
+
+function captureGit(args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  }).trim();
+}
+
+function isTrackedAtHead(targetPath) {
+  return captureGit(["ls-tree", "--name-only", "HEAD", targetPath]).length > 0;
+}
+
+async function confirmReset(rl) {
+  const answer = (await rl.question("Reset this migration run back to branch HEAD? [y/N] ")).trim().toLowerCase();
+  return answer === "y" || answer === "yes";
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+
+  try {
+    console.log("Source-first migration reset");
+    console.log(`Repo root: ${repoRoot}`);
+    console.log("This will:");
+    console.log("- restore tracked step-templates and src/step-templates to current branch HEAD");
+    console.log("- remove step-templates-orig/");
+    console.log("- remove any untracked src/step-templates/ leftovers");
+
+    const confirmed = await confirmReset(rl);
+    if (!confirmed) {
+      console.log("Aborted.");
+      return;
+    }
+
+    const restorePaths = ["step-templates"];
+    const sourceTrackedAtHead = isTrackedAtHead("src/step-templates");
+    if (sourceTrackedAtHead) {
+      restorePaths.push("src/step-templates");
+    }
+
+    runGit(["restore", "--source=HEAD", "--staged", "--worktree", ...restorePaths]);
+
+    if (!sourceTrackedAtHead) {
+      runGit(["rm", "-r", "-f", "--cached", "--ignore-unmatch", "src/step-templates"]);
+    }
+
+    removePath(backupRoot);
+
+    if (pathExists(sourceRoot)) {
+      const entries = fs.readdirSync(sourceRoot);
+      if (entries.length === 0) {
+        removePath(sourceRoot);
+      }
+    }
+
+    if (pathExists(sourceRoot)) {
+      removePath(sourceRoot);
+    }
+
+    if (!pathExists(legacyRoot)) {
+      throw new Error("step-templates/ is missing after reset.");
+    }
+
+    console.log("Reset complete.");
+    console.log("- restored tracked step-templates and src/step-templates to branch HEAD");
+    console.log("- removed step-templates-orig/");
+    console.log("- removed src/step-templates/ leftovers");
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/tools/migrate-source-first.js
+++ b/tools/migrate-source-first.js
@@ -1,0 +1,467 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const readline = require("readline/promises");
+const { stdin, stdout } = require("process");
+const { execFileSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+const legacyRoot = path.join(repoRoot, "step-templates");
+const backupRoot = path.join(repoRoot, "step-templates-orig");
+const sourceRoot = path.join(repoRoot, "src", "step-templates");
+const placeholderPrefix = "__SOURCE_FILE__:";
+const ansiReset = "\u001b[0m";
+const ansiBold = "\u001b[1m";
+const ansiDim = "\u001b[2m";
+const ansiGreen = "\u001b[32m";
+const ansiRed = "\u001b[31m";
+const ansiYellow = "\u001b[33m";
+const ansiBlue = "\u001b[34m";
+const ansiCyan = "\u001b[36m";
+
+const scriptDefinitions = [
+  {
+    sourceBaseName: "scriptbody",
+    legacyBaseName: "ScriptBody",
+    propertyName: "Octopus.Action.Script.ScriptBody",
+    getExtension(template) {
+      const syntax = (((template || {}).Properties || {})["Octopus.Action.Script.Syntax"] || "PowerShell").toLowerCase();
+      if (syntax === "bash") {
+        return ".sh";
+      }
+
+      if (syntax === "python") {
+        return ".py";
+      }
+
+      return ".ps1";
+    },
+    shouldExtract(template) {
+      const properties = (template || {}).Properties || {};
+      const scriptSource = properties["Octopus.Action.Script.ScriptSource"] || "Inline";
+      return scriptSource === "Inline" && typeof properties[this.propertyName] === "string" && properties[this.propertyName].length > 0;
+    },
+  },
+  {
+    sourceBaseName: "predeploy",
+    legacyBaseName: "PreDeploy",
+    propertyName: "Octopus.Action.CustomScripts.PreDeploy.ps1",
+    getExtension() {
+      return ".ps1";
+    },
+    shouldExtract(template) {
+      const value = (((template || {}).Properties || {})[this.propertyName] || "");
+      return typeof value === "string" && value.length > 0;
+    },
+  },
+  {
+    sourceBaseName: "deploy",
+    legacyBaseName: "Deploy",
+    propertyName: "Octopus.Action.CustomScripts.Deploy.ps1",
+    getExtension() {
+      return ".ps1";
+    },
+    shouldExtract(template) {
+      const value = (((template || {}).Properties || {})[this.propertyName] || "");
+      return typeof value === "string" && value.length > 0;
+    },
+  },
+  {
+    sourceBaseName: "postdeploy",
+    legacyBaseName: "PostDeploy",
+    propertyName: "Octopus.Action.CustomScripts.PostDeploy.ps1",
+    getExtension() {
+      return ".ps1";
+    },
+    shouldExtract(template) {
+      const value = (((template || {}).Properties || {})[this.propertyName] || "");
+      return typeof value === "string" && value.length > 0;
+    },
+  },
+];
+
+const excludedValidationFields = new Set(["ExportedAt", "LastModifiedOn", "LastModifiedAt", "LastModfiedAt"]);
+
+function listTemplateJsonFiles(rootPath) {
+  return fs
+    .readdirSync(rootPath)
+    .filter((entry) => entry.endsWith(".json"))
+    .sort();
+}
+
+function runGit(args) {
+  execFileSync("git", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+}
+
+function colorize(color, text) {
+  return `${color}${text}${ansiReset}`;
+}
+
+function log(message, type = "info") {
+  if (type === "blank") {
+    console.log("");
+    return;
+  }
+
+  if (type === "banner") {
+    console.log(colorize(ansiBold + ansiBlue, message));
+    return;
+  }
+
+  if (type === "error") {
+    console.log(colorize(ansiBold + ansiRed, message));
+    return;
+  }
+
+  if (type === "step") {
+    console.log("");
+    console.log(colorize(ansiBold + ansiBlue, message));
+    return;
+  }
+
+  if (type === "note") {
+    console.log(colorize(ansiYellow, `NOTE ${message}`));
+    return;
+  }
+
+  if (type === "success") {
+    console.log(`${colorize(ansiGreen, "DONE")} ${message}`);
+    return;
+  }
+
+  if (type === "action") {
+    console.log(`${colorize(ansiCyan, "ACTION")} ${message}`);
+    return;
+  }
+
+  if (type === "pass") {
+    console.log(`${ansiGreen}PASS${ansiReset} ${message}`);
+    return;
+  }
+
+  if (type === "fail") {
+    console.log(`${ansiRed}FAIL${ansiReset} ${message}`);
+    return;
+  }
+
+  console.log(message);
+}
+
+function normalizeForComparison(value) {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForComparison);
+  }
+
+  if (value && typeof value === "object") {
+    const result = {};
+    for (const [key, childValue] of Object.entries(value)) {
+      if (excludedValidationFields.has(key)) {
+        continue;
+      }
+
+      result[key] = normalizeForComparison(childValue);
+    }
+
+    return result;
+  }
+
+  return value;
+}
+
+function diffObjects(left, right, currentPath = "$") {
+  if (typeof left !== typeof right) {
+    return [`${currentPath}: type mismatch (${typeof left} !== ${typeof right})`];
+  }
+
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return [`${currentPath}: array length mismatch (${left.length} !== ${right.length})`];
+    }
+
+    for (let index = 0; index < left.length; index += 1) {
+      const nested = diffObjects(left[index], right[index], `${currentPath}[${index}]`);
+      if (nested.length > 0) {
+        return nested;
+      }
+    }
+
+    return [];
+  }
+
+  if (left && typeof left === "object" && right && typeof right === "object") {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+
+    if (leftKeys.join("|") !== rightKeys.join("|")) {
+      return [`${currentPath}: key mismatch (${leftKeys.join(", ")} !== ${rightKeys.join(", ")})`];
+    }
+
+    for (const key of leftKeys) {
+      const nested = diffObjects(left[key], right[key], `${currentPath}.${key}`);
+      if (nested.length > 0) {
+        return nested;
+      }
+    }
+
+    return [];
+  }
+
+  if (left !== right) {
+    return [`${currentPath}: value mismatch (${JSON.stringify(left)} !== ${JSON.stringify(right)})`];
+  }
+
+  return [];
+}
+
+async function confirmStep(rl, prompt) {
+  const answer = (await rl.question(`${prompt} [y/N] `)).trim().toLowerCase();
+  if (answer !== "y" && answer !== "yes") {
+    log("Aborted.");
+    return false;
+  }
+
+  return true;
+}
+
+async function step1_PrepareValidationBaseline(rl) {
+  log("Step 1: Prepare validation baseline", "step");
+  log("This creates a frozen pre-migration copy of the current step-template JSON files.");
+  log("The copied files are written to step-templates-orig/ at the repo root.");
+  log("The copy is unpacked so we can later compare the rebuilt source-first output to the original repo state.");
+  log("step-templates-orig/ is git-ignored so these temporary baseline files cannot be accidentally committed.");
+
+  if (fs.existsSync(backupRoot)) {
+    log("step-templates-orig/ already exists and will be replaced.", "note");
+  }
+
+  if (!(await confirmStep(rl, "Prepare the validation baseline?"))) {
+    return false;
+  }
+
+  if (fs.existsSync(backupRoot)) {
+    fs.rmSync(backupRoot, { recursive: true, force: true });
+  }
+
+  fs.cpSync(legacyRoot, backupRoot, { recursive: true });
+
+  for (const fileName of listTemplateJsonFiles(backupRoot)) {
+    const templateName = fileName.replace(/\.json$/i, "");
+    const template = JSON.parse(fs.readFileSync(path.join(backupRoot, fileName), "utf8"));
+    const unpackedSidecars = [];
+
+    for (const definition of scriptDefinitions) {
+      if (!definition.shouldExtract(template)) {
+        continue;
+      }
+
+      const extension = definition.getExtension(template);
+      const sidecarPath = path.join(backupRoot, `${templateName}.${definition.legacyBaseName}${extension}`);
+      const value = template.Properties[definition.propertyName];
+      fs.writeFileSync(sidecarPath, value, "utf8");
+      unpackedSidecars.push(path.basename(sidecarPath));
+    }
+
+    if (unpackedSidecars.length > 0) {
+      log(`UNPACK ${fileName} -> ${unpackedSidecars.join(", ")}`, "action");
+      continue;
+    }
+
+    log(`UNPACK ${fileName} -> ${colorize(ansiDim, "no sidecars")}`, "action");
+  }
+
+  log("Created step-templates-orig/", "success");
+  log("Unpacked reference sidecars in step-templates-orig/", "success");
+  return true;
+}
+
+async function step2_MoveJsonTemplatesIntoSourceTree(rl) {
+  log("Step 2: Move JSON templates into the source tree with history", "step");
+  log("Each step-template JSON file is moved with git history into src/step-templates/<template>/metadata.json.");
+  log("We are choosing metadata.json as the file that will retain the existing JSON history after the split.");
+  log("Shared logos/ and tests/ assets also move into src/step-templates/.");
+
+  if (!(await confirmStep(rl, "Move the existing templates into the new source tree?"))) {
+    return false;
+  }
+
+  fs.mkdirSync(sourceRoot, { recursive: true });
+
+  for (const fileName of listTemplateJsonFiles(legacyRoot)) {
+    const templateName = fileName.replace(/\.json$/i, "");
+    const targetDirectory = path.join(sourceRoot, templateName);
+
+    if (fs.existsSync(targetDirectory)) {
+      throw new Error(`Target directory already exists: ${path.relative(repoRoot, targetDirectory)}`);
+    }
+  }
+
+  for (const sharedDirectoryName of ["logos", "tests"]) {
+    const targetPath = path.join(sourceRoot, sharedDirectoryName);
+    if (fs.existsSync(targetPath)) {
+      throw new Error(`Target path already exists: ${path.relative(repoRoot, targetPath)}`);
+    }
+  }
+
+  for (const fileName of listTemplateJsonFiles(legacyRoot)) {
+    const templateName = fileName.replace(/\.json$/i, "");
+    const sourceJsonPath = path.join("step-templates", fileName);
+    const targetDirectory = path.join(sourceRoot, templateName);
+    const targetMetadataPath = path.join(targetDirectory, "metadata.json");
+
+    fs.mkdirSync(targetDirectory, { recursive: true });
+    log(`MOVE ${sourceJsonPath} -> ${path.relative(repoRoot, targetMetadataPath)} ${colorize(ansiDim, "(preserve history)")}`, "action");
+    runGit(["mv", sourceJsonPath, path.relative(repoRoot, targetMetadataPath)]);
+  }
+
+  for (const sharedDirectoryName of ["logos", "tests"]) {
+    const sourcePath = path.join("step-templates", sharedDirectoryName);
+    const targetPath = path.join("src", "step-templates", sharedDirectoryName);
+    log(`MOVE ${sourcePath} -> ${targetPath} ${colorize(ansiDim, "(preserve history)")}`, "action");
+    runGit(["mv", sourcePath, targetPath]);
+  }
+
+  log("Moved template JSON files into src/step-templates/.../metadata.json", "success");
+  log("Moved step-templates/logos and step-templates/tests into src/step-templates/", "success");
+  return true;
+}
+
+async function step3_SplitSourceTemplatesIntoConstituentFiles(rl) {
+  log("Step 3: Split source templates into constituent files", "step");
+  log("Inline script content is extracted from metadata.json into dedicated source files beside each template.");
+  log("Octopus.Action.Script.ScriptBody becomes scriptbody.ps1, scriptbody.sh, or scriptbody.py based on script syntax.");
+  log("Non-empty custom script fields become predeploy.ps1, deploy.ps1, and postdeploy.ps1 when those fields are present.");
+  log("metadata.json stays as the history-carrying file, and placeholders are written so the existing pack tooling can rebuild the legacy JSON.");
+
+  if (!(await confirmStep(rl, "Split inline script content into source sidecar files?"))) {
+    return false;
+  }
+
+  for (const fileName of listTemplateJsonFiles(backupRoot)) {
+    const templateName = fileName.replace(/\.json$/i, "");
+    const metadataPath = path.join(sourceRoot, templateName, "metadata.json");
+    const template = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+    template.Properties = template.Properties || {};
+    const extractedSidecars = [];
+
+    for (const definition of scriptDefinitions) {
+      if (!definition.shouldExtract(template)) {
+        continue;
+      }
+
+      const extension = definition.getExtension(template);
+      const sourceSidecarPath = path.join(sourceRoot, templateName, `${definition.sourceBaseName}${extension}`);
+      const value = template.Properties[definition.propertyName];
+
+      fs.writeFileSync(sourceSidecarPath, value, "utf8");
+      template.Properties[definition.propertyName] = `${placeholderPrefix}${path.basename(sourceSidecarPath)}`;
+      extractedSidecars.push(path.basename(sourceSidecarPath));
+    }
+
+    fs.writeFileSync(metadataPath, `${JSON.stringify(template, null, 2)}\n`);
+
+    if (extractedSidecars.length > 0) {
+      log(`EXTRACT ${fileName} -> ${extractedSidecars.join(", ")}`, "action");
+      continue;
+    }
+
+    log(`EXTRACT ${fileName} -> ${colorize(ansiDim, "no sidecars")}`, "action");
+  }
+
+  log("Extracted source sidecars and replaced metadata placeholders", "success");
+  return true;
+}
+
+async function step4_RebuildAndValidateGeneratedJson(rl) {
+  log("Step 4: Rebuild and validate generated JSON output", "step");
+  log("This rebuilds step-templates/*.json from src/step-templates/ using the existing pack tooling.");
+  log("The rebuilt JSON is then compared to the frozen baseline in step-templates-orig/.");
+  log("A passing result shows the source-first tree can reproduce the original packed JSON apart from excluded regenerated metadata fields.");
+
+  if (!(await confirmStep(rl, "Rebuild the packed JSON and validate it against the baseline?"))) {
+    return false;
+  }
+
+  const gulpExecutable =
+    process.platform === "win32" ? path.join(repoRoot, "node_modules", ".bin", "gulp.cmd") : path.join(repoRoot, "node_modules", ".bin", "gulp");
+
+  execFileSync(gulpExecutable, ["step-templates"], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+
+  log("", "blank");
+  log("Regenerated packed step-templates/*.json from src/step-templates", "success");
+
+  const mismatches = [];
+
+  log(
+    `Validation excludes regenerated metadata fields: ${Array.from(excludedValidationFields)
+      .map((fieldName) => `'${fieldName}'`)
+      .join(", ")}`,
+    "note"
+  );
+
+  for (const fileName of listTemplateJsonFiles(backupRoot)) {
+    const originalJsonPath = path.join(backupRoot, fileName);
+    const generatedJsonPath = path.join(legacyRoot, fileName);
+
+    if (!fs.existsSync(generatedJsonPath)) {
+      mismatches.push(`${fileName}: regenerated file is missing`);
+      continue;
+    }
+
+    const original = normalizeForComparison(JSON.parse(fs.readFileSync(originalJsonPath, "utf8")));
+    const generated = normalizeForComparison(JSON.parse(fs.readFileSync(generatedJsonPath, "utf8")));
+    const diff = diffObjects(original, generated);
+
+    if (diff.length > 0) {
+      mismatches.push(`${fileName}: ${diff[0]}`);
+      continue;
+    }
+
+    log(fileName, "pass");
+  }
+
+  if (mismatches.length > 0) {
+    log("", "blank");
+    log("Validation mismatches:", "error");
+    for (const mismatch of mismatches) {
+      log(mismatch, "fail");
+    }
+
+    throw new Error(`Validation failed for ${mismatches.length} template(s).`);
+  }
+
+  log("Validated regenerated step-templates/*.json against step-templates-orig/", "success");
+  log("Rebuilt and validated regenerated step-templates/*.json against step-templates-orig/", "success");
+  return true;
+}
+
+async function main() {
+  const rl = readline.createInterface({ input: stdin, output: stdout });
+
+  try {
+    log("Source-first migration", "banner");
+    log(colorize(ansiDim, `Repo root: ${repoRoot}`));
+    log(colorize(ansiDim, "This script does not commit anything."));
+
+    if (!(await step1_PrepareValidationBaseline(rl))) { return; }
+
+    if (!(await step2_MoveJsonTemplatesIntoSourceTree(rl))) { return; }
+
+    if (!(await step3_SplitSourceTemplatesIntoConstituentFiles(rl))) { return; }
+
+    if (!(await step4_RebuildAndValidateGeneratedJson(rl))) { return; }
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/tools/migrate-source-first.js
+++ b/tools/migrate-source-first.js
@@ -388,6 +388,44 @@ async function step4_BuildStepTemplateJsonFilesFromSrcAndValidateAgainstBaseline
   const gulpExecutable =
     process.platform === "win32" ? path.join(repoRoot, "node_modules", ".bin", "gulp.cmd") : path.join(repoRoot, "node_modules", ".bin", "gulp");
 
+  if (!fs.existsSync(gulpExecutable)) {
+    log("Build dependencies are missing. Step 4 needs the existing gulp-based toolchain to rebuild step-template JSON files.", "note");
+
+    if (!(await confirmStep(rl, "Run npm ci to install the required build dependencies?"))) {
+      return false;
+    }
+
+    log("Running npm ci", "action");
+
+    try {
+      execFileSync("npm", ["ci"], {
+        cwd: repoRoot,
+        stdio: "inherit",
+      });
+    } catch (error) {
+      log("npm ci failed. This repository may require npm install because package-lock.json is not in sync with the current npm client.", "note");
+
+      if (!(await confirmStep(rl, "Run npm install instead?"))) {
+        throw new Error("Dependency installation failed while running npm ci.");
+      }
+
+      log("Running npm install", "action");
+
+      try {
+        execFileSync("npm", ["install"], {
+          cwd: repoRoot,
+          stdio: "inherit",
+        });
+      } catch (installError) {
+        throw new Error("Dependency installation failed while running npm install.");
+      }
+    }
+
+    if (!fs.existsSync(gulpExecutable)) {
+      throw new Error("Dependency installation completed, but the gulp executable is still missing.");
+    }
+  }
+
   execFileSync(gulpExecutable, ["step-templates"], {
     cwd: repoRoot,
     stdio: "inherit",

--- a/tools/migrate-source-first.js
+++ b/tools/migrate-source-first.js
@@ -227,7 +227,7 @@ async function confirmStep(rl, prompt) {
   return true;
 }
 
-async function step1_PrepareValidationBaseline(rl) {
+async function step1_DupeStepTemplateJsonFilesForValidationBaseline(rl) {
   log("Step 1: Prepare validation baseline", "step");
   log("This creates a frozen pre-migration copy of the current step-template JSON files.");
   log("The copied files are written to step-templates-orig/ at the repo root.");
@@ -278,7 +278,7 @@ async function step1_PrepareValidationBaseline(rl) {
   return true;
 }
 
-async function step2_MoveJsonTemplatesIntoSourceTree(rl) {
+async function step2_GitMoveStepTemplateJsonFilesToSrcAsMetadataJsonFiles(rl) {
   log("Step 2: Move JSON templates into the source tree with history", "step");
   log("Each step-template JSON file is moved with git history into src/step-templates/<template>/metadata.json.");
   log("We are choosing metadata.json as the file that will retain the existing JSON history after the split.");
@@ -329,7 +329,7 @@ async function step2_MoveJsonTemplatesIntoSourceTree(rl) {
   return true;
 }
 
-async function step3_SplitSourceTemplatesIntoConstituentFiles(rl) {
+async function step3_SplitSrcMetadataJsonFilesIntoConstituentFiles(rl) {
   log("Step 3: Split source templates into constituent files", "step");
   log("Inline script content is extracted from metadata.json into dedicated source files beside each template.");
   log("Octopus.Action.Script.ScriptBody becomes scriptbody.ps1, scriptbody.sh, or scriptbody.py based on script syntax.");
@@ -375,7 +375,7 @@ async function step3_SplitSourceTemplatesIntoConstituentFiles(rl) {
   return true;
 }
 
-async function step4_RebuildAndValidateGeneratedJson(rl) {
+async function step4_BuildStepTemplateJsonFilesFromSrcAndValidateAgainstBaseline(rl) {
   log("Step 4: Rebuild and validate generated JSON output", "step");
   log("This rebuilds step-templates/*.json from src/step-templates/ using the existing pack tooling.");
   log("The rebuilt JSON is then compared to the frozen baseline in step-templates-orig/.");
@@ -449,13 +449,13 @@ async function main() {
     log(colorize(ansiDim, `Repo root: ${repoRoot}`));
     log(colorize(ansiDim, "This script does not commit anything."));
 
-    if (!(await step1_PrepareValidationBaseline(rl))) { return; }
+    if (!(await step1_DupeStepTemplateJsonFilesForValidationBaseline(rl))) { return; }
 
-    if (!(await step2_MoveJsonTemplatesIntoSourceTree(rl))) { return; }
+    if (!(await step2_GitMoveStepTemplateJsonFilesToSrcAsMetadataJsonFiles(rl))) { return; }
 
-    if (!(await step3_SplitSourceTemplatesIntoConstituentFiles(rl))) { return; }
+    if (!(await step3_SplitSrcMetadataJsonFilesIntoConstituentFiles(rl))) { return; }
 
-    if (!(await step4_RebuildAndValidateGeneratedJson(rl))) { return; }
+    if (!(await step4_BuildStepTemplateJsonFilesFromSrcAndValidateAgainstBaseline(rl))) { return; }
   } finally {
     rl.close();
   }


### PR DESCRIPTION
## Summary

Adds the tooling needed to validate a source-first step-template workflow before submitting the actual repository migration.

Related: #1677

## Included in this PR

- migration tooling for moving step-template JSON into a source-first layout
- script extraction tooling for splitting embedded script content into source files
- build integration for regenerating `step-templates/*.json` from source
- validation tooling to compare generated output with the current JSON workflow
- reset tooling for local migration runs

## Intended use

This branch is meant to support validation of the follow-up migration branch.

Use it to:

1. run the migration tooling
2. confirm the generated JSON output matches the current workflow within the known validation exclusions
3. review the resulting source-first layout
4. reset back to the branch baseline if needed

A follow-up PR will use this tooling to submit the actual repository migration and related documentation updates.