### PR TITLE
Feat: Add Supabase - Set Secrets community step template

### DIFF
--- a/step-templates/supabase-set-secrets.json
+++ b/step-templates/supabase-set-secrets.json
@@ -1,0 +1,89 @@
+{
+  "Id": "9a8b7c6d-5e4f-4321-8fed-cba987654321",
+  "Name": "Supabase - Set Secrets",
+  "Description": "Sets environment variable secrets on a Supabase project using the Supabase CLI.\n\nThis step will:\n1. Install the Supabase CLI if not already present on the worker\n2. Set the specified secrets on the target project\n3. Optionally list secret names after the operation to confirm the result\n\n**Notes:**\n- Provide secrets as inline `KEY=VALUE` pairs (one per line) or as a path to a `.env`-style file on the worker.\n- If both are provided, inline secrets take precedence.\n- Secret values are never logged \u2014 only key names are printed during the list step.\n- Run this step **before** the Supabase - Deploy Edge Function step so secrets are available when the function first executes.\n\n**Finding your Project Ref:**\n- From the Supabase Dashboard URL: `https://app.supabase.com/project/<PROJECT_REF>/settings/general`\n- Or go to **Project Settings \u2192 General**\n\n[Supabase Secrets Documentation](https://supabase.com/docs/guides/functions/secrets)\n[Supabase CLI Reference](https://supabase.com/docs/reference/cli/supabase-secrets-set)",
+  "ActionType": "Octopus.Script",
+  "Version": 1,
+  "CommunityActionTemplateId": null,
+  "Properties": {
+    "Octopus.Action.Script.Syntax": "Bash",
+    "Octopus.Action.Script.ScriptSource": "Inline",
+    "Octopus.Action.RunOnServer": "true",
+    "Octopus.Action.Script.ScriptBody": "# Supabase - Set Secrets\n# This script sets environment variable secrets on a Supabase project using the Supabase CLI\n\nset -e\n\n# Export Octopus variables as environment variables\nexport SUPABASE_PROJECT_REF=\"#{SupabaseProjectRef}\"\nexport SUPABASE_ACCESS_TOKEN=\"#{SupabaseAccessToken}\"\nexport SUPABASE_SECRETS=\"#{SupabaseSecrets}\"\nexport SUPABASE_ENV_FILE=\"#{SupabaseEnvFile}\"\nexport SUPABASE_LIST_AFTER_SET=\"#{SupabaseListAfterSet}\"\nexport SUPABASE_CLI_VERSION=\"#{SupabaseCliVersion}\"\n\n# Octopus leaves #{Variable} literal when a parameter has an empty default and\n# the user does not supply a value. Treat those as the correct defaults.\ncase \"$SUPABASE_SECRETS\"        in \"#{\"*) SUPABASE_SECRETS=\"\"         ;; esac\ncase \"$SUPABASE_ENV_FILE\"       in \"#{\"*) SUPABASE_ENV_FILE=\"\"         ;; esac\ncase \"$SUPABASE_LIST_AFTER_SET\" in \"#{\"*) SUPABASE_LIST_AFTER_SET=\"True\"  ;; esac\ncase \"$SUPABASE_CLI_VERSION\"    in \"#{\"*) SUPABASE_CLI_VERSION=\"latest\" ;; esac\n\n# Parameter validation\nif [ -z \"$SUPABASE_PROJECT_REF\" ]; then\n    echo \"ERROR: Supabase Project Ref is required.\"\n    exit 1\nfi\n\nif [ -z \"$SUPABASE_ACCESS_TOKEN\" ]; then\n    echo \"ERROR: Access Token is required.\"\n    exit 1\nfi\n\nif [ -z \"$SUPABASE_SECRETS\" ] && [ -z \"$SUPABASE_ENV_FILE\" ]; then\n    echo \"ERROR: No secrets provided. Set the Secrets or Env File Path parameter.\"\n    exit 1\nfi\n\nif [ -z \"$SUPABASE_CLI_VERSION\" ]; then\n    SUPABASE_CLI_VERSION=\"latest\"\nfi\n\necho \"==========================================\"\necho \"Supabase - Set Secrets\"\necho \"==========================================\"\necho \"Project Ref: $SUPABASE_PROJECT_REF\"\nif [ -n \"$SUPABASE_SECRETS\" ]; then\n    echo \"Mode:        Inline key=value pairs\"\nelif [ -n \"$SUPABASE_ENV_FILE\" ]; then\n    echo \"Mode:        Env file: $SUPABASE_ENV_FILE\"\nfi\necho \"CLI Version: $SUPABASE_CLI_VERSION\"\necho \"==========================================\"\n\n# Check if Supabase CLI is installed\ninstall_supabase_cli() {\n    local version=\"$1\"\n\n    echo \"Installing Supabase CLI...\"\n\n    # Detect OS\n    if [ \"$(uname)\" = \"Darwin\" ]; then\n        # macOS\n        if [ \"$version\" = \"latest\" ]; then\n            brew install supabase/tap/supabase\n        else\n            brew install supabase/tap/supabase@\"$version\"\n        fi\n    elif [ \"$(uname)\" = \"Linux\" ]; then\n        # Linux - download binary directly from GitHub releases\n        local arch\n        arch=$(uname -m)\n        case \"$arch\" in\n            x86_64)  arch=\"amd64\" ;;\n            aarch64) arch=\"arm64\" ;;\n            *) echo \"ERROR: Unsupported architecture: $arch\"; exit 1 ;;\n        esac\n        local download_url\n        if [ \"$version\" = \"latest\" ]; then\n            download_url=\"https://github.com/supabase/cli/releases/latest/download/supabase_linux_${arch}.tar.gz\"\n        else\n            download_url=\"https://github.com/supabase/cli/releases/download/v${version}/supabase_linux_${arch}.tar.gz\"\n        fi\n        echo \"Downloading Supabase CLI from GitHub releases...\"\n        mkdir -p \"$HOME/.local/bin\"\n        curl -fsSL \"$download_url\" -o /tmp/supabase.tar.gz\n        tar -xzf /tmp/supabase.tar.gz -C \"$HOME/.local/bin\"\n        chmod +x \"$HOME/.local/bin/supabase\"\n        export PATH=\"$HOME/.local/bin:$PATH\"\n        rm -f /tmp/supabase.tar.gz\n    else\n        echo \"ERROR: Unsupported operating system: $(uname)\"\n        exit 1\n    fi\n}\n\nif ! command -v supabase &> /dev/null; then\n    echo \"Supabase CLI not found. Installing...\"\n    install_supabase_cli \"$SUPABASE_CLI_VERSION\"\nelse\n    echo \"Supabase CLI found: $(which supabase)\"\n    CURRENT_VERSION=$(supabase --version 2>/dev/null | awk '{print $2}')\n    echo \"Current version: $CURRENT_VERSION\"\n\n    if [ \"$SUPABASE_CLI_VERSION\" != \"latest\" ] && [ \"$SUPABASE_CLI_VERSION\" != \"$CURRENT_VERSION\" ]; then\n        echo \"Updating CLI to version $SUPABASE_CLI_VERSION...\"\n        install_supabase_cli \"$SUPABASE_CLI_VERSION\"\n    fi\nfi\n\n# Verify CLI installation\nif ! command -v supabase &> /dev/null; then\n    echo \"ERROR: Failed to install Supabase CLI\"\n    exit 1\nfi\n\n# Resolve working directory from extracted package\nWORKDIR=\"#{Octopus.Action.Package[supabase-migrations].ExtractedPath}\"\nif [ -z \"$WORKDIR\" ] || [ ! -d \"$WORKDIR\" ]; then\n    WORKDIR=\"$(pwd)\"\nfi\necho \"Supabase workdir: $WORKDIR\"\n\necho \"\"\necho \"==========================================\"\necho \"Setting Secrets...\"\necho \"==========================================\"\n\nif [ -n \"$SUPABASE_SECRETS\" ]; then\n    # Write inline secrets to a temp file to avoid process listing exposure\n    TEMP_ENV_FILE=$(mktemp /tmp/octopus-supabase-secrets.XXXXXX)\n    trap \"rm -f $TEMP_ENV_FILE\" EXIT\n    echo \"$SUPABASE_SECRETS\" > \"$TEMP_ENV_FILE\"\n    SET_OUTPUT=$(supabase secrets set --env-file \"$TEMP_ENV_FILE\" --project-ref \"$SUPABASE_PROJECT_REF\" 2>&1) || {\n        echo \"ERROR: secrets set failed.\"\n        echo \"$SET_OUTPUT\"\n        exit 1\n    }\n    echo \"$SET_OUTPUT\"\nelif [ -n \"$SUPABASE_ENV_FILE\" ]; then\n    if [ ! -f \"$SUPABASE_ENV_FILE\" ]; then\n        echo \"ERROR: Env file not found at path: $SUPABASE_ENV_FILE\"\n        exit 1\n    fi\n    SET_OUTPUT=$(supabase secrets set --env-file \"$SUPABASE_ENV_FILE\" --project-ref \"$SUPABASE_PROJECT_REF\" 2>&1) || {\n        echo \"ERROR: secrets set failed.\"\n        echo \"$SET_OUTPUT\"\n        exit 1\n    }\n    echo \"$SET_OUTPUT\"\nelse\n    echo \"ERROR: No secrets provided. Set the Secrets or Env File Path parameter.\"\n    exit 1\nfi\n\nif [ \"$SUPABASE_LIST_AFTER_SET\" = \"True\" ]; then\n    echo \"\"\n    echo \"==========================================\"\n    echo \"Listing Secrets...\"\n    echo \"==========================================\"\n    LIST_OUTPUT=$(supabase secrets list --project-ref \"$SUPABASE_PROJECT_REF\" 2>&1) || {\n        echo \"ERROR: secrets list failed.\"\n        echo \"$LIST_OUTPUT\"\n        exit 1\n    }\n    echo \"$LIST_OUTPUT\"\nfi\n\necho \"\"\necho \"==========================================\"\necho \"Secrets set successfully!\"\necho \"==========================================\"\n"
+  },
+  "Parameters": [
+    {
+      "Id": "1a2b3c4d-5e6f-4789-abcd-ef0123456789",
+      "Name": "SupabaseProjectRef",
+      "Label": "Project Ref",
+      "HelpText": "The unique identifier of your Supabase project.\n\n**Where to find it:**\n- From your project URL: `https://app.supabase.com/project/<PROJECT_REF>/settings/general`\n- In Dashboard: **Project Settings \u2192 General \u2192 Project ID**\n\nExample: `abcdefghijklmn`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "2b3c4d5e-6f70-4891-bcde-f01234567890",
+      "Name": "SupabaseAccessToken",
+      "Label": "Access Token",
+      "HelpText": "Your Supabase personal access token for CLI authentication.\n\n**Where to get it:**\n1. Go to [Supabase Dashboard \u2192 Account](https://app.supabase.com/account/tokens)\n2. Click **Access Tokens**\n3. Create a new token or use an existing one\n\nThis value is stored securely and will not be displayed in logs.",
+      "DefaultValue": null,
+      "DisplaySettings": {
+        "Octopus.ControlType": "Sensitive"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "3c4d5e6f-7081-4902-cdef-012345678901",
+      "Name": "SupabaseSecrets",
+      "Label": "Secrets (Key=Value)",
+      "HelpText": "One `KEY=VALUE` pair per line. Values should reference Octopus sensitive variables (e.g. `MY_API_KEY=#{MyProject.ApiKey}`).\n\nMutually exclusive with **Env File Path** \u2014 if both are provided, inline secrets take precedence.\n\nLeave empty to use the **Env File Path** instead.",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "MultiLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "4d5e6f70-8192-4013-def0-123456789012",
+      "Name": "SupabaseEnvFile",
+      "Label": "Env File Path",
+      "HelpText": "Path to a `.env`-style file on the worker. Passed to `supabase secrets set --env-file`.\n\nUsed only when **Secrets (Key=Value)** is empty. The file must exist on the worker at deploy time.\n\nExample: `/etc/octopus/supabase/.env`",
+      "DefaultValue": "",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "5e6f7081-9203-4124-ef01-234567890123",
+      "Name": "SupabaseListAfterSet",
+      "Label": "List Secrets After Set",
+      "HelpText": "When enabled, runs `supabase secrets list` after setting secrets and prints the secret names (not values) to the task log.\n\nUseful for confirming which secrets are configured on the project.\n\nDefault: enabled.",
+      "DefaultValue": "True",
+      "DisplaySettings": {
+        "Octopus.ControlType": "Checkbox"
+      },
+      "Links": {}
+    },
+    {
+      "Id": "6f708192-0314-4235-f012-345678901234",
+      "Name": "SupabaseCliVersion",
+      "Label": "CLI Version",
+      "HelpText": "The version of the Supabase CLI to install.\n\n- Use `latest` to always use the newest version\n- Specify a version like `1.176.6` to pin a specific release\n\nDefault: `latest`",
+      "DefaultValue": "latest",
+      "DisplaySettings": {
+        "Octopus.ControlType": "SingleLineText"
+      },
+      "Links": {}
+    }
+  ],
+  "LastModifiedBy": "itsmebenwalker",
+  "$Meta": {
+    "ExportedAt": "2026-06-08T00:00:00.000Z",
+    "OctopusVersion": "2026.1.0",
+    "Type": "ActionTemplate"
+  },
+  "Category": "supabase"
+}


### PR DESCRIPTION
# Background

[Supabase](https://supabase.com) is an open-source alternative to Firebase built on PostgreSQL. It includes a managed database, authentication, storage, realtime subscriptions, and Edge Functions - globally distributed TypeScript/Deno serverless functions.

The rise of AI-assisted development tools such as Cursor, Windsurf, and Claude Code has also led to broader adoption of Supabase. Its generated SDKs, built-in APIs, and CLI tooling make it easy to stand up and evolve a backend, which works well for teams building applications with AI coding tools. Many people are now deploying applications built with Supabase, and Edge Functions are increasingly where application logic is implemented. This presents a strong opportunity for Octopus to further support and streamline these deployment workflows.

The Octopus Library already has a `Supabase - Run Migrations` step template for pushing database schema changes and a `Supabase - Deploy Edge Function` step template (added in #1688) for deploying functions. This PR adds the missing companion step: pushing environment variable secrets to a Supabase project so they are in place before Edge Functions first execute.

# Results

Adds a new community step template **`Supabase - Set Secrets`** (`step-templates/supabase-set-secrets.json`) that:

- Installs the Supabase CLI on the worker if not already present (Linux binary from GitHub releases, Homebrew on macOS), with optional version pinning
- Authenticates via the `SUPABASE_ACCESS_TOKEN` environment variable - no interactive login required, safe for CI/CD workers
- Accepts secrets as inline `KEY=VALUE` pairs (one per line, referencing Octopus sensitive variables) or as a path to a `.env`-style file on the worker - if both are provided, inline pairs take precedence
- Writes inline secrets to a `mktemp` file with `trap` cleanup, ensuring secret values never appear in process listings and the temp file is removed even on failure
- Calls `supabase secrets set --env-file` in a single CLI invocation
- Optionally runs `supabase secrets list` after setting and prints key names (never values) to the task log for confirmation

**Intended pipeline order:**

```
1. Supabase - Set Secrets          ← this step
2. Supabase - Deploy Edge Function
3. Supabase - Run Migrations       (if applicable)
```

**Parameters**

| Parameter | Type | Required |
|---|---|---|
| `SupabaseProjectRef` | String | Yes |
| `SupabaseAccessToken` | Sensitive | Yes |
| `SupabaseSecrets` | MultiLineText | No - at least one of Secrets or Env File Path required |
| `SupabaseEnvFile` | String | No - at least one of Secrets or Env File Path required |
| `SupabaseListAfterSet` | Checkbox | No - default: enabled |
| `SupabaseCliVersion` | String | No - default: `latest` |

## Before

Setting Supabase secrets from an Octopus deployment required a custom **Run a Script** step, manually scripting CLI installation, authentication, and `supabase secrets set` - with no built-in protection against secret values appearing in process listings or logs.

## After

<img width="1910" height="871" alt="image" src="https://github.com/user-attachments/assets/1c8ce4bf-a6f7-4732-9e9d-43a82446c183" />

Task log: [ServerTasks-2521.log.txt](https://github.com/user-attachments/files/28702370/ServerTasks-2521.log.txt)

<img width="1913" height="869" alt="image" src="https://github.com/user-attachments/assets/76786f9d-722a-4a8e-80d6-0e0ff518a9c2" />

<img width="1910" height="823" alt="image" src="https://github.com/user-attachments/assets/86e2696c-427c-42b8-89de-cf61b1726d87" />

# Pre-requisites

- [x] `Id` is a GUID (`9a8b7c6d-5e4f-4321-8fed-cba987654321`) and not all zeros
- [x] `Version` is `1` (new template)
- [x] Parameter names do not start with `$`
- [x] All parameter names are prefixed with `Supabase` to avoid clashing with user-defined project variables
- [x] `LastModifiedBy` is present (`itsmebenwalker`)
- [x] `Category` is `supabase` - existing category, no new logo or `gulpfile.babel.js` change required